### PR TITLE
Fix run_r_code subprocess error handling

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -52,6 +52,10 @@
   set. The summary clone preserves configured provider behavior while removing
   tools and callbacks and suppressing console echo.
 
+* `tool_run_r_code()` now rejects timed-out or failed `callr` subprocesses with
+  readable tool errors instead of failing later while formatting an unbound
+  result (#27).
+
 # deputy 0.0.0.9000
 
 * Added semantic content streaming with `tool_start`, `tool_end`, `usage`, and

--- a/R/tools-builtin.R
+++ b/R/tools-builtin.R
@@ -881,6 +881,66 @@ tool_grep_files <- ellmer::tool(
   )
 )
 
+run_r_code_impl <- function(code, timeout = 30) {
+  if (!rlang::is_installed("callr")) {
+    ellmer::tool_reject(
+      paste(
+        "Cannot execute R code: package 'callr' is required for",
+        "subprocess execution. Install with install.packages('callr')"
+      )
+    )
+  }
+
+  result <- tryCatch(
+    callr::r(
+      function(code_string) {
+        output <- utils::capture.output({
+          result <- tryCatch(
+            base::eval(base::parse(text = code_string)),
+            error = function(e) list(.deputy_error = e$message)
+          )
+        })
+        list(
+          output = paste(output, collapse = "\n"),
+          result = if (is.list(result) && ".deputy_error" %in% names(result)) {
+            paste("Error:", result$.deputy_error)
+          } else {
+            utils::capture.output(print(result))
+          }
+        )
+      },
+      args = list(code_string = code),
+      timeout = timeout
+    ),
+    error = function(e) {
+      if (inherits(e, "callr_timeout_error")) {
+        ellmer::tool_reject(sprintf(
+          "R code execution timed out after %s seconds",
+          format(timeout, trim = TRUE)
+        ))
+      }
+      ellmer::tool_reject(paste(
+        "R code execution failed:",
+        conditionMessage(e)
+      ))
+    }
+  )
+
+  parts <- character()
+  if (nchar(result$output) > 0) {
+    parts <- c(parts, "Output:", result$output)
+  }
+  if (length(result$result) > 0 && any(nchar(result$result) > 0)) {
+    parts <- c(parts, "Result:", paste(result$result, collapse = "\n"))
+  }
+
+  if (length(parts) == 0) {
+    return("Code executed successfully (no output)")
+  }
+
+  paste(parts, collapse = "\n")
+}
+
 #' Execute R code
 #'
 #' @description
@@ -912,85 +972,7 @@ tool_grep_files <- ellmer::tool(
 #' @export
 tool_run_r_code <- ellmer::tool(
   fun = function(code) {
-    # Internal parameters (not exposed to LLM)
-    sandbox <- TRUE
-    timeout <- 30
-
-    execute_r_code <- function(code_string) {
-      # Parse and evaluate the code, capturing output
-      output <- utils::capture.output({
-        result <- tryCatch(
-          base::eval(base::parse(text = code_string)),
-          error = function(e) {
-            list(.deputy_error = e$message)
-          }
-        )
-      })
-
-      list(
-        output = paste(output, collapse = "\n"),
-        result = if (is.list(result) && ".deputy_error" %in% names(result)) {
-          paste("Error:", result$.deputy_error)
-        } else {
-          utils::capture.output(print(result))
-        }
-      )
-    }
-
-    if (sandbox && rlang::is_installed("callr")) {
-      tryCatch(
-        {
-          result <- callr::r(
-            function(code_string) {
-              output <- utils::capture.output({
-                result <- tryCatch(
-                  base::eval(base::parse(text = code_string)),
-                  error = function(e) list(.deputy_error = e$message)
-                )
-              })
-              list(
-                output = paste(output, collapse = "\n"),
-                result = if (
-                  is.list(result) && ".deputy_error" %in% names(result)
-                ) {
-                  paste("Error:", result$.deputy_error)
-                } else {
-                  utils::capture.output(print(result))
-                }
-              )
-            },
-            args = list(code_string = code),
-            timeout = timeout
-          )
-        },
-        error = function(e) {
-          return(paste("Execution error:", e$message))
-        }
-      )
-    } else if (sandbox && !rlang::is_installed("callr")) {
-      # Security: Require callr for sandboxed execution - don't fall back to unsafe
-      return(ellmer::tool_reject(
-        "Cannot execute R code: package 'callr' is required for sandboxed execution. Install with install.packages('callr')"
-      ))
-    } else {
-      # sandbox = FALSE (not exposed to LLM, only for internal use)
-      result <- execute_r_code(code)
-    }
-
-    # Format output
-    parts <- character()
-    if (nchar(result$output) > 0) {
-      parts <- c(parts, "Output:", result$output)
-    }
-    if (length(result$result) > 0 && any(nchar(result$result) > 0)) {
-      parts <- c(parts, "Result:", paste(result$result, collapse = "\n"))
-    }
-
-    if (length(parts) == 0) {
-      return("Code executed successfully (no output)")
-    }
-
-    paste(parts, collapse = "\n")
+    run_r_code_impl(code)
   },
   name = "run_r_code",
   description = "Execute R code and return the output and result. By default runs in a sandboxed process for safety.",

--- a/tests/testthat/_snaps/tools.md
+++ b/tests/testthat/_snaps/tools.md
@@ -1,0 +1,8 @@
+# tool_run_r_code rejects subprocess timeouts readably
+
+    Code
+      error
+    Output
+      <error/ellmer_tool_reject>
+      Error in `ellmer::tool_reject()`:
+      ! Tool call rejected. R code execution timed out after 0.05 seconds

--- a/tests/testthat/test-tools.R
+++ b/tests/testthat/test-tools.R
@@ -423,6 +423,18 @@ test_that("tool_run_r_code handles runtime errors", {
   expect_true(grepl("intentional error", result, ignore.case = TRUE))
 })
 
+test_that("tool_run_r_code rejects subprocess timeouts readably", {
+  skip_if_not_installed("callr")
+
+  error <- tryCatch(
+    run_r_code_impl("Sys.sleep(10)", timeout = 0.05),
+    ellmer_tool_reject = identity
+  )
+
+  expect_s3_class(error, "ellmer_tool_reject")
+  expect_snapshot(error)
+})
+
 test_that("tool_run_bash handles command not found", {
   result <- tryCatch(
     tool_run_bash("nonexistent_command_xyz123"),


### PR DESCRIPTION
## Summary

- extract the one-shot R subprocess runner into a testable internal helper
- reject `callr` timeouts and worker failures with readable tool errors
- add a real timeout regression snapshot and a NEWS entry

## Verification

- `air format R/ tests/testthat/`
- `jarl check R/` (seven pre-existing warnings)
- `Rscript -e "devtools::test()"` (2,026 passed, 6 skipped, 2 existing warnings)
- `Rscript -e "devtools::check()"` (0 errors, 0 warnings, 1 environment clock note)
- `Rscript -e "pkgdown::check_pkgdown(); pkgdown::build_site(preview = FALSE)"`
- `git diff --check`

Closes #27
