### PR TITLE
feat: add Agent$run_async() for non-blocking worker runs

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -48,4 +48,4 @@ Imports:
     R6,
     Rapp (>= 0.4.0),
     rlang
-Config/roxygen2/version: 8.0.0
+Config/roxygen2/version: 8.1.0

--- a/NAMESPACE
+++ b/NAMESPACE
@@ -57,21 +57,27 @@ export(tools_preset)
 export(tools_web)
 importFrom(R6,R6Class)
 importFrom(Rapp,run)
-importFrom(cli,cli_abort)
-importFrom(cli,cli_alert)
-importFrom(cli,cli_alert_danger)
-importFrom(cli,cli_alert_info)
-importFrom(cli,cli_alert_success)
-importFrom(cli,cli_alert_warning)
-importFrom(cli,cli_inform)
-importFrom(cli,cli_warn)
-importFrom(coro,exhausted)
-importFrom(coro,generator)
-importFrom(coro,is_exhausted)
+importFrom(cli,
+  cli_abort,
+  cli_alert,
+  cli_alert_danger,
+  cli_alert_info,
+  cli_alert_success,
+  cli_alert_warning,
+  cli_inform,
+  cli_warn
+)
+importFrom(coro,
+  exhausted,
+  generator,
+  is_exhausted
+)
 importFrom(digest,digest)
-importFrom(rlang,"%||%")
-importFrom(rlang,abort)
-importFrom(rlang,check_installed)
-importFrom(rlang,inform)
-importFrom(rlang,is_installed)
-importFrom(rlang,warn)
+importFrom(rlang,
+  "%||%",
+  abort,
+  check_installed,
+  inform,
+  is_installed,
+  warn
+)

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,18 @@
 # deputy (development version)
 
+* New `Agent$run_async()` runs a task without blocking the R process and
+  returns a promise that resolves to an `AgentResult`. It shares
+  `run_shiny()`'s engine -- ellmer's `stream_async()` with permissions, hooks,
+  and `UsageLimits` enforced through callbacks and terminal accounting -- but
+  collects the final response, run-scoped usage, and stop reason instead of
+  streaming to a UI, accepts a per-run `UsageLimits` override (including
+  `on_exceed = "error"`, which rejects the promise with the structured limit
+  error), and does not impose `run_shiny()`'s absolute-file-path rule. Use it
+  when an Agent is a worker inside a larger async system, such as a sub-agent
+  invoked from a streaming parent chat's tool. Callback-driven runs now also
+  record their run-scoped usage so `AgentResult$usage` and the Agent's last
+  run usage reflect `run_shiny()`/`run_async()` runs.
+
 * The `deputy` command now ships as a tested Rapp 0.4 package executable for
   one-off `rx` use and persistent `ir tool install` launchers. Its task and
   interactive modes now consume streaming generators correctly, report tool

--- a/R/agent.R
+++ b/R/agent.R
@@ -1189,177 +1189,18 @@ Agent <- R6::R6Class(
         "max_tool_calls",
         integer = TRUE
       )
+      shiny_limits <- self$usage_limits
+      shiny_limits$max_tool_calls <- max_tool_calls
 
       agent <- self
