### PR TITLE
docs: record the SDK-parity and shinychat host decisions as ADRs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -62,6 +62,10 @@ The repository includes a SessionStart hook (`.claude/setup-r.sh`) that automati
 # Install dependencies
 Rscript -e "devtools::install_deps(dependencies = TRUE)"
 
+# deputy tracks the DEVELOPMENT versions of ellmer and shinychat, not CRAN.
+# Install them from GitHub or you will be working against an older API.
+Rscript -e "pak::pak(c('tidyverse/ellmer', 'posit-dev/shinychat'))"
+
 # Load package for development
 Rscript -e "devtools::load_all()"
 ```
@@ -110,10 +114,22 @@ Rscript -e "devtools::install()"
 
 ### Versioning
 
-deputy stays on development versions (`0.0.0.9xxx`) until it is ready for CRAN.
-Do not bump to `0.1.0` or any release version as a way of marking progress — a
-release number means "submitted to CRAN", nothing else. Milestones carry
-direction; the version carries release state.
+deputy stays on `0.0.0.9xxx` until it is ready for CRAN.
+
+- **Do not bump the major or minor version.** Not to `0.1.0`, not to mark a
+  milestone, not to signal that a batch of work is done. A release number
+  means "submitted to CRAN" and nothing else.
+- **Do not add a release heading to `NEWS.md`.** New entries go under
+  `# deputy (development version)`. A `# deputy 0.1.0` heading reads as a
+  release announcement.
+- Milestones carry direction; the version carries release state.
+
+### Upstream dependencies
+
+deputy develops against the **development** versions of ellmer and shinychat,
+not their CRAN releases — see `dev/adr/0004-track-upstream-development-versions.md`.
+Install them from GitHub before working on the package. An upstream break is
+something to absorb promptly and report upstream, not to work around locally.
 
 ## Code Conventions
 

--- a/dev/adr/0001-features-over-agent-sdk-parity.md
+++ b/dev/adr/0001-features-over-agent-sdk-parity.md
@@ -1,0 +1,16 @@
+# Track Agent SDK features, not literal Agent SDK parity
+
+deputy began by mirroring Anthropic's Claude Agent SDK closely, shipping a compatibility facade — `ClaudeSDKClient`, `claude_sdk_query()`, Claude-style settings adapters, automatic session stores, and aliases — alongside the native `Agent` and `LeadAgent` APIs. That facade was removed in PR #23, reducing the exported API from 82 to 51 symbols. deputy takes its *ideas* from the Agent SDK — permissions, hooks, delegation, skills, human-in-the-loop — but expresses them in whatever shape is idiomatic for R, and does not commit to matching the SDK's names, options, or file formats.
+
+## Why
+
+Literal parity is a maintenance treadmill with no finish line: the SDK moves, and every move becomes deputy work that delivers nothing to an R user. It also imported foreign conventions — `.claude/` directory layouts, `settings.json` field names, camelCase options — into a package whose users expect tidyverse idiom. Two surfaces for the same capability meant every feature was built and tested twice, and the compatibility one was always the less-loved.
+
+The features are the valuable part. The wire format is not.
+
+## Consequences
+
+- **`.claude/` conventions are not a target.** A future declarative agent format should be deputy's own. Re-adding a `.claude/` loader would reintroduce what #23 removed. See issue #41.
+- **Issues framed as "parity gaps" are not automatically valid.** Several were closed as not-planned on these grounds: they asked to extend a surface that had been deliberately deleted.
+- **Downstream callers on the facade must migrate** to the native constructors. See issue #56.
+- **This is not a rejection of the SDK's design.** Ideas from it remain welcome; what is rejected is the obligation to match its interface.

