### PR TITLE
Make conversation compaction provider-safe and isolated

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -16,6 +16,13 @@
   class, so `provider@model` fails for every provider and the `$` fallback threw
   from inside the error handler. The model is now read with `Chat$get_model()`.
 
+* `compact()` now summarizes on a clone of the agent's own chat instead of
+  constructing a new provider. Previously any provider other than OpenAI,
+  Anthropic, or Google fell through to `ellmer::chat_openai("gpt-4o-mini")`,
+  sending conversation history to OpenAI when `OPENAI_API_KEY` happened to be
+  set. The summary clone preserves configured provider behavior while removing
+  tools and callbacks and suppressing console echo.
+
 # deputy 0.0.0.9000
 
 * Added semantic content streaming with `tool_start`, `tool_end`, `usage`, and

--- a/R/agent.R
+++ b/R/agent.R
@@ -1,5 +1,44 @@
 # Agent class for deputy
 
+clone_compaction_chat <- function(chat) {
+  summary_chat <- chat$clone(deep = TRUE)
+  if (identical(summary_chat, chat)) {
+    cli::cli_abort("Chat cloning returned the original mutable object")
+  }
+  validate_chat(summary_chat)
+
+  callback_names <- c(
+    "callback_on_tool_request",
+    "callback_on_tool_result"
+  )
+  live_private <- chat$.__enclos_env__$private
+  summary_private <- summary_chat$.__enclos_env__$private
+
+  for (callback_name in callback_names) {
+    live_manager <- live_private[[callback_name]]
+    summary_manager <- summary_private[[callback_name]]
+    if (is.null(summary_manager) || !is.function(summary_manager$clear)) {
+      cli::cli_abort(
+        "The summary chat does not expose an isolated {callback_name} manager"
+      )
+    }
+    if (identical(summary_manager, live_manager)) {
+      cli::cli_abort(
+        "The summary chat shares its {callback_name} manager with the live chat"
+      )
+    }
+  }
+
+  for (callback_name in callback_names) {
+    summary_private[[callback_name]]$clear()
+  }
+  summary_chat$set_turns(list())
+  summary_chat$set_system_prompt(NULL)
+  summary_chat$set_tools(list())
+
+  summary_chat
+}
+
 #' Agent R6 Class
 #'
 #' @description