-      stream_state <- new.env(parent = emptyenv())
-      stream_state$reason <- "complete"
-      stream_state$active_run_id <- NULL
-      stream_state$session_started <- FALSE
-      stream_state$finished <- FALSE
-
-      wrapped_stream <- coro::async_generator(function() {
-        if (isTRUE(agent$.__enclos_env__$private$run_active)) {
-          cli::cli_abort(
-            "This agent already has an active run",
-            class = c("deputy_run_active", "deputy_error")
-          )
-        }
-
-        agent$.__enclos_env__$private$run_active <- TRUE
-        agent$.__enclos_env__$private$current_run_id <-
-          agent$.__enclos_env__$private$new_run_id()
-        agent$.__enclos_env__$private$current_run_context <-
-          effective_run_context
-        active_run_id <- agent$.__enclos_env__$private$current_run_id
-        stream_state$active_run_id <- active_run_id
-        on.exit(
-          agent$.__enclos_env__$private$finish_shiny_stream(stream_state),
-          add = TRUE
-        )
-
-        # Initialize lazily on first consumption. Merely constructing and
-        # abandoning a Shiny stream must not reserve this Agent forever.
-        agent$.__enclos_env__$private$tool_call_count <- 0L
-        agent$.__enclos_env__$private$tool_call_limit <- max_tool_calls
-        agent$.__enclos_env__$private$should_stop <- FALSE
-        agent$.__enclos_env__$private$stop_reason_from_hook <- NULL
-        shiny_limits <- agent$usage_limits
-        shiny_limits$max_tool_calls <- max_tool_calls
-        agent$.__enclos_env__$private$current_usage_limits <- shiny_limits
-        agent$.__enclos_env__$private$current_usage_baseline <-
-          agent_usage_snapshot(agent$chat)
-        agent$.__enclos_env__$private$current_tool_calls <- 0L
-        agent$.__enclos_env__$private$current_tool_results <- 0L
-        agent$.__enclos_env__$private$current_outer_requests <- 0L
-        agent$.__enclos_env__$private$current_external_usage <- AgentUsage()
-        agent$.__enclos_env__$private$current_stream_controller <- tryCatch(
-          ellmer::stream_controller(),
-          error = function(e) NULL
-        )
-        agent$.__enclos_env__$private$current_stream_content <- TRUE
-        agent$.__enclos_env__$private$pending_events <- list()
-        agent$.__enclos_env__$private$tool_started_at <- list()
-        agent$.__enclos_env__$private$tool_event_overrides <- list()
-        agent$.__enclos_env__$private$tool_call_records <- list()
-        agent$.__enclos_env__$private$pending_delegations <- list()
-        agent$.__enclos_env__$private$last_limit_status <- NULL
-        agent$.__enclos_env__$private$last_run_usage <- AgentUsage()
-        agent$.__enclos_env__$private$current_run_checkpoint_id <- NULL
-        agent$.__enclos_env__$private$current_run_requires_absolute_file_paths <-
-          TRUE
-
-        if (!is.null(agent$.__enclos_env__$private$.file_checkpoints)) {
-          checkpoint_id <- agent$.__enclos_env__$private$.file_checkpoints$checkpoint(
-            paste0("run ", active_run_id),
-            metadata = list(run_id = active_run_id, task = prompt)
-          )
-          agent$.__enclos_env__$private$current_run_checkpoint_id <-
-            checkpoint_id
-        }
-
-        agent$hooks$fire(
-          "SessionStart",
-          context = agent$.__enclos_env__$private$hook_context(
-            permissions = agent$permissions,
-            provider = agent$provider(),
-            tools_count = length(agent$chat$get_tools()),
-            run_id = active_run_id
-          )
-        )
-        stream_state$session_started <- TRUE
-        agent$hooks$fire(
-          "UserPromptSubmit",
-          prompt = prompt,
-          context = agent$.__enclos_env__$private$hook_context(
-            run_id = active_run_id
-          )
-        )
-
-        initial_limit_status <- usage_limit_status(
-          agent$.__enclos_env__$private$current_run_usage(),
-          agent$.__enclos_env__$private$current_usage_limits,
-          require_followup = TRUE
-        )
-        if (!is.null(initial_limit_status)) {
-          agent$.__enclos_env__$private$mark_usage_limit(initial_limit_status)
-          stream_state$reason <- initial_limit_status$reason
-        }
-
-        if (agent$.__enclos_env__$private$should_stop) {
-          stream <- coro::async_generator(function() {
-            if (FALSE) coro::yield("unreachable")
-          })()
-        } else {
-          stream <- tryCatch(
-            agent$.__enclos_env__$private$start_async_stream(prompt),
-            error = function(error) {
-              stream_state$reason <- "error"
-              stop(error)
-            }
-          )
-        }
-        is_generator <- inherits(stream, "coro_generator_instance")
-
-        repeat {
-          if (agent$.__enclos_env__$private$should_stop) {
-            stream_state$reason <-
-              agent$.__enclos_env__$private$stop_reason_from_hook %||%
-              "interrupted"
-            break
-          }
-
-          stream_error <- NULL
-          chunk <- NULL
-          if (isTRUE(is_generator)) {
-            chunk <- tryCatch(
-              stream(),
-              error = function(error) {
-                stream_error <<- error
-                NULL
-              }
-            )
-          } else {
-            chunk <- stream
-          }
-
-          if (is.null(stream_error) && promises::is.promising(chunk)) {
-            chunk <- tryCatch(
-              coro::await(chunk),
-              error = function(error) {
-                stream_error <<- error
-                NULL
-              }
-            )
-          }
-
-          if (!is.null(stream_error)) {
-            if (agent$.__enclos_env__$private$should_stop) {
-              stream_state$reason <-
-                agent$.__enclos_env__$private$stop_reason_from_hook %||%
-                "interrupted"
-              break
-            }
-            stream_state$reason <- "error"
-            stop(stream_error)
-          }
-
-          if (agent$.__enclos_env__$private$should_stop) {
-            stream_state$reason <-
-              agent$.__enclos_env__$private$stop_reason_from_hook %||%
-              "interrupted"
-            break
-          }
-
-          if (coro::is_exhausted(chunk)) {
-            break
-          }
-
-          coro::yield(chunk)
-          if (!isTRUE(is_generator)) {
-            break
-          }
-        }
-      })()
+      stream_state <- private$new_callback_run_state()
+      wrapped_stream <- private$callback_run_stream(
+        prompt,
+        limits = shiny_limits,
+        run_context = effective_run_context,
+        require_absolute_file_paths = TRUE,
+        state = stream_state
+      )
       reg.finalizer(
         environment(wrapped_stream),
         function(environment) {
@@ -1373,7 +1214,7 @@ Agent <- R6::R6Class(
               silent = TRUE
             )
             try(
-              agent$.__enclos_env__$private$finish_shiny_stream(stream_state),
+              agent$.__enclos_env__$private$finish_callback_run(stream_state),
               silent = TRUE
             )
           }
@@ -1381,9 +1222,103 @@ Agent <- R6::R6Class(
         onexit = TRUE
       )
       wrapped_stream
+    },
+
+    #' @description
+    #' Run an agentic task asynchronously and resolve to an [AgentResult].
+    #'
+    #' Like `run_shiny()`, the multi-turn loop is driven by ellmer's
+    #' `stream_async()`, so the R process is never blocked while the model or
+    #' tools work: other Shiny sessions, `later` callbacks, and promise chains
+    #' keep running. Unlike `run_shiny()`, nothing is streamed to a UI. The
+    #' returned promise resolves once the run stops and carries the final
+    #' response, run-scoped usage, and stop reason. Permissions, hooks, and
+    #' [UsageLimits] are enforced as in `run_shiny()` (callbacks plus terminal
+    #' accounting). File tools may use relative paths resolved against
+    #' `working_dir`, as in `run()`; the absolute-path rule is specific to
+    #' `run_shiny()`.
+    #'
+    #' Use this when an Agent is a *worker* inside a larger async system, for
+    #' example a delegated sub-agent executed from the tool of a parent chat
+    #' that is itself streaming. `output_format` is not supported here;
+    #' structured output still requires `run()` or `run_sync()`.
+    #'
+    #' @param task The task for the agent to perform
+    #' @param usage_limits Optional [UsageLimits] override for this run. Unset
+    #'   fields fall back to the Agent's limits. With `on_exceed = "error"`,
+    #'   hitting a limit rejects the promise with the structured limit error
+    #'   instead of resolving with a typed `stop_reason`.
+    #' @param run_context Canonical JSON-compatible context to add to or narrow
+    #'   for this run. Protected constructor identity fields cannot change.
+    #' @return A `promises::promise` resolving to an [AgentResult]. It is
+    #'   rejected if the provider stream fails or a limit configured with
+    #'   `on_exceed = "error"` is reached.
+    run_async = function(task, usage_limits = NULL, run_context = list()) {
+      rlang::check_installed("promises", reason = "for run_async()")
+
+      if (isTRUE(private$run_active)) {
+        cli::cli_abort(
+          "This agent already has an active run",
+          class = c("deputy_run_active", "deputy_error")
+        )
+      }
+
+      effective_run_context <- merge_run_context(
+        private$.run_context,
+        run_context
+      )
+
+      limits <- if (is.null(usage_limits)) {
+        self$usage_limits
+      } else {
+        merge_usage_limits(usage_limits, self$usage_limits)
+      }
+      limits <- normalize_usage_limits(limits)
+
+      agent <- self
+      start_time <- Sys.time()
+      stream_state <- private$new_callback_run_state()
+      stream <- private$callback_run_stream(
+        task,
+        limits = limits,
+        run_context = effective_run_context,
+        require_absolute_file_paths = FALSE,
+        state = stream_state
+      )
+
+      coro::async(function() {
+        # Text emitted before a tool call is working narration, not the
+        # answer. Reset on every tool result so `response` is the text of the
+        # final assistant turn, matching `run_sync()`'s `text_complete`.
+        response_parts <- character()
+        repeat {
+          chunk <- coro::await(stream())
+          if (coro::is_exhausted(chunk)) {
+            break
+          }
+          if (inherits(chunk, "ellmer::ContentToolResult")) {
+            response_parts <- character()
+          } else if (inherits(chunk, "ellmer::ContentText")) {
+            response_parts <- c(response_parts, chunk@text)
+          } else if (is.character(chunk)) {
+            response_parts <- c(response_parts, chunk)
+          }
+        }
+
+        # The stream's exit handler has finalized the run by now: hooks have
+        # fired, run-scoped state is cleared, and `stream_state` carries the
+        # terminal reason, usage, and cost. (Assembled outside the async body
+        # because coro's state-machine parser rejects `x <- if (...)`.)
+        agent$.__enclos_env__$private$callback_run_result(
+          response_parts,
+          limits = limits,
+          state = stream_state,
+          run_context = effective_run_context,
+          start_time = start_time
+        )
+      })()
     }
   ),
