### PR TITLE
Fail closed on unreadable sub-agent tool names

### DIFF
--- a/R/agent.R
+++ b/R/agent.R
@@ -2813,9 +2813,10 @@ Agent <- R6::R6Class(
         }
       )
 
-      provider_tool_call_id <- tryCatch(
-        request@id,
-        error = function(e) NULL
+      provider_tool_call_id <- read_provider_tool_call_id(
+        function() request@id,
+        source = "request",
+        object = request
       )
 
       # Tool annotations
@@ -2909,15 +2910,16 @@ Agent <- R6::R6Class(
         }
       )
 
-      provider_tool_call_id <- tryCatch(
-        {
+      provider_tool_call_id <- read_provider_tool_call_id(
+        function() {
           if (!is.null(result@request)) {
             result@request@id
           } else {
             NULL
           }
         },
-        error = function(e) NULL
+        source = "result",
+        object = result
       )
 
       list(

--- a/R/agents-multi.R
+++ b/R/agents-multi.R
@@ -765,16 +765,48 @@ LeadAgent <- R6::R6Class(
       }
 
       disallowed <- tolower(trimws(as.character(disallowed_tools)))
-      Filter(
-        function(tool) {
-          name <- tryCatch(tool@name, error = function(e) NULL)
-          if (is.null(name)) {
-            return(TRUE)
+      tool_names <- names(tools)
+      keep <- vapply(
+        seq_along(tools),
+        function(index) {
+          tool <- tools[[index]]
+          label <- if (
+            !is.null(tool_names) &&
+              length(tool_names) >= index &&
+              is_nonempty_string(tool_names[[index]])
+          ) {
+            tool_names[[index]]
+          } else {
+            paste0("#", index)
           }
-          !tolower(name) %in% disallowed
+          name <- read_optional_value(
+            function() tool@name,
+            validator = is_nonempty_string
+          )
+
+          if (identical(name$status, "unreadable")) {
+            cli_warn(c(
+              "Dropping tool {.val {label}} because its name could not be read.",
+              "i" = "Tool object class: {.cls {class(tool)}}.",
+              "x" = conditionMessage(name$error)
+            ))
+            return(FALSE)
+          }
+
+          if (!identical(name$status, "present")) {
+            cli_warn(c(
+              "Dropping tool {.val {label}} because it has no usable name.",
+              "i" = "Tool object class: {.cls {class(tool)}}."
+            ))
+            return(FALSE)
+          }
+
+          !tolower(trimws(name$value)) %in% disallowed
         },
-        tools
+        logical(1)
       )
+
+      tools[keep]
     },
 
     subagent_runs = list()

--- a/R/utils.R
+++ b/R/utils.R
@@ -1,5 +1,77 @@
 # Internal utility functions for deputy
 
+# Read an optional value without collapsing absence and read failures.
+#
+# @param reader Zero-argument function that reads the value.
+# @param validator Optional predicate for validating a present value.
+# @return A list with `status`, `value`, and `error`. Status is one of
+#   `"present"`, `"absent"`, `"invalid"`, or `"unreadable"`.
+# @noRd
+read_optional_value <- function(reader, validator = NULL) {
+  attempt <- tryCatch(
+    list(value = reader(), error = NULL),
+    error = function(error) list(value = NULL, error = error)
+  )
+
+  if (!is.null(attempt$error)) {
+    return(list(
+      status = "unreadable",
+      value = NULL,
+      error = attempt$error
+    ))
+  }
+
+  if (is.null(attempt$value)) {
+    return(list(status = "absent", value = NULL, error = NULL))
+  }
+
+  if (!is.null(validator) && !isTRUE(validator(attempt$value))) {
+    return(list(
+      status = "invalid",
+      value = attempt$value,
+      error = NULL
+    ))
+  }
+
+  list(status = "present", value = attempt$value, error = NULL)
+}
+
+# @noRd
+is_nonempty_string <- function(value) {
+  is.character(value) &&
+    length(value) == 1L &&
+    !is.na(value) &&
+    nzchar(trimws(value))
+}
+
+# Read an optional provider tool call ID and report malformed values.
+# @noRd
+read_provider_tool_call_id <- function(reader, source, object) {
+  id <- read_optional_value(reader, validator = is_nonempty_string)
+
+  if (identical(id$status, "present")) {
+    return(id$value)
+  }
+  if (identical(id$status, "absent")) {
+    return(NULL)
+  }
+
+  if (identical(id$status, "unreadable")) {
+    cli_warn(c(
+      "Failed to read provider tool call ID from {source}.",
+      "i" = "Source class: {.cls {class(object)}}.",
+      "x" = conditionMessage(id$error)
+    ))
+  } else {
+    cli_warn(c(
+      "Ignoring invalid provider tool call ID from {source}.",
+      "i" = "Expected one non-empty string; got {.cls {class(id$value)}}."
+    ))
+  }
+
+  NULL
+}
+
 #' Resolve symlinks in a path (follows symlink chains)
 #'
 #' Recursively resolves symlinks to get the final target path.

--- a/tests/testthat/_snaps/agent.md
+++ b/tests/testthat/_snaps/agent.md
@@ -1,0 +1,27 @@
+# provider tool call IDs distinguish absence from invalid values
+
+    Code
+      request_data <- agent$.__enclos_env__$private$extract_tool_request_data(
+        invalid_request)
+    Condition
+      Warning:
+      Ignoring invalid provider tool call ID from request.
+      i Expected one non-empty string; got <list>.
+    Code
+      result_data <- agent$.__enclos_env__$private$extract_tool_result_data(
+        invalid_result)
+    Condition
+      Warning:
+      Ignoring invalid provider tool call ID from result.
+      i Expected one non-empty string; got <list>.
+
+---
+
+    Code
+      unreadable_id <- read_provider_tool_call_id(function() unreadable_request@id,
+      source = "request", object = unreadable_request)
+    Condition
+      Warning:
+      Failed to read provider tool call ID from request.
+      i Source class: <environment>.
+      x no applicable method for `@` applied to an object of class "environment"

--- a/tests/testthat/_snaps/agents-multi.md
+++ b/tests/testthat/_snaps/agents-multi.md
@@ -1,0 +1,10 @@
+# sub-agent tool denylist drops tools with unreadable names
+
+    Code
+      filtered <- lead$.__enclos_env__$private$filter_disallowed_tools(tools,
+        disallowed_tools = "run_bash")
+    Condition
+      Warning:
+      Dropping tool "unreadable" because its name could not be read.
+      i Tool object class: <environment>.
+      x no applicable method for `@` applied to an object of class "environment"

--- a/tests/testthat/test-agent.R
+++ b/tests/testthat/test-agent.R
@@ -552,3 +552,46 @@ test_that("extract_tool_result_data handles NULL result", {
   expect_null(result$tool_result)
   expect_equal(result$tool_error, "NULL result received")
 })
+
+test_that("provider tool call IDs distinguish absence from invalid values", {
+  agent <- Agent$new(chat = create_mock_chat())
+
+  absent_request <- create_mock_tool_request()
+  attr(absent_request, "id") <- NULL
+  expect_no_warning(
+    absent <- agent$.__enclos_env__$private$extract_tool_request_data(
+      absent_request
+    )
+  )
+  expect_null(absent$provider_tool_call_id)
+
+  invalid_request <- create_mock_tool_request()
+  attr(invalid_request, "id") <- list("call_123")
+  invalid_result <- ellmer::ContentToolResult(
+    value = "ok",
+    request = invalid_request
+  )
+
+  request_data <- result_data <- NULL
+  expect_snapshot({
+    request_data <- agent$.__enclos_env__$private$extract_tool_request_data(
+      invalid_request
+    )
+    result_data <- agent$.__enclos_env__$private$extract_tool_result_data(
+      invalid_result
+    )
+  })
+  expect_null(request_data$provider_tool_call_id)
+  expect_null(result_data$provider_tool_call_id)
+
+  unreadable_request <- new.env(parent = emptyenv())
+  unreadable_id <- NULL
+  expect_snapshot(
+    unreadable_id <- read_provider_tool_call_id(
+      function() unreadable_request@id,
+      source = "request",
+      object = unreadable_request
+    )
+  )
+  expect_null(unreadable_id)
+})

--- a/tests/testthat/test-agents-multi.R
+++ b/tests/testthat/test-agents-multi.R
@@ -475,6 +475,23 @@ test_that("sub-agent disallowed tools override permission prompts", {
   expect_false(grepl("Use ask_user", result$reason, fixed = TRUE))
 })
 
+test_that("sub-agent tool denylist drops tools with unreadable names", {
+  lead <- LeadAgent$new(chat = create_mock_chat())
+  readable <- tools_file()[[1L]]
+  tools <- list(readable = readable, unreadable = new.env(parent = emptyenv()))
+
+  filtered <- NULL
+  expect_snapshot(
+    filtered <- lead$.__enclos_env__$private$filter_disallowed_tools(
+      tools,
+      disallowed_tools = "run_bash"
+    )
+  )
+
+  expect_named(filtered, "readable")
+  expect_identical(filtered[[1L]], readable)
+})
+
 test_that("sub-agents retain inherited prompt-tool gates", {
   definition <- agent_definition(
     name = "gated-prompt",


### PR DESCRIPTION
## Summary
- drop and warn on sub-agent tools whose names are unreadable or invalid
- preserve the distinction between absent, unreadable, and invalid provider tool-call IDs
- add snapshot regressions for the fail-closed and malformed-slot paths

## Validation
- `air format R/ tests/testthat/`
- `jarl check R/` (no new findings; matches the 7 findings on `origin/main`)
- `Rscript -e "devtools::test()"` (2,036 passed, 6 skipped)
- `Rscript -e "devtools::check()"` (0 errors, 0 warnings, 1 environment clock note)
- `Rscript -e "pkgdown::build_site(preview = FALSE)"`

Closes #25