@@ -3901,27 +3940,9 @@ Agent <- R6::R6Class(
         {
           # Create a temporary chat for summarization
           # Use the same provider as the main chat
-          provider_info <- self$provider()
-
           temp_chat <- tryCatch(
             {
-              # Try to create a chat with the same provider
-              if (provider_info$name == "openai") {
-                ellmer::chat_openai(
-                  model = provider_info$model %||% "gpt-4o-mini"
-                )
-              } else if (provider_info$name == "anthropic") {
-                ellmer::chat_anthropic(
-                  model = provider_info$model %||% "claude-sonnet-4-5-20250929"
-                )
-              } else if (provider_info$name == "google") {
-                ellmer::chat_google(
-                  model = provider_info$model %||% "gemini-2.0-flash"
-                )
-              } else {
-                # Fallback to a default provider
-                ellmer::chat_openai(model = "gpt-4o-mini")
-              }
+              clone_compaction_chat(self$chat)
             },
             error = function(e) {
               cli_warn(c(
@@ -3944,7 +3965,7 @@ Agent <- R6::R6Class(
           }
 
           # Generate summary
-          response <- temp_chat$chat(summarization_prompt)
+          response <- temp_chat$chat(summarization_prompt, echo = "none")
           response
         },
         error = function(e) {

--- a/tests/testthat/helper-mocks.R
+++ b/tests/testthat/helper-mocks.R
@@ -106,6 +106,7 @@ create_mock_chat <- function(responses = list("Hello!")) {
       get_system_prompt = function() system_prompt,
       set_system_prompt = function(prompt) system_prompt <<- prompt,
       get_tools = function() tools,
+      set_tools = function(new_tools) tools <<- new_tools,
       register_tool = function(tool) {
         tools[[tool@name]] <<- tool
       },
@@ -137,7 +138,7 @@ create_mock_chat <- function(responses = list("Hello!")) {
       on_tool_result = function(callback) {
         tool_result_callback <<- callback
       },
-      clone = function() {
+      clone = function(deep = FALSE) {
         cloned <- create_mock_chat(responses = responses)
         cloned$set_turns(turns)
         cloned$set_system_prompt(system_prompt)
@@ -148,5 +149,179 @@ create_mock_chat <- function(responses = list("Hello!")) {
       }
     ),
     class = "Chat"
+  )
+}
+
+create_mock_callback_manager <- function(callbacks = list()) {
+  state <- new.env(parent = emptyenv())
+  state$callbacks <- callbacks
+
+  structure(
+    list(
+      add = function(callback) {
+        state$callbacks <- c(state$callbacks, list(callback))
+        invisible(NULL)
+      },
+      clear = function() {
+        state$callbacks <- list()
+        invisible(NULL)
+      },
+      count = function() length(state$callbacks),
+      get_callbacks = function() state$callbacks,
+      invoke = function(value) {
+        for (callback in state$callbacks) {
+          callback(value)
+        }
+        invisible(NULL)
+      },
+      clone = function() create_mock_callback_manager(state$callbacks)
+    ),
+    class = "CallbackManager"
+  )
+}
+
+create_compaction_mock_chat <- function(
+  responses = list("Hello!"),
+  provider = list(
+    name = "gateway",
+    model = "test-model",
+    base_url = "https://gateway.invalid"
+  ),
+  request_callbacks = list(),
+  result_callbacks = list(),
+  simulate_tool_activity = FALSE,
+  chat_error = NULL,
+  probe = new.env(parent = emptyenv())
+) {
+  build_chat <- function(
+    turns,
+    tools,
+    system_prompt,
+    request_manager,
+    result_manager
+  ) {
+    response_idx <- 0L
+    private <- new.env(parent = emptyenv())
+    private$callback_on_tool_request <- request_manager
+    private$callback_on_tool_result <- result_manager
+
+    chat <- list(
+      .__enclos_env__ = list(private = private),
+      chat = function(prompt = NULL, echo = NULL) {
+        probe$summary_call <- list(
+          prompt = prompt,
+          echo = echo,
+          turns = turns,
+          system_prompt = system_prompt,
+          tools = tools,
+          callback_counts = c(
+            request = request_manager$count(),
+            result = result_manager$count()
+          ),
+          provider = provider
+        )
+        if (!is.null(chat_error)) {
+          stop(chat_error)
+        }
+        if (isTRUE(simulate_tool_activity)) {
+          request_manager$invoke(list(
+            name = "write_file",
+            arguments = list(
+              path = "../outside",
+              content = "unexpected summary tool content"
+            )
+          ))
+          result_manager$invoke(list(
+            name = "write_file",
+            value = "unexpected summary tool result"
+          ))
+        }
+        response_idx <<- min(response_idx + 1L, length(responses))
+        responses[[response_idx]]
+      },
+      stream = function(prompt = NULL) {
+        response_idx <<- min(response_idx + 1L, length(responses))
+        text <- responses[[response_idx]]
+        yielded <- FALSE
+        function() {
+          if (yielded) {
+            return(coro::exhausted())
+          }
+          yielded <<- TRUE
+          text
+        }
+      },
+      get_turns = function() turns,
+      set_turns = function(new_turns) turns <<- new_turns,
+      get_system_prompt = function() system_prompt,
+      set_system_prompt = function(prompt) system_prompt <<- prompt,
+      get_tools = function() tools,
+      set_tools = function(new_tools) tools <<- new_tools,
+      register_tool = function(tool) {
+        tools[[tool@name]] <<- tool
+      },
+      register_tools = function(tool_list) {
+        for (tool in tool_list) {
+          tools[[tool@name]] <<- tool
+        }
+      },
+      get_tokens = function() {
+        data.frame(
+          input = 100,
+          output = 50,
+          cached_input = 0,
+          cost = 0.001
+        )
+      },
+      get_provider = function() provider,
+      get_model = function() provider$model,
+      last_turn = function(role = "assistant") {
+        text <- responses[[max(1L, response_idx)]]
+        create_mock_assistant_turn(text = text)
+      },
+      on_tool_request = function(callback) {
+        request_manager$add(callback)
+      },
+      on_tool_result = function(callback) {
+        result_manager$add(callback)
+      },
+      callback_counts = function() {
+        c(
+          request = request_manager$count(),
+          result = result_manager$count()
+        )
+      },
+      clone = function(deep = FALSE) {
+        probe$clone_calls <- (probe$clone_calls %||% 0L) + 1L
+        probe$clone_deep <- deep
+        cloned_request_manager <- if (isTRUE(deep)) {
+          request_manager$clone()
+        } else {
+          request_manager
+        }
+        cloned_result_manager <- if (isTRUE(deep)) {
+          result_manager$clone()
+        } else {
+          result_manager
+        }
+        build_chat(
+          turns = turns,
+          tools = tools,
+          system_prompt = system_prompt,
+          request_manager = cloned_request_manager,
+          result_manager = cloned_result_manager
+        )
+      }
+    )
+
+    structure(chat, class = "Chat")
+  }
+
+  build_chat(
+    turns = list(),
+    tools = list(),
+    system_prompt = NULL,
+    request_manager = create_mock_callback_manager(request_callbacks),
+    result_manager = create_mock_callback_manager(result_callbacks)
   )
 }

--- a/tests/testthat/test-agent.R
+++ b/tests/testthat/test-agent.R
@@ -435,6 +435,153 @@ test_that("generate_fallback_summary creates text summary", {
   expect_true(grepl("Asst msg", fallback))
 })
 
+test_that("compaction summary clone is isolated, callback-free, and silent", {
+  request_calls <- 0L
+  result_calls <- 0L
+  probe <- new.env(parent = emptyenv())
+  provider <- list(
+    name = "private-gateway",
+    model = "private-model",
+    base_url = "https://gateway.invalid",
+    credentials = function() "test-token"
+  )
+  mock_chat <- create_compaction_mock_chat(
+    responses = list("A summary."),
+    provider = provider,
+    request_callbacks = list(function(request) {
+      request_calls <<- request_calls + 1L
+    }),
+    result_callbacks = list(function(result) {
+      result_calls <<- result_calls + 1L
+    }),
+    simulate_tool_activity = TRUE,
+    probe = probe
+  )
+  run_context <- list(
+    product = "tempest",
+    research_run_id = "research-123",
+    stage = "expert-research"
+  )
+  agent <- Agent$new(
+    chat = mock_chat,
+    tools = list(tool_read_file),
+    system_prompt = "KEEP ME",
+    run_context = run_context,
+    agent_id = "agent-compaction"
+  )
+  agent$configure_sdk_compat(list(
+    persist_session = FALSE,
+    session_id = "session-compaction"
+  ))
+  original_turns <- list(
+    create_mock_user_turn("Q"),
+    create_mock_assistant_turn("A")
+  )
+  mock_chat$set_turns(original_turns)
+  original_callback_counts <- mock_chat$callback_counts()
+  original_run_context <- agent$run_context
+  original_agent_id <- agent$agent_id
+  original_session_id <- agent$session_id()
+
+  summary <- agent$.__enclos_env__$private$generate_compaction_summary(
+    original_turns
+  )
+
+  expect_equal(summary, "A summary.")
+  expect_identical(probe$clone_calls, 1L)
+  expect_identical(probe$clone_deep, TRUE)
+  expect_length(probe$summary_call$turns, 0L)
+  expect_null(probe$summary_call$system_prompt)
+  expect_length(probe$summary_call$tools, 0L)
+  expect_equal(
+    probe$summary_call$callback_counts,
+    c(request = 0L, result = 0L)
+  )
+  expect_identical(probe$summary_call$echo, "none")
+  expect_identical(probe$summary_call$provider, provider)
+  expect_equal(mock_chat$get_system_prompt(), "KEEP ME")
+  expect_identical(mock_chat$get_turns(), original_turns)
+  expect_named(mock_chat$get_tools(), "read_file")
+  expect_equal(mock_chat$callback_counts(), original_callback_counts)
+  expect_identical(agent$run_context, original_run_context)
+  expect_identical(agent$agent_id, original_agent_id)
+  expect_identical(agent$session_id(), original_session_id)
+  expect_identical(request_calls, 0L)
+  expect_identical(result_calls, 0L)
+})
+
+test_that("compaction does not select a new provider constructor", {
+  mock_chat <- create_mock_chat(responses = list("A summary."))
+  agent <- Agent$new(chat = mock_chat)
+  compaction_code <- paste(
+    c(
+      deparse(body(clone_compaction_chat)),
+      deparse(body(
+        agent$.__enclos_env__$private$generate_compaction_summary
+      ))
+    ),
+    collapse = "\n"
+  )
+
+  expect_no_match(compaction_code, "ellmer::chat_[[:alnum:]_]+")
+})
+
+test_that("compaction preserves run context and session identity", {
+  mock_chat <- create_compaction_mock_chat(responses = list("A summary."))
+  run_context <- list(product = "tempest", research_run_id = "research-123")
+  agent <- Agent$new(
+    chat = mock_chat,
+    run_context = run_context,
+    agent_id = "agent-compaction"
+  )
+  agent$configure_sdk_compat(list(
+    persist_session = FALSE,
+    session_id = "session-compaction"
+  ))
+  mock_chat$set_turns(list(
+    create_mock_user_turn("Q1"),
+    create_mock_assistant_turn("A1"),
+    create_mock_user_turn("Q2")
+  ))
+  original_callback_counts <- mock_chat$callback_counts()
+
+  suppressMessages(agent$compact(keep_last = 1L))
+
+  expect_identical(agent$run_context, run_context)
+  expect_identical(agent$agent_id, "agent-compaction")
+  expect_identical(agent$session_id(), "session-compaction")
+  expect_equal(mock_chat$callback_counts(), original_callback_counts)
+})
+
+test_that("compaction falls back only after clone or summary runtime failure", {
+  turns <- list(
+    create_mock_user_turn("User msg"),
+    create_mock_assistant_turn("Assistant msg")
+  )
+  clone_failure_chat <- create_mock_chat()
+  clone_failure_agent <- Agent$new(chat = clone_failure_chat)
+  clone_failure_chat$clone <- function(deep = FALSE) {
+    stop("clone failed")
+  }
+  runtime_failure_agent <- Agent$new(
+    chat = create_compaction_mock_chat(chat_error = "provider failed")
+  )
+
+  clone_fallback <- suppressWarnings(suppressMessages(
+    clone_failure_agent$.__enclos_env__$private$generate_compaction_summary(
+      turns
+    )
+  ))
+  runtime_fallback <- suppressWarnings(suppressMessages(
+    runtime_failure_agent$.__enclos_env__$private$generate_compaction_summary(
+      turns
+    )
+  ))
+
+  expect_match(clone_fallback, "Compacted 2 earlier turns")
+  expect_match(runtime_fallback, "Compacted 2 earlier turns")
+})
+
 # Tool data extraction tests
 test_that("extract_tool_request_data handles NULL request", {
   mock_chat <- create_mock_chat()

--- a/tests/testthat/test-tools-web.R
+++ b/tests/testthat/test-tools-web.R
@@ -142,16 +142,42 @@ test_that("web_fetch handles invalid URL", {
 
 test_that("web_search returns results", {
   skip_if_not_installed("httr2")
-  skip_on_cran()
-  skip_if_offline()
 
-  # Search for something common
+  httr2::local_mocked_responses(list(httr2::response(
+    status_code = 200,
+    url = "https://html.duckduckgo.com/html/?q=R%20programming%20language",
+    headers = list(`Content-Type` = "text/html; charset=utf-8"),
+    body = charToRaw(paste0(
+      "<html><body>",
+      "<div class='result results_links web-result'>",
+      "<h2 class='result__title'>",
+      "<a class='result__a' href='//duckduckgo.com/l/?uddg=",
+      "https%3A%2F%2Fwww.r-project.org%2F&amp;rut=fixture'>",
+      "The R Project for Statistical Computing</a>",
+      "</h2>",
+      "<a class='result__snippet' href='https://www.r-project.org/'>",
+      "R is a free software environment for statistical computing.",
+      "</a>",
+      "</div>",
+      "</body></html>"
+    ))
+  )))
+
   result <- tool_web_search("R programming language", num_results = 5)
 
   expect_type(result, "character")
-  expect_true(nchar(result) > 0)
-  # Should contain search query
-  expect_true(grepl("R programming language", result))
+  expect_match(
+    result,
+    "Search results for: R programming language",
+    fixed = TRUE
+  )
+  expect_match(result, "The R Project for Statistical Computing", fixed = TRUE)
+  expect_match(result, "https://www.r-project.org/", fixed = TRUE)
+  expect_match(
+    result,
+    "R is a free software environment for statistical computing.",
+    fixed = TRUE
+  )
 })
 
 test_that("web permission is checked correctly", {


### PR DESCRIPTION
Supersedes #19 while preserving Anatoliy Sokolov's original commit authorship.

## Summary

- Summarize on a deep clone of the Agent's configured chat, preserving its provider, gateway, model, base URL, and authentication behavior without calling any `ellmer::chat_*()` constructor.
- Remove turns, system prompt, tools, and both callback managers from the summary clone, reject shared callback managers, and force the internal request to `echo = "none"`.
- Preserve the live chat, Agent run context, and session identity, with deterministic regressions for malicious summary tool content and genuine clone/runtime fallback.
- Replace an unrelated live DuckDuckGo test with deterministic mocked HTML so the suite never depends on network availability.

## Verification

- `devtools::test(filter = "^agent$")`: 105 pass, 0 fail, 1 existing skip.
- `devtools::test(filter = "^tools-web$")`: 50 pass, 0 fail.
- `devtools::test()`: 2,246 pass, 0 fail, 6 known warnings, 7 environmental skips.
- `air format --check .`: clean.
- `devtools::check(document = FALSE, manual = FALSE, cran = FALSE, quiet = TRUE)`: 0 errors, 0 warnings, 1 expected worktree `.git` note.
- Independent adversarial review and real no-network ellmer clone probes: approved.
- GitHub Actions: full R matrix, packaged executable, pkgdown, coverage, Codecov, formatting, and automated review all pass.