### PR TITLE
Read the model from Chat, not from Provider

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,10 @@
+# deputy (development version)
+
+* `Agent$provider()` no longer errors with "Can't get S7 properties with `$`"
+  against current ellmer. ellmer moved `model` off `Provider` onto a new `Model`
+  class, so `provider@model` fails for every provider and the `$` fallback threw
+  from inside the error handler. The model is now read with `Chat$get_model()`.
+
 # deputy 0.0.0.9000
 
 * Initial development version

--- a/R/agent.R
+++ b/R/agent.R
@@ -341,12 +341,13 @@ Agent <- R6::R6Class(
     #' @return A list with provider name and model
     provider = function() {
       provider <- self$chat$get_provider()
-      # Handle both S7 objects (@ access) and regular lists ($ access)
+      # Handle both S7 objects (@ access) and regular lists ([[ access)
       name <- tryCatch(provider@name, error = function(e) {
-        provider$name %||% "unknown"
+        if (is.list(provider)) provider[["name"]] %||% "unknown" else "unknown"
       })
-      model <- tryCatch(provider@model, error = function(e) {
-        provider$model %||% "unknown"
+      # As of ellmer's Model class the model lives on Chat, not on Provider
+      model <- tryCatch(self$chat$get_model(), error = function(e) {
+        if (is.list(provider)) provider[["model"]] %||% "unknown" else "unknown"
       })
       list(
         name = name,

--- a/tests/testthat/test-agent.R
+++ b/tests/testthat/test-agent.R
@@ -136,6 +136,32 @@ test_that("Agent provider returns correct structure", {
   expect_equal(provider$model, "test-model")
 })
 
+test_that("Agent provider reports a model for a provider without a model property", {
+  chat <- ellmer::chat_openai(
+    credentials = function() "test-key",
+    model = "gpt-4o-mini"
+  )
+  skip_if_not(is.null(attr(chat$get_provider(), "model")))
+  agent <- Agent$new(chat = chat)
+
+  provider <- agent$provider()
+
+  expect_equal(provider$name, "OpenAI")
+  expect_equal(provider$model, "gpt-4o-mini")
+})
+
+test_that("Agent provider falls back to unknown when the model cannot be read", {
+  mock_chat <- create_mock_chat()
+  mock_chat$get_provider <- function() list(name = "mock")
+  mock_chat$get_model <- function() stop("no model available")
+  agent <- Agent$new(chat = mock_chat)
+
+  provider <- agent$provider()
+
+  expect_equal(provider$name, "mock")
+  expect_equal(provider$model, "unknown")
+})
+
 test_that("Agent turns returns list", {
   mock_chat <- create_mock_chat()
   agent <- Agent$new(chat = mock_chat)


### PR DESCRIPTION
### What breaks

Every call to `Agent$provider()` fails against current ellmer:

```
Error: Can't get S7 properties with `$`. Did you mean `provider@model`?
```

This is not provider-specific. It affects **every** ellmer provider, so an
affected agent cannot answer at all.

### Why

ellmer moved model configuration off `Provider` onto a new `Model` class
([ellmer #499](https://github.com/tidyverse/ellmer/pull/499)):

> New `Model` class separates model configuration (name, parameters, extra
> arguments) from the `Provider` class, which now only captures API endpoint
> details. `Chat` gains a new `$get_model_object()` method to retrieve the
> `Model` object. **This is a breaking change for anyone who directly accesses
> `provider@model`**, `provider@params`, or `provider@extra_args`; use the
> `Model` object instead.

Measured on ellmer 0.4.2.9000: **0 of 22 provider classes have a `model`
property.** They expose `name`, `base_url`, `extra_headers`, `credentials`.

The existing code:

```r
model <- tryCatch(provider@model, error = function(e) {
  provider$model %||% "unknown"
})
```

The `tryCatch` is correct in intent, but **the fallback is what turns a missing
property into a crash.** Its comment says "Handle both S7 objects (`@` access)
and regular lists (`$` access)" — written for an object that might not be S7.
The actual break is an object that *is* S7 and simply lacks the property, and on
an S7 object `$` **throws** rather than returning `NULL`:

```r
provider$model
#> Error: Can't get S7 properties with `$`. Did you mean `provider@model`?
```

So the error is raised from inside the error handler, where nothing catches it.

### Blast radius

`Agent$provider()` has five callers: `$print()`, `$load_skill()`,
`$run_shiny()`, `build_session_payload()`, and `create_run_generator()`. The
last two are on the answer path, which is why every question fails rather than
only some.

### The fix

```r
model <- tryCatch(self$chat$get_model(), error = function(e) {
  if (is.list(provider)) provider[["model"]] %||% "unknown" else "unknown"
})
```

`Chat$get_model()` has existed since **ellmer 0.1.1** (#299) and deputy already
requires `ellmer >= 0.3.0`, so **no version bump is needed** and this works on
every ellmer deputy supports.

Two smaller points in the same method:

- The list fallbacks now use `[[` instead of `$`, so they can never re-throw
  when handed an S7 object. `is.list()` is a clean discriminator — an S7
  provider returns `FALSE`, and `[[` on one throws "S7 objects are not
  subsettable."
- The `name` line is left reading `provider@name`, which still works — `name`
  did not move.

### Why the test is shaped this way

The existing test passes a mock whose `get_provider()` returns a plain
**list**, so it never touches the S7 path. That is why this shipped green.

The new test therefore uses a **real** `ellmer::chat_openai()` (with a stub
credential function — no network, no API key), and asserts the invariant *a
provider with no `model` property still yields a model* rather than "provider X
works." It skips if a future ellmer puts `model` back on `Provider`, so it
stays honest instead of silently testing nothing.

Verified it has teeth: reverting the fix makes it fail with the original error,
with the backtrace showing the raise coming from inside the error handler.

### The package's own vignettes reproduce it

Worth noting independently of the tests: `R CMD check` on `main` fails four
vignettes with this exact error. From `agent-configuration.Rmd.log`:

```
> chat <- ellmer::chat_anthropic(model = "claude-sonnet-4-20250514")
> agent <- Agent$new(chat = chat, tools = tools_file())
> result <- agent$run_sync("How many files are in the current directory?")

  When sourcing 'agent-configuration.R':
Error: Can't get S7 properties with `$`. Did you mean `provider@model`?
Execution halted
```

`agent-configuration.Rmd`, `example-code-review.Rmd`,
`example-data-analysis.Rmd`, and `example-extraction-pipeline.Rmd` all fail this
way; `claude-sdk-parity.Rmd` (which does not call `run_sync()`) passes. Note the
vignette has no API key available, so it should be failing on credentials — it
dies before reaching that point.

With this change, `agent-configuration.Rmd` and `example-code-review.Rmd` pass.
The other two get further and then fail on something unrelated that needs a live
API key — `invalid for() loop sequence` from streaming with no credential, and a
`stopifnot()` on real structured output. Those are pre-existing and untouched
here; I mention them only so the vignette results are not read as fully green.

### Verification

- Full suite before: 418 blocks / 1193 passing / 6 skips
- Full suite after: **420 blocks / 1197 passing / 6 skips** — 0 failures, no new skips
- `R CMD check`: all stages through `checking tests ... OK`, plus
  `checking examples`, `R code for possible problems`, `dependencies in R code`,
  and `S3 generic/method consistency` — all OK. 2 of the 4 S7-failing vignettes
  now pass; the other 2 fail later on unrelated API-key-dependent assertions.

  The check does not reach a final `Status:` line, because
  `example-shiny-chat.Rmd` calls `shinyApp()` and `shiny::runApp()`, which block
  forever under `R CMD check` (confirmed: the worker sits in `futex_wait` on an
  open socket). That is pre-existing on `main` and unrelated to this change —
  no vignette is touched here. Worth knowing before anyone waits on a full check.
- `air format` applied; made no changes to the submitted code