--- a/dev/adr/0002-shinychat-as-primary-host.md
+++ b/dev/adr/0002-shinychat-as-primary-host.md
@@ -1,0 +1,17 @@
+# Design for shinychat as the primary host, keep headless first-class
+
+Most deputy agents are expected to run inside a Shiny application using shinychat, not in a terminal or a script. Design decisions should presume that host: async by default, per-session agent lifecycle, and human-in-the-loop expressed as UI. Headless and CLI use remain fully supported — some agents will always run that way — so no capability may depend on Shiny being present.
+
+## Why
+
+deputy's users are R users, and the way R work reaches non-R colleagues is a Shiny app. An agent that only runs in a terminal reaches the person who wrote it. shinychat already supplies the chat UI, streaming, conversation history and per-user scoping, so building on it costs little and skips a large amount of undifferentiated work.
+
+Presuming the host matters because the blocking-versus-async choice is not neutral. In a single-process Shiny app a blocking call freezes every connected session, not just the caller's. Decisions that look equivalent for a CLI tool are not equivalent here, and the difference is invisible until someone deploys.
+
+## Consequences
+
+- **Blocking calls in a shared path are defects, not limitations.** `LeadAgent` inherits `run_shiny()` while delegating through a blocking `run_sync()`; under this ADR that is a bug (issue #63), not a missing feature. `Agent$run_async()`, added in PR #64, is the primitive that fixes it.
+- **Two persistence layers now overlap.** deputy has `save_session()` / `load_session()` / `session_id()`; shinychat has `ConversationStore` with its own ids and scoping. Ownership must be settled rather than left ambiguous. Conversation forking is where the overlap becomes unavoidable (issue #62).
+- **Human-in-the-loop is a UI concern.** `tool_ask_user` was designed around a console prompt. Under a Shiny host, approval gating is a modal and an event, and pending state has to outlive a reactive flush (issue #43).
+- **No hard dependency on Shiny.** shiny, shinychat and promises stay in `Suggests`. A capability that cannot work headless needs an explicit, documented reason.
+- **"Most but not all" is the hard part.** The temptation is one API that works beautifully under Shiny and degrades silently elsewhere. Prefer an API that behaves identically in both, even where that costs more.

--- a/dev/adr/0003-shinychat-owns-conversation-persistence.md
+++ b/dev/adr/0003-shinychat-owns-conversation-persistence.md
@@ -14,4 +14,15 @@ The store also works headless. `FileConversationStore$new(dir)` instantiates and
 - **deputy needs API from shinychat that is currently internal.** `conversation_partition()` is unexported, so a partition — required by every `put()`, `get()` and `list()` call — cannot be constructed by another package without `:::`, which is not acceptable in a released package. The branching helpers (`record_set_current_leaf()`, `record_path_node_ids()`, `record_subtree_leaf()`) are likewise internal. **This decision is blocked on an upstream export request.**
 - **`save_session()` / `load_session()` become the headless fallback**, not the primary mechanism, and should not grow features that duplicate the store.
 - **Correlation is still deputy's problem.** `Agent$session_id()` and a shinychat conversation id are different identifiers, and runs, delegations and checkpoints key off deputy's. The mapping between them has to be explicit.
-- **The record schema is shinychat's to change.** deputy inherits a compatibility dependency on `schema_version`. This is the cost of the decision and is accepted deliberately.
+- **The record schema is shinychat's to change**, and deputy tracks it. This is not a reluctant cost. deputy and shinychat are meant to work well together and stay in sync, which means following upstream rather than insulating against it. Insulation would mean a translation layer, and a translation layer is how two packages drift apart while appearing to cooperate.
+
+## Timing
+
+The store is **unreleased**. `ConversationStore`, `FileConversationStore`, `chat_enable_history()` and `history_options()` are all in shinychat's development version (upstream #264, #266); CRAN has 0.4.0, which has none of it.
+
+That is fortunate rather than a problem. An API that has not shipped can still change shape, so the export request in issue #66 arrives while it is cheap to act on — and better still as a pull request than an issue. After a release the same request competes against backward compatibility.
+
+It does mean two things must be true before deputy can depend on this:
+
+- CI has to test against shinychat's development version. Today it installs from CRAN, where the store does not exist, so nothing deputy writes against it would be exercised.
+- deputy needs actual shinychat integration tests. There are currently none, despite ADR-0002 naming it the primary host.

--- a/dev/adr/0003-shinychat-owns-conversation-persistence.md
+++ b/dev/adr/0003-shinychat-owns-conversation-persistence.md
@@ -1,0 +1,17 @@
+# shinychat owns conversation persistence
+
+deputy and shinychat both persist conversations: deputy through `Agent$save_session()` / `load_session()` / `session_id()`, shinychat through `ConversationStore` with its own ids, partitions and scoping. shinychat's store is authoritative. deputy's job is to produce and consume conversation state, not to own where it lives.
+
+## Why
+
+shinychat's model is strictly richer. A stored record is a **tree** — `nodes` with `selected_child` links, a `current_leaf` pointer, and helpers that walk a path from root to leaf — because branching is what edit, retry and regenerate need in the UI. deputy's snapshot is a flat serialization of one conversation. Anything deputy built on top of its own format would have to grow into that tree eventually, and would then be a second, worse implementation of a structure that already exists.
+
+The store also works headless. `FileConversationStore$new(dir)` instantiates and round-trips outside a Shiny session, so deferring to it does not make persistence Shiny-only and stays consistent with ADR-0002.
+
+## Consequences
+
+- **Conversation forking is largely already built.** `current_leaf` plus `nodes` is a branching model; a fork is selecting a different leaf, not copying a record. See issue #62, whose scope shrinks accordingly.
+- **deputy needs API from shinychat that is currently internal.** `conversation_partition()` is unexported, so a partition — required by every `put()`, `get()` and `list()` call — cannot be constructed by another package without `:::`, which is not acceptable in a released package. The branching helpers (`record_set_current_leaf()`, `record_path_node_ids()`, `record_subtree_leaf()`) are likewise internal. **This decision is blocked on an upstream export request.**
+- **`save_session()` / `load_session()` become the headless fallback**, not the primary mechanism, and should not grow features that duplicate the store.
+- **Correlation is still deputy's problem.** `Agent$session_id()` and a shinychat conversation id are different identifiers, and runs, delegations and checkpoints key off deputy's. The mapping between them has to be explicit.
+- **The record schema is shinychat's to change.** deputy inherits a compatibility dependency on `schema_version`. This is the cost of the decision and is accepted deliberately.

--- a/dev/adr/0004-track-upstream-development-versions.md
+++ b/dev/adr/0004-track-upstream-development-versions.md
@@ -1,0 +1,19 @@
+# Track the development versions of ellmer and shinychat
+
+deputy develops and tests against the **development** versions of ellmer and shinychat, not their CRAN releases. `DESCRIPTION` should declare development floors and a `Remotes:` field pointing at the upstream repositories, and CI should install from those sources.
+
+## Why
+
+deputy is built on ellmer and hosted by shinychat (ADR-0002), and defers conversation persistence to shinychat's store (ADR-0003). That store is development-only — CRAN's shinychat 0.4.0 does not have it. Building against releases would mean deferring every capability by a release cycle, and designing against an API a cycle behind the one the maintainers are actually shaping.
+
+Staying current also changes when problems surface. An upstream change that breaks deputy is found the week it lands, while the maintainer still has it in mind and the fix is a conversation. Found at release time it is deputy's emergency, and the window for influencing the design has closed.
+
+The same currency is what makes upstream contribution possible. The export request in issue #66 is only well timed because deputy is looking at unreleased code.
+
+## Consequences
+
+- **`Remotes:` must be removed before CRAN submission.** CRAN does not accept it, and every dependency must be a released version. This ADR therefore has an expiry: at submission time deputy must be buildable against CRAN releases of ellmer and shinychat, which means those releases must have landed first. That is a real scheduling dependency on two other packages, and it is accepted deliberately.
+- **CI must install from development sources**, otherwise it tests something nobody runs. See issue #67.
+- **Version floors should name development versions** — `ellmer (>= 0.4.2.9000)`, `shinychat (>= 0.4.0.9000)` — so an install that silently resolved to CRAN fails loudly rather than at first use.
+- **Upstream breaking changes are deputy's to absorb promptly**, not to work around. See ADR-0003 on why insulation is the wrong instinct.
+- **Contributors need the dev versions installed.** This should be stated in the development setup instructions, not discovered through a confusing failure.


### PR DESCRIPTION
Two decisions currently live only in PR descriptions and a chat log. This writes them into `dev/adr/`, which was created empty by #24 and has been waiting for its first entries.

**Both drafts are inferred.** I wrote the reasoning from what the decisions imply, not from a statement of intent — please correct anything that misrepresents why.

## ADR-0001 — Track Agent SDK features, not literal parity

Records why #23 removed the compatibility facade: deputy takes the SDK's *ideas* — permissions, hooks, delegation, skills, HITL — and expresses them in R idiom, without committing to its names, options, or file formats.

Without this written down, #23 reads as gratuitous deletion and someone eventually proposes a shim. It also gives #41 its guardrail: a declarative agent format should be deputy's own, not a re-entry point for `.claude/` conventions.

## ADR-0002 — shinychat as the primary host, headless first-class

Records that most agents are expected to run inside a Shiny app via shinychat, while headless use stays fully supported and nothing may depend on Shiny being present.

This is the one that changes how open issues get designed. Under it:

- `LeadAgent` inheriting `run_shiny()` while delegating through a blocking `run_sync()` is a **defect** (#63), not a missing feature — in a single-process app it freezes every connected session, not just the caller's. `Agent$run_async()` from #64 is the primitive that fixes it.
- deputy's `save_session()`/`session_id()` and shinychat's `ConversationStore` are **two overlapping persistence layers**, and ownership needs settling. Forking is where that becomes unavoidable (#62).
- `tool_ask_user` was designed for a console prompt; under a Shiny host, approval gating is a modal whose pending state must outlive a reactive flush (#43).

## Not decided here

Which persistence layer wins. That is #62, and it needs answering before forking, durable HITL, or background subagents get designed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TdvtKdSspvyKBs8TXk5NaQ