-
   active = list(
     #' @field agent_id Stable Agent instance identifier. Read-only.
     agent_id = function(value) {
@@ -1624,7 +1559,251 @@ Agent <- R6::R6Class(
       private$.file_checkpoints$finalize_pending()
     },
 
-    finish_shiny_stream = function(state) {
+    # Shared state for one callback-driven run (`run_shiny()`/`run_async()`).
+    # The stream body and its exit handler communicate through this env so a
+    # consumer can read the terminal reason, usage, and cost after the stream
+    # is exhausted and run-scoped private fields have been cleared.
+    new_callback_run_state = function() {
+      state <- new.env(parent = emptyenv())
+      state$reason <- "complete"
+      state$active_run_id <- NULL
+      state$session_started <- FALSE
+      state$finished <- FALSE
+      state$usage <- NULL
+      state$cost <- NULL
+      state
+    },
+
+    # Assemble the `AgentResult` for a finished `run_async()` run. Honors
+    # `on_exceed = "error"` by signalling the structured limit error when the
+    # run stopped because of the recorded limit.
+    callback_run_result = function(
+      response_parts,
+      limits,
+      state,
+      run_context,
+      start_time
+    ) {
+      response <- if (length(response_parts) > 0L) {
+        paste(response_parts, collapse = "")
+      } else {
+        tryCatch(private$get_last_response(), error = function(e) NULL)
+      }
+
+      limit_status <- private$last_limit_status
+      if (
+        !is.null(limit_status) &&
+          identical(limits$on_exceed, "error") &&
+          identical(state$reason, limit_status$reason)
+      ) {
+        private$abort_usage_limit(limit_status)
+      }
+
+      AgentResult$new(
+        response = response,
+        turns = self$chat$get_turns(),
+        cost = state$cost %||% self$cost(),
+        events = list(),
+        duration = as.numeric(Sys.time() - start_time, units = "secs"),
+        stop_reason = state$reason %||% "complete",
+        structured_output = NULL,
+        session_id = private$.session_id,
+        run_id = state$active_run_id,
+        agent_id = self$agent_id,
+        agent_name = self$agent_name,
+        parent_agent_id = private$.parent_agent_id,
+        parent_run_id = private$.parent_run_id,
+        delegation_id = private$.delegation_id,
+        run_context = run_context,
+        usage = state$usage %||% AgentUsage()
+      )
+    },
+
+    # The engine behind `run_shiny()` and `run_async()`: a lazily-started
+    # async generator that drives ellmer's `stream_async()` while deputy's
+    # permissions, hooks, and usage limits are enforced through the
+    # `on_tool_request`/`on_tool_result` callbacks. Yields whatever the
+    # provider stream yields (content objects in content mode).
+    callback_run_stream = function(
+      prompt,
+      limits,
+      run_context,
+      require_absolute_file_paths,
+      state
+    ) {
+      agent <- self
+      stream_state <- state
+      effective_run_context <- run_context
+      run_limits <- limits
+
+      coro::async_generator(function() {
+        if (isTRUE(agent$.__enclos_env__$private$run_active)) {
+          cli::cli_abort(
+            "This agent already has an active run",
+            class = c("deputy_run_active", "deputy_error")
+          )
+        }
+
+        agent$.__enclos_env__$private$run_active <- TRUE
+        agent$.__enclos_env__$private$current_run_id <-
+          agent$.__enclos_env__$private$new_run_id()
+        agent$.__enclos_env__$private$current_run_context <-
+          effective_run_context
+        active_run_id <- agent$.__enclos_env__$private$current_run_id
+        stream_state$active_run_id <- active_run_id
+        on.exit(
+          agent$.__enclos_env__$private$finish_callback_run(stream_state),
+          add = TRUE
+        )
+
+        # Initialize lazily on first consumption. Merely constructing and
+        # abandoning a stream must not reserve this Agent forever.
+        agent$.__enclos_env__$private$tool_call_count <- 0L
+        agent$.__enclos_env__$private$tool_call_limit <-
+          run_limits$max_tool_calls
+        agent$.__enclos_env__$private$should_stop <- FALSE
+        agent$.__enclos_env__$private$stop_reason_from_hook <- NULL
+        agent$.__enclos_env__$private$current_usage_limits <- run_limits
+        agent$.__enclos_env__$private$current_usage_baseline <-
+          agent_usage_snapshot(agent$chat)
+        agent$.__enclos_env__$private$current_tool_calls <- 0L
+        agent$.__enclos_env__$private$current_tool_results <- 0L
+        agent$.__enclos_env__$private$current_outer_requests <- 0L
+        agent$.__enclos_env__$private$current_external_usage <- AgentUsage()
+        agent$.__enclos_env__$private$current_stream_controller <- tryCatch(
+          ellmer::stream_controller(),
+          error = function(e) NULL
+        )
+        agent$.__enclos_env__$private$current_stream_content <- TRUE
+        agent$.__enclos_env__$private$pending_events <- list()
+        agent$.__enclos_env__$private$tool_started_at <- list()
+        agent$.__enclos_env__$private$tool_event_overrides <- list()
+        agent$.__enclos_env__$private$tool_call_records <- list()
+        agent$.__enclos_env__$private$pending_delegations <- list()
+        agent$.__enclos_env__$private$last_limit_status <- NULL
+        agent$.__enclos_env__$private$last_run_usage <- AgentUsage()
+        agent$.__enclos_env__$private$current_run_checkpoint_id <- NULL
+        agent$.__enclos_env__$private$current_run_requires_absolute_file_paths <-
+          isTRUE(require_absolute_file_paths)
+
+        if (!is.null(agent$.__enclos_env__$private$.file_checkpoints)) {
+          checkpoint_id <- agent$.__enclos_env__$private$.file_checkpoints$checkpoint(
+            paste0("run ", active_run_id),
+            metadata = list(run_id = active_run_id, task = prompt)
+          )
+          agent$.__enclos_env__$private$current_run_checkpoint_id <-
+            checkpoint_id
+        }
+
+        agent$hooks$fire(
+          "SessionStart",
+          context = agent$.__enclos_env__$private$hook_context(
+            permissions = agent$permissions,
+            provider = agent$provider(),
+            tools_count = length(agent$chat$get_tools()),
+            run_id = active_run_id
+          )
+        )
+        stream_state$session_started <- TRUE
+        agent$hooks$fire(
+          "UserPromptSubmit",
+          prompt = prompt,
+          context = agent$.__enclos_env__$private$hook_context(
+            run_id = active_run_id
+          )
+        )
+
+        initial_limit_status <- usage_limit_status(
+          agent$.__enclos_env__$private$current_run_usage(),
+          agent$.__enclos_env__$private$current_usage_limits,
+          require_followup = TRUE
+        )
+        if (!is.null(initial_limit_status)) {
+          agent$.__enclos_env__$private$mark_usage_limit(initial_limit_status)
+          stream_state$reason <- initial_limit_status$reason
+        }
+
+        if (agent$.__enclos_env__$private$should_stop) {
+          stream <- coro::async_generator(function() {
+            if (FALSE) coro::yield("unreachable")
+          })()
+        } else {
+          stream <- tryCatch(
+            agent$.__enclos_env__$private$start_async_stream(prompt),
+            error = function(error) {
+              stream_state$reason <- "error"
+              stop(error)
+            }
+          )
+        }
+        is_generator <- inherits(stream, "coro_generator_instance")
+
+        repeat {
+          if (agent$.__enclos_env__$private$should_stop) {
+            stream_state$reason <-
+              agent$.__enclos_env__$private$stop_reason_from_hook %||%
+              "interrupted"
+            break
+          }
+
+          stream_error <- NULL
+          chunk <- NULL
+          if (isTRUE(is_generator)) {
+            chunk <- tryCatch(
+              stream(),
+              error = function(error) {
+                stream_error <<- error
+                NULL
+              }
+            )
+          } else {
+            chunk <- stream
+          }
+
+          if (is.null(stream_error) && promises::is.promising(chunk)) {
+            chunk <- tryCatch(
+              coro::await(chunk),
+              error = function(error) {
+                stream_error <<- error
+                NULL
+              }
+            )
+          }
+
+          if (!is.null(stream_error)) {
+            if (agent$.__enclos_env__$private$should_stop) {
+              stream_state$reason <-
+                agent$.__enclos_env__$private$stop_reason_from_hook %||%
+                "interrupted"
+              break
+            }
+            stream_state$reason <- "error"
+            stop(stream_error)
+          }
+
+          if (agent$.__enclos_env__$private$should_stop) {
+            stream_state$reason <-
+              agent$.__enclos_env__$private$stop_reason_from_hook %||%
+              "interrupted"
+            break
+          }
+
+          if (coro::is_exhausted(chunk)) {
+            break
+          }
+
+          coro::yield(chunk)
+          if (!isTRUE(is_generator)) {
+            break
+          }
+        }
+      })()
+    },
+
+    # Terminal accounting for a callback-driven run (`run_shiny()` /
+    # `run_async()`): settles the stop reason, fires Stop/SessionEnd, records
+    # run-scoped usage and cost on `state`, and releases the active run.
+    finish_callback_run = function(state) {
       active_run_id <- state$active_run_id
       if (
         isTRUE(state$finished) ||
@@ -1642,6 +1821,9 @@ Agent <- R6::R6Class(
             private$current_tool_calls > private$current_tool_results
           private$finalize_pending_checkpoints()
           usage <- private$current_run_usage()
+          state$usage <- usage
+          state$cost <- tryCatch(self$cost(), error = function(e) NULL)
+          private$last_run_usage <- usage
           limits <- private$current_usage_limits
           if (
             identical(state$reason, "complete") &&

--- a/README.Rmd
+++ b/README.Rmd
@@ -92,6 +92,34 @@ repeat {
 }
 ```
 
+### Async Runs
+
+`run_async()` runs a task without blocking the R process and returns a
+promise that resolves to an `AgentResult`. It uses the same
+callback-enforced permissions, hooks, and `UsageLimits` as `run_shiny()`,
+but collects the result instead of streaming to a UI. Reach for it when an
+Agent is a worker inside a larger async system, such as a sub-agent invoked
+from a tool of a chat that is itself streaming in Shiny:
+
+``` r
+worker <- Agent$new(
+  chat = parent_chat$clone()$set_turns(list()),
+  system_prompt = "You are a literature scout. Report sources with DOIs.",
+  tools = tools_web(),
+  usage_limits = UsageLimits(max_requests = 8, max_tool_calls = 12)
+)
+
+worker$run_async("Find three recent reviews on PFAS remediation") |>
+  promises::then(function(result) {
+    cat(result$stop_reason, "-", result$usage$tool_calls, "tool calls\n")
+    result$response
+  })
+```
+
+With `UsageLimits(on_exceed = "error")` the promise is rejected with the
+structured limit error instead of resolving with a typed `stop_reason`.
+Structured `output_format` still requires `run()` or `run_sync()`.
+
 ### CLI (`exec/deputy.R`)
 
 deputy ships a [Rapp](https://github.com/r-lib/Rapp) package executable that

--- a/README.md
+++ b/README.md
@@ -89,6 +89,34 @@ repeat {
 }
 ```
 
+### Async Runs
+
+`run_async()` runs a task without blocking the R process and returns a
+promise that resolves to an `AgentResult`. It uses the same
+callback-enforced permissions, hooks, and `UsageLimits` as `run_shiny()`,
+but collects the result instead of streaming to a UI. Reach for it when an
+Agent is a worker inside a larger async system, such as a sub-agent invoked
+from a tool of a chat that is itself streaming in Shiny:
+
+``` r
+worker <- Agent$new(
+  chat = parent_chat$clone()$set_turns(list()),
+  system_prompt = "You are a literature scout. Report sources with DOIs.",
+  tools = tools_web(),
+  usage_limits = UsageLimits(max_requests = 8, max_tool_calls = 12)
+)
+
+worker$run_async("Find three recent reviews on PFAS remediation") |>
+  promises::then(function(result) {
+    cat(result$stop_reason, "-", result$usage$tool_calls, "tool calls\n")
+    result$response
+  })
+```
+
+With `UsageLimits(on_exceed = "error")` the promise is rejected with the
+structured limit error instead of resolving with a typed `stop_reason`.
+Structured `output_format` still requires `run()` or `run_sync()`.
+
 ### CLI (`exec/deputy.R`)
 
 deputy ships a [Rapp](https://github.com/r-lib/Rapp) package executable

--- a/man/Agent.Rd
+++ b/man/Agent.Rd
@@ -146,6 +146,7 @@ agent$add_hook(HookMatcher$new(
     \item \href{#method-Agent-mcp_tools}{\code{Agent$mcp_tools()}}
     \item \href{#method-Agent-mcp_status}{\code{Agent$mcp_status()}}
     \item \href{#method-Agent-run_shiny}{\code{Agent$run_shiny()}}
+    \item \href{#method-Agent-run_async}{\code{Agent$run_async()}}
     \item \href{#method-Agent-clone}{\code{Agent$clone()}}
   }
 }
@@ -846,6 +847,52 @@ for this run. Protected constructor identity fields cannot change.}
   \subsection{Returns}{
     An async content stream suitable for
 \code{shinychat::chat_append()}.
+  }
+}
+
+\if{html}{\out{<hr>}}
+\if{html}{\out{<a id="method-Agent-run_async"></a>}}
+\if{latex}{\out{\hypertarget{method-Agent-run_async}{}}}
+\subsection{\code{Agent$run_async()}}{
+  Run an agentic task asynchronously and resolve to an \link{AgentResult}.
+
+Like \code{run_shiny()}, the multi-turn loop is driven by ellmer's
+\code{stream_async()}, so the R process is never blocked while the model or
+tools work: other Shiny sessions, \code{later} callbacks, and promise chains
+keep running. Unlike \code{run_shiny()}, nothing is streamed to a UI. The
+returned promise resolves once the run stops and carries the final
+response, run-scoped usage, and stop reason. Permissions, hooks, and
+\link{UsageLimits} are enforced as in \code{run_shiny()} (callbacks plus terminal
+accounting). File tools may use relative paths resolved against
+\code{working_dir}, as in \code{run()}; the absolute-path rule is specific to
+\code{run_shiny()}.
+
+Use this when an Agent is a \emph{worker} inside a larger async system, for
+example a delegated sub-agent executed from the tool of a parent chat
+that is itself streaming. \code{output_format} is not supported here;
+structured output still requires \code{run()} or \code{run_sync()}.
+  \subsection{Usage}{
+    \if{html}{\out{<div class="r">}}
+    \preformatted{Agent$run_async(task, usage_limits = NULL, run_context = list())}
+    \if{html}{\out{</div>}}
+  }
+  \subsection{Arguments}{
+    \if{html}{\out{<div class="arguments">}}
+    \describe{
+      \item{\code{task}}{The task for the agent to perform}
+      \item{\code{usage_limits}}{Optional \link{UsageLimits} override for this run. Unset
+fields fall back to the Agent's limits. With \code{on_exceed = "error"},
+hitting a limit rejects the promise with the structured limit error
+instead of resolving with a typed \code{stop_reason}.}
+      \item{\code{run_context}}{Canonical JSON-compatible context to add to or narrow
+for this run. Protected constructor identity fields cannot change.}
+    }
+    \if{html}{\out{</div>}}
+  }
+  \subsection{Returns}{
+    A \code{promises::promise} resolving to an \link{AgentResult}. It is
+rejected if the provider stream fails or a limit configured with
+\code{on_exceed = "error"} is reached.
   }
 }
 

--- a/man/LeadAgent.Rd
+++ b/man/LeadAgent.Rd
@@ -51,6 +51,7 @@ sub-agents based on registered AgentDefinitions.
   <li><span class="pkg-link" data-pkg="deputy" data-topic="Agent" data-id="register_tools"><a href='../../deputy/html/Agent.html#method-Agent-register_tools'><code>Agent$register_tools()</code></a></span></li>
   <li><span class="pkg-link" data-pkg="deputy" data-topic="Agent" data-id="rewind_files"><a href='../../deputy/html/Agent.html#method-Agent-rewind_files'><code>Agent$rewind_files()</code></a></span></li>
   <li><span class="pkg-link" data-pkg="deputy" data-topic="Agent" data-id="run"><a href='../../deputy/html/Agent.html#method-Agent-run'><code>Agent$run()</code></a></span></li>
+  <li><span class="pkg-link" data-pkg="deputy" data-topic="Agent" data-id="run_async"><a href='../../deputy/html/Agent.html#method-Agent-run_async'><code>Agent$run_async()</code></a></span></li>
   <li><span class="pkg-link" data-pkg="deputy" data-topic="Agent" data-id="run_shiny"><a href='../../deputy/html/Agent.html#method-Agent-run_shiny'><code>Agent$run_shiny()</code></a></span></li>
   <li><span class="pkg-link" data-pkg="deputy" data-topic="Agent" data-id="run_sync"><a href='../../deputy/html/Agent.html#method-Agent-run_sync'><code>Agent$run_sync()</code></a></span></li>
   <li><span class="pkg-link" data-pkg="deputy" data-topic="Agent" data-id="save_session"><a href='../../deputy/html/Agent.html#method-Agent-save_session'><code>Agent$save_session()</code></a></span></li>

--- a/tests/testthat/helper-mocks.R
+++ b/tests/testthat/helper-mocks.R
@@ -6,7 +6,10 @@ create_mock_provider <- function(
   model = "test-model",
   base_url = "https://example.invalid"
 ) {
-  ellmer::Provider(
+  # ellmer's development version moved `model`, `params`, and `extra_args`
+  # off `Provider`. Pass only the arguments the installed ellmer accepts so
+  # the mocks build against both the CRAN and development APIs.
+  args <- list(
     name = name,
     model = model,
     base_url = base_url,
@@ -15,6 +18,16 @@ create_mock_provider <- function(
     extra_headers = character(),
     credentials = NULL
   )
+  accepted <- names(formals(ellmer::Provider))
+  provider <- do.call(ellmer::Provider, args[names(args) %in% accepted])
+  attr(provider, "mock_model") <- model
+  provider
+}
+
+# The model name behind a mock provider, whichever ellmer API built it.
+mock_provider_model <- function(provider) {
+  attr(provider, "mock_model") %||%
+    tryCatch(provider@model, error = function(e) "test-model")
 }
 
 # Helper to create a proper S7 AssistantTurn
@@ -144,7 +157,7 @@ create_mock_chat <- function(responses = list("Hello!")) {
       get_provider = function() {
         provider
       },
-      get_model = function() provider@model,
+      get_model = function() mock_provider_model(provider),
       last_turn = function(role = "assistant") {
         # Return a proper S7 AssistantTurn
         text <- responses[[min(response_idx, length(responses))]]
@@ -292,7 +305,7 @@ create_compaction_mock_chat <- function(
         )
       },
       get_provider = function() provider,
-      get_model = function() provider@model,
+      get_model = function() mock_provider_model(provider),
       last_turn = function(role = "assistant") {
         text <- responses[[max(1L, response_idx)]]
         create_mock_assistant_turn(text = text)

--- a/tests/testthat/helper-runtime.R
+++ b/tests/testthat/helper-runtime.R
@@ -127,7 +127,7 @@ create_content_stream_chat <- function(
         do.call(rbind, state$token_rows)
       },
       get_provider = function() provider,
-      get_model = function() provider@model,
+      get_model = function() mock_provider_model(provider),
       last_turn = function(role = "assistant") {
         if (length(state$turns) == 0L) NULL else tail(state$turns, 1L)[[1]]
       },

--- a/tests/testthat/test-agent-async.R
+++ b/tests/testthat/test-agent-async.R
@@ -1,0 +1,315 @@
+test_that("run_async resolves to an AgentResult with the final turn's text", {
+  skip_if_not_installed("promises")
+  skip_if_not_installed("later")
+
+  chat <- create_mock_chat()
+  chat$stream_async <- function(prompt, stream = "content", controller = NULL) {
+    coro::async_generator(function() {
+      coro::yield(ellmer::ContentText("Thinking... "))
+      request <- ellmer::ContentToolRequest(
+        id = "t1",
+        name = "read_file",
+        arguments = list(path = "a.txt")
+      )
+      coro::yield(request)
+      coro::yield(ellmer::ContentToolResult(value = "ok", request = request))
+      coro::yield(ellmer::ContentText("Final "))
+      coro::yield(ellmer::ContentText("answer"))
+    })()
+  }
+  agent <- Agent$new(chat = chat, agent_name = "worker")
+
+  promise <- agent$run_async("do it", run_context = list(role = "worker"))
+  expect_true(promises::is.promising(promise))
+
+  result <- resolve_async_value(promise)
+  expect_s3_class(result, "AgentResult")
+  # Text before the tool call is narration; only the last turn survives.
+  expect_identical(result$response, "Final answer")
+  expect_identical(result$stop_reason, "complete")
+  expect_identical(result$agent_name, "worker")
+  expect_identical(result$agent_id, agent$agent_id)
+  expect_identical(result$session_id, agent$session_id())
+  expect_match(result$run_id, "^run_")
+  expect_identical(result$run_context$role, "worker")
+  expect_s3_class(result$usage, "AgentUsage")
+  expect_true(is.numeric(result$duration))
+  expect_false(agent$.__enclos_env__$private$run_active)
+})
+
+test_that("run_async accepts plain text chunks and falls back to last turn", {
+  skip_if_not_installed("promises")
+  skip_if_not_installed("later")
+
+  chat <- create_mock_chat(responses = list("from last turn"))
+  chat$stream_async <- function(prompt, stream = "content", controller = NULL) {
+    coro::async_generator(function() {
+      coro::yield("plain ")
+      coro::yield("text")
+    })()
+  }
+  agent <- Agent$new(chat = chat)
+  expect_identical(
+    resolve_async_value(agent$run_async("x"))$response,
+    "plain text"
+  )
+
+  silent <- create_mock_chat(responses = list("from last turn"))
+  silent$stream_async <- function(
+    prompt,
+    stream = "content",
+    controller = NULL
+  ) {
+    coro::async_generator(function() {
+      if (FALSE) coro::yield("unreachable")
+    })()
+  }
+  silent$last_turn <- function(role = "assistant") {
+    create_mock_assistant_turn(text = "from last turn")
+  }
+  agent <- Agent$new(chat = silent)
+  expect_identical(
+    resolve_async_value(agent$run_async("x"))$response,
+    "from last turn"
+  )
+})
+
+test_that("run_async enforces tool-call limits and releases the run", {
+  skip_if_not_installed("promises")
+  skip_if_not_installed("later")
+
+  calls <- 0L
+  chat <- create_mock_chat()
+  request_cb <- NULL
+  result_cb <- NULL
+  chat$on_tool_request <- function(callback) request_cb <<- callback
+  chat$on_tool_result <- function(callback) result_cb <<- callback
+  chat$stream_async <- function(prompt, stream = "content", controller = NULL) {
+    coro::async_generator(function() {
+      for (i in 1:3) {
+        request <- ellmer::ContentToolRequest(
+          id = paste0("t", i),
+          name = "read_file",
+          arguments = list(path = "a.txt")
+        )
+        rejected <- tryCatch(
+          {
+            request_cb(request)
+            FALSE
+          },
+          ellmer_tool_reject = function(e) TRUE
+        )
+        if (!rejected) {
+          calls <<- calls + 1L
+        }
+        result_cb(ellmer::ContentToolResult(
+          value = if (rejected) NULL else "ok",
+          error = if (rejected) "limit" else NULL,
+          request = request
+        ))
+        coro::yield(request)
+      }
+      coro::yield(ellmer::ContentText("done"))
+    })()
+  }
+  agent <- Agent$new(chat = chat)
+
+  result <- resolve_async_value(
+    agent$run_async("x", usage_limits = UsageLimits(max_tool_calls = 2))
+  )
+  expect_equal(calls, 2L)
+  expect_identical(result$stop_reason, "tool_call_limit")
+  expect_false(agent$.__enclos_env__$private$run_active)
+  expect_null(agent$.__enclos_env__$private$tool_call_limit)
+
+  # Agent-level limits apply when no override is given.
+  calls <- 0L
+  agent <- Agent$new(
+    chat = chat,
+    usage_limits = UsageLimits(max_tool_calls = 1)
+  )
+  result <- resolve_async_value(agent$run_async("x"))
+  expect_equal(calls, 1L)
+  expect_identical(result$stop_reason, "tool_call_limit")
+})
+
+test_that("run_async leaves tool calls unbounded when no tool-call limit is set", {
+  skip_if_not_installed("promises")
+  skip_if_not_installed("later")
+
+  observed <- NULL
+  chat <- create_mock_chat()
+  chat$stream_async <- function(prompt, stream = "content", controller = NULL) {
+    observed <<- agent$.__enclos_env__$private$tool_call_limit
+    coro::async_generator(function() coro::yield("done"))()
+  }
+  agent <- Agent$new(chat = chat, usage_limits = UsageLimits(max_requests = 5))
+  resolve_async_value(agent$run_async("x"))
+  expect_null(observed)
+})
+
+test_that("run_async honors on_exceed = 'error' by rejecting the promise", {
+  skip_if_not_installed("promises")
+  skip_if_not_installed("later")
+
+  cost <- 0
+  chat <- create_mock_chat()
+  chat$get_tokens <- function() {
+    data.frame(input = 1, output = 1, cached_input = 0, cost = cost)
+  }
+  chat$stream_async <- function(prompt, stream = "content", controller = NULL) {
+    cost <<- 0.01
+    coro::async_generator(function() coro::yield("over budget"))()
+  }
+  agent <- Agent$new(
+    chat = chat,
+    usage_limits = UsageLimits(max_cost_usd = 0.001, on_exceed = "error")
+  )
+  expect_error(
+    resolve_async_value(agent$run_async("expensive")),
+    class = "deputy_budget_exceeded"
+  )
+  expect_false(agent$.__enclos_env__$private$run_active)
+
+  # With the default "stop", the same run resolves with a typed reason.
+  cost <- 0
+  agent <- Agent$new(
+    chat = chat,
+    usage_limits = UsageLimits(max_cost_usd = 0.001)
+  )
+  result <- resolve_async_value(agent$run_async("expensive"))
+  expect_identical(result$stop_reason, "cost_limit")
+  expect_gt(result$usage$cost_usd, 0)
+})
+
+test_that("run_async fires lifecycle hooks and records usage on the result", {
+  skip_if_not_installed("promises")
+  skip_if_not_installed("later")
+
+  fired <- character()
+  chat <- create_mock_chat()
+  chat$stream_async <- function(prompt, stream = "content", controller = NULL) {
+    coro::async_generator(function() coro::yield("done"))()
+  }
+  agent <- Agent$new(chat = chat)
+  for (event in c("SessionStart", "UserPromptSubmit", "Stop", "SessionEnd")) {
+    local({
+      name <- event
+      agent$add_hook(HookMatcher$new(
+        event = name,
+        timeout = 0,
+        callback = function(...) {
+          fired <<- c(fired, name)
+          NULL
+        }
+      ))
+    })
+  }
+
+  result <- resolve_async_value(agent$run_async("x"))
+  expect_identical(
+    fired,
+    c("SessionStart", "UserPromptSubmit", "Stop", "SessionEnd")
+  )
+  expect_s3_class(result$usage, "AgentUsage")
+  expect_identical(agent$.__enclos_env__$private$last_run_usage, result$usage)
+})
+
+test_that("run_async rejects on stream failure and releases the agent", {
+  skip_if_not_installed("promises")
+  skip_if_not_installed("later")
+
+  # The mock chat is a plain list, so the stream must consult mutable state
+  # rather than being reassigned after the Agent captured it.
+  mode <- new.env(parent = emptyenv())
+  mode$fail <- TRUE
+  chat <- create_mock_chat()
+  chat$stream_async <- function(prompt, stream = "content", controller = NULL) {
+    coro::async_generator(function() {
+      if (mode$fail) {
+        stop("stream failed")
+      }
+      coro::yield("ok")
+    })()
+  }
+  agent <- Agent$new(chat = chat)
+  expect_error(resolve_async_value(agent$run_async("x")), "stream failed")
+  expect_false(agent$.__enclos_env__$private$run_active)
+
+  # A failed run must not block the next one.
+  mode$fail <- FALSE
+  expect_identical(resolve_async_value(agent$run_async("y"))$response, "ok")
+})
+
+test_that("run_async refuses to start while another run is active", {
+  skip_if_not_installed("promises")
+  skip_if_not_installed("later")
+
+  chat <- create_mock_chat()
+  chat$stream_async <- function(prompt, stream = "content", controller = NULL) {
+    coro::async_generator(function() {
+      coro::await(promises::promise(function(resolve, reject) {
+        later::later(function() resolve(TRUE), 0.05)
+      }))
+      coro::yield("done")
+    })()
+  }
+  agent <- Agent$new(chat = chat)
+  first <- agent$run_async("x")
+  expect_error(agent$run_async("y"), class = "deputy_run_active")
+  expect_identical(resolve_async_value(first)$response, "done")
+  expect_identical(resolve_async_value(agent$run_async("z"))$response, "done")
+})
+
+test_that("run_async allows relative file paths unlike run_shiny", {
+  skip_if_not_installed("promises")
+  skip_if_not_installed("later")
+
+  dir <- withr::local_tempdir()
+  writeLines("hello", file.path(dir, "note.txt"))
+  read <- create_shiny_tool_chat(
+    tool_name = "read_file",
+    tool_input = list(path = "note.txt")
+  )
+  agent <- Agent$new(
+    chat = read$chat,
+    tools = list(tool_read_file),
+    permissions = permissions_readonly(),
+    working_dir = dir
+  )
+
+  result <- resolve_async_value(agent$run_async("read"))
+  expect_true(read$state$executed)
+  expect_false(read$state$rejected)
+  expect_identical(result$response, "done")
+})
+
+test_that("run_async reports clean interruption", {
+  skip_if_not_installed("promises")
+  skip_if_not_installed("later")
+
+  agent <- NULL
+  chat <- create_mock_chat()
+  chat$stream_async <- function(prompt, stream = "content", controller = NULL) {
+    coro::async_generator(function() {
+      agent$interrupt("user_cancelled")
+      coro::yield("ignored")
+    })()
+  }
+  agent <- Agent$new(chat = chat)
+  result <- resolve_async_value(agent$run_async("cancel"))
+  expect_identical(result$stop_reason, "user_cancelled")
+})
+
+test_that("run_shiny still records usage on the shared callback state", {
+  skip_if_not_installed("promises")
+  skip_if_not_installed("later")
+
+  chat <- create_mock_chat()
+  chat$stream_async <- function(prompt, stream = "content", controller = NULL) {
+    coro::async_generator(function() coro::yield("done"))()
+  }
+  agent <- Agent$new(chat = chat)
+  expect_equal(collect_async_stream(agent$run_shiny("x")), list("done"))
+  expect_s3_class(agent$.__enclos_env__$private$last_run_usage, "AgentUsage")
+})

--- a/tests/testthat/test-agent.R
+++ b/tests/testthat/test-agent.R
@@ -384,14 +384,10 @@ test_that("compaction summary clone is isolated, callback-free, and silent", {
   request_calls <- 0L
   result_calls <- 0L
   probe <- new.env(parent = emptyenv())
-  provider <- ellmer::Provider(
+  provider <- create_mock_provider(
     name = "private-gateway",
     model = "private-model",
-    base_url = "https://gateway.invalid",
-    params = list(),
-    extra_args = list(),
-    extra_headers = character(),
-    credentials = function() "test-token"
+    base_url = "https://gateway.invalid"
   )
   mock_chat <- create_compaction_mock_chat(
     responses = list("A summary."),

--- a/vignettes/example-shiny-chat.Rmd
+++ b/vignettes/example-shiny-chat.Rmd
@@ -55,6 +55,41 @@ streaming errors in the chat UI.
 | Stall detection | No | Requires deputy's own loop |
 | `output_format` (structured output) | No | Requires deputy's own loop |
 
+## Sub-Agents Inside a Streaming Chat: `run_async()`
+
+`run_shiny()` is for the agent that owns the chat UI. When a Deputy Agent
+is instead a *worker* -- for example a delegated sub-agent invoked from an
+ellmer tool of a chat that is already streaming -- use `run_async()`. It
+drives the same callback-enforced loop but returns a promise that resolves
+to an `AgentResult`, so the tool body can `await` it without blocking other
+Shiny sessions:
+
+```{r}
+scout <- Agent$new(
+  chat = chat$clone()$set_turns(list()),
+  system_prompt = "You are a literature scout. Report sources with DOIs.",
+  tools = tools_web(),
+  usage_limits = UsageLimits(max_requests = 8, max_tool_calls = 12)
+)
+
+tool_scout <- ellmer::tool(
+  fun = coro::async(function(prompt) {
+    result <- coro::await(scout$run_async(prompt))
+    paste0(result$response, "\n\n(stopped: ", result$stop_reason, ")")
+  }),
+  name = "agent_scout",
+  description = "Delegate a literature search to the scout sub-agent.",
+  arguments = list(prompt = ellmer::type_string("Self-contained task"))
+)
+chat$register_tool(tool_scout)
+```
+
+`run_async()` enforces everything in the table above except file path
+confinement, which is a `run_shiny()` rule: worker agents resolve relative
+paths against their `working_dir` like `run()` does. Pass
+`UsageLimits(on_exceed = "error")` to have the promise rejected on a limit
+instead of resolving with a typed `stop_reason`.
+
 ## Basic Setup
 
 ```{r}


### PR DESCRIPTION
## Summary

- **New `Agent$run_async(task, usage_limits = NULL, run_context = list())`** — runs a task through ellmer's `stream_async()` and returns a promise resolving to an `AgentResult`, so a worker agent never blocks the R process. Intended for an Agent acting as a *worker* inside a larger async system, e.g. a delegated sub-agent invoked from the tool of a parent chat that is itself streaming in Shiny.
- Shares `run_shiny()`'s engine, now extracted into private `callback_run_stream()` / `new_callback_run_state()` / `callback_run_result()`; `run_shiny()` becomes a thin wrapper with identical behavior.
- Enforces permissions, hooks (SessionStart/UserPromptSubmit/Stop/SessionEnd, Pre/PostToolUse), and `UsageLimits` via callbacks and terminal accounting. Accepts a full per-run `UsageLimits` override; `on_exceed = "error"` rejects the promise with the structured limit error. Does **not** impose `run_shiny()`'s absolute-file-path rule.
- `response` is the text of the final assistant turn (narration before tool calls is dropped, matching `run_sync()`), with `chat$last_turn()` as fallback. Result carries `stop_reason`, run-scoped `usage`, `cost`, run/agent/session ids, parent/delegation ids, `run_context`, `duration`.
- `finish_shiny_stream` → `finish_callback_run`, which now records run-scoped usage/cost and sets `last_run_usage` (callback-driven runs previously never populated usage, so `LeadAgent`'s failure-path accounting read an empty `AgentUsage()`).
- Test mocks build `ellmer::Provider()` with only the formals the installed ellmer accepts (dev ellmer dropped `model`/`params`/`extra_args`), so the suite runs against both CRAN and development ellmer.
- Docs: roxygen/`man`, NEWS, README "Async Runs", and a "Sub-Agents Inside a Streaming Chat" section in the Shiny vignette showing the worker-tool pattern.

## Test plan

- [x] `tests/testthat/test-agent-async.R` (11 tests / 40 expectations): result assembly, narration reset, text-chunk and last-turn fallback, tool-call limits (override and agent-level), unbounded when unset, `on_exceed` error vs stop, lifecycle hooks + usage recording, stream-failure rejection + run release, active-run guard, relative paths allowed, clean interruption, `run_shiny()` records usage
- [x] Full `testthat` suite: 0 failures / 0 errors (2,031 pass, 33 skips) against ellmer 0.4.2.9000
- [x] `air format` on changed R files; `devtools::document()`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01K4vdVb7wZmcMUUHcjRF7oy
