### PR TITLE
Validate runtime identities and hook configuration

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -53,9 +53,10 @@
   arguments and regex patterns that do not compile, reporting both problems at
   construction instead of during a run (#35, #36).
 
-* `Skill$check_requirements()` now treats an unknown current provider as a
-  mismatch, and internal provider normalization returns `NA` for unknown names
-  as documented (#30).
+* `Skill$check_requirements()` now treats malformed or unmatched provider names
+  as mismatches while preserving compatibility when a skill and chat name the
+  same generic provider. Internal provider normalization returns `NA` for
+  unknown names as documented (#30).
 
 * `compact()` now summarizes on a clone of the agent's own chat instead of
   constructing a new provider. Previously any provider other than OpenAI,

--- a/NEWS.md
+++ b/NEWS.md
@@ -45,6 +45,18 @@
   changes may only narrow authority. Delegated agents use the same rule and
   retain lead capability, tool-gate, callback, and write-root restrictions.
 
+* `Agent` now rejects a provider tool request whose name is missing,
+  unreadable, or malformed before it reaches usage accounting, permissions,
+  hooks, or execution (#26).
+
+* `HookMatcher$new()` now rejects callbacks that cannot accept an event's
+  arguments and regex patterns that do not compile, reporting both problems at
+  construction instead of during a run (#35, #36).
+
+* `Skill$check_requirements()` now treats an unknown current provider as a
+  mismatch, and internal provider normalization returns `NA` for unknown names
+  as documented (#30).
+
 * `compact()` now summarizes on a clone of the agent's own chat instead of
   constructing a new provider. Previously any provider other than OpenAI,
   Anthropic, or Google fell through to `ellmer::chat_openai("gpt-4o-mini")`,

--- a/R/agent.R
+++ b/R/agent.R
@@ -2515,6 +2515,9 @@ Agent <- R6::R6Class(
     on_tool_request = function(request) {
       # Validate and extract request data safely
       extracted <- private$extract_tool_request_data(request)
+      if (!is.null(extracted$tool_identity_error)) {
+        ellmer::tool_reject(extracted$tool_identity_error)
+      }
       tool_name <- extracted$tool_name
       tool_input <- extracted$tool_input
       tool_annotations <- extracted$tool_annotations
@@ -2767,6 +2770,7 @@ Agent <- R6::R6Class(
       tool_input <- list()
       tool_annotations <- NULL
       provider_tool_call_id <- NULL
+      tool_identity_error <- NULL
 
       # Check if we have a valid request object
       if (is.null(request)) {
@@ -2775,7 +2779,8 @@ Agent <- R6::R6Class(
           tool_name = tool_name,
           tool_input = tool_input,
           tool_annotations = tool_annotations,
-          provider_tool_call_id = provider_tool_call_id
+          provider_tool_call_id = provider_tool_call_id,
+          tool_identity_error = tool_request_identity_error(request)
         ))
       }
 
@@ -2790,19 +2795,16 @@ Agent <- R6::R6Class(
           tool_name = tool_name,
           tool_input = tool_input,
           tool_annotations = tool_annotations,
-          provider_tool_call_id = provider_tool_call_id
+          provider_tool_call_id = provider_tool_call_id,
+          tool_identity_error = tool_request_identity_error(request)
         ))
       }
 
       # Extract from S7 object with error handling
       # Tool name
-      tool_name <- tryCatch(
-        request@name %||% "unknown",
-        error = function(e) {
-          cli_warn("Failed to extract tool name from request: {e$message}")
-          "unknown"
-        }
-      )
+      request_name <- read_tool_request_name(request)
+      tool_name <- request_name$value
+      tool_identity_error <- request_name$error
 
       # Tool arguments
       tool_input <- tryCatch(
@@ -2838,7 +2840,8 @@ Agent <- R6::R6Class(
         tool_name = tool_name,
         tool_input = tool_input,
         tool_annotations = tool_annotations,
-        provider_tool_call_id = provider_tool_call_id
+        provider_tool_call_id = provider_tool_call_id,
+        tool_identity_error = tool_identity_error
       )
     },
 

--- a/R/hook-validation.R
+++ b/R/hook-validation.R
@@ -1,0 +1,89 @@
+# Internal validation for HookMatcher configuration.
+
+hook_callback_arguments <- list(
+  PreToolUse = c("tool_name", "tool_input", "context"),
+  PostToolUse = c("tool_name", "tool_result", "tool_error", "context"),
+  PostToolUseFailure = c(
+    "tool_name",
+    "tool_result",
+    "tool_error",
+    "context"
+  ),
+  Stop = c("reason", "context"),
+  SubagentStart = c("agent_name", "task", "context"),
+  SubagentStop = c("agent_name", "task", "result", "context"),
+  UserPromptSubmit = c("prompt", "context"),
+  Notification = c("message", "context"),
+  PermissionRequest = c(
+    "tool_name",
+    "tool_input",
+    "permission_result",
+    "context"
+  ),
+  ConfigChange = c("key", "old_value", "new_value", "context"),
+  PreCompact = c("turns_to_compact", "turns_to_keep", "context"),
+  SessionStart = "context",
+  SessionEnd = c("reason", "context")
+)
+
+validate_hook_callback <- function(event, callback) {
+  callback_formals <- formals(callback)
+  expected <- hook_callback_arguments[[event]]
+  signature <- paste0("function(", paste(expected, collapse = ", "), ")")
+
+  if (!is.null(callback_formals) && "..." %in% names(callback_formals)) {
+    return(invisible(callback))
+  }
+
+  actual <- names(callback_formals)
+  missing_expected <- setdiff(expected, actual)
+  extra <- setdiff(actual, expected)
+  required_extra <- extra[vapply(
+    callback_formals[extra],
+    function(value) identical(value, quote(expr = )),
+    logical(1)
+  )]
+
+  if (
+    is.null(callback_formals) ||
+      length(missing_expected) > 0L ||
+      length(required_extra) > 0L
+  ) {
+    cli_abort(c(
+      "Invalid callback for {.val {event}} hook.",
+      "i" = paste0(
+        "Expected signature: ",
+        signature,
+        " or a callback accepting `...`."
+      )
+    ))
+  }
+
+  invisible(callback)
+}
+
+validate_hook_pattern <- function(pattern) {
+  if (is.null(pattern)) {
+    return(invisible(pattern))
+  }
+  if (
+    !is.character(pattern) ||
+      length(pattern) != 1L ||
+      is.na(pattern)
+  ) {
+    cli_abort("{.arg pattern} must be NULL or one non-missing string")
+  }
+
+  valid <- tryCatch(
+    {
+      suppressWarnings(grepl(pattern, ""))
+      TRUE
+    },
+    error = function(error) FALSE
+  )
+  if (!valid) {
+    cli_abort("Invalid hook pattern: {.val {pattern}}")
+  }
+
+  invisible(pattern)
+}

--- a/R/hook-validation.R
+++ b/R/hook-validation.R
@@ -30,14 +30,10 @@ validate_hook_callback <- function(event, callback) {
   callback_formals <- formals(callback)
   expected <- hook_callback_arguments[[event]]
   signature <- paste0("function(", paste(expected, collapse = ", "), ")")
-
-  if (!is.null(callback_formals) && "..." %in% names(callback_formals)) {
-    return(invisible(callback))
-  }
-
   actual <- names(callback_formals)
+  accepts_dots <- !is.null(callback_formals) && "..." %in% actual
   missing_expected <- setdiff(expected, actual)
-  extra <- setdiff(actual, expected)
+  extra <- setdiff(actual, c(expected, "..."))
   required_extra <- extra[vapply(
     callback_formals[extra],
     function(value) identical(value, quote(expr = )),
@@ -46,7 +42,7 @@ validate_hook_callback <- function(event, callback) {
 
   if (
     is.null(callback_formals) ||
-      length(missing_expected) > 0L ||
+      (!accepts_dots && length(missing_expected) > 0L) ||
       length(required_extra) > 0L
   ) {
     cli_abort(c(

--- a/R/hooks.R
+++ b/R/hooks.R
@@ -353,6 +353,9 @@ HookMatcher <- R6::R6Class(
         cli_abort("{.arg callback} must be a function")
       }
 
+      validate_hook_callback(event, callback)
+      validate_hook_pattern(pattern)
+
       private$.event <- event
       private$.callback <- callback
       private$.pattern <- pattern

--- a/R/skills.R
+++ b/R/skills.R
@@ -14,7 +14,7 @@ normalize_provider_name <- function(provider) {
   provider <- tolower(provider)
 
   # Handle common variations
-  provider <- switch(
+  switch(
     provider,
     "openai" = "openai",
     "chat_openai" = "openai",
@@ -39,11 +39,8 @@ normalize_provider_name <- function(provider) {
     "chat_openrouter" = "openrouter",
     "groq" = "groq",
     "chat_groq" = "groq",
-    # Default: return as-is
-    provider
+    NA_character_
   )
-
-  provider
 }
 
 #' Skill R6 Class
@@ -116,7 +113,6 @@ Skill <- R6::R6Class(
     check_requirements = function(current_provider = NULL) {
       missing <- character()
       provider_mismatch <- FALSE
-      mismatched_provider <- NULL
 
       # Check required packages
       if (!is.null(self$requires$packages)) {
@@ -134,8 +130,9 @@ Skill <- R6::R6Class(
           # Normalize provider name for comparison
           normalized_provider <- normalize_provider_name(current_provider)
 
-          # Only check if we could normalize the provider name
-          if (!is.na(normalized_provider)) {
+          if (is.na(normalized_provider)) {
+            provider_mismatch <- TRUE
+          } else {
             # Check if current provider is in the required list
             normalized_required <- vapply(
               required_providers,
@@ -149,11 +146,10 @@ Skill <- R6::R6Class(
             ]
 
             if (
-              length(normalized_required) > 0 &&
+              length(normalized_required) == 0L ||
                 !normalized_provider %in% normalized_required
             ) {
               provider_mismatch <- TRUE
-              mismatched_provider <- current_provider
             }
           }
         }

--- a/R/skills.R
+++ b/R/skills.R
@@ -43,6 +43,20 @@ normalize_provider_name <- function(provider) {
   )
 }
 
+# Compare known provider aliases while preserving exact matching for generic
+# providers supported by ellmer::chat().
+provider_requirement_key <- function(provider) {
+  normalized <- normalize_provider_name(provider)
+  if (!is.na(normalized)) {
+    return(paste0("known:", normalized))
+  }
+  if (!is_nonempty_string(provider)) {
+    return(NA_character_)
+  }
+
+  paste0("generic:", tolower(provider))
+}
+
 #' Skill R6 Class
 #'
 #' @description
@@ -127,30 +141,21 @@ Skill <- R6::R6Class(
       if (!is.null(current_provider) && !is.null(self$requires$providers)) {
         required_providers <- self$requires$providers
         if (length(required_providers) > 0) {
-          # Normalize provider name for comparison
-          normalized_provider <- normalize_provider_name(current_provider)
+          provider_key <- provider_requirement_key(current_provider)
+          required_keys <- vapply(
+            required_providers,
+            provider_requirement_key,
+            character(1),
+            USE.NAMES = FALSE
+          )
+          required_keys <- required_keys[!is.na(required_keys)]
 
-          if (is.na(normalized_provider)) {
+          if (
+            is.na(provider_key) ||
+              length(required_keys) == 0L ||
+              !provider_key %in% required_keys
+          ) {
             provider_mismatch <- TRUE
-          } else {
-            # Check if current provider is in the required list
-            normalized_required <- vapply(
-              required_providers,
-              normalize_provider_name,
-              character(1),
-              USE.NAMES = FALSE
-            )
-            # Remove any NULLs that became NA
-            normalized_required <- normalized_required[
-              !is.na(normalized_required)
-            ]
-
-            if (
-              length(normalized_required) == 0L ||
-                !normalized_provider %in% normalized_required
-            ) {
-              provider_mismatch <- TRUE
-            }
           }
         }
       }

--- a/R/tool-request-validation.R
+++ b/R/tool-request-validation.R
@@ -1,0 +1,49 @@
+# Internal validation for provider tool requests.
+
+tool_request_class_label <- function(request) {
+  classes <- class(request)
+  if (length(classes) == 0L) {
+    return("unknown")
+  }
+  paste(classes, collapse = "/")
+}
+
+tool_request_identity_error <- function(request, detail = NULL) {
+  message <- paste0(
+    "Cannot execute tool request because its name could not be read. ",
+    "Request class: <",
+    tool_request_class_label(request),
+    ">."
+  )
+  if (!is.null(detail)) {
+    message <- paste(message, detail)
+  }
+  message
+}
+
+read_tool_request_name <- function(request) {
+  name <- read_optional_value(
+    function() request@name,
+    validator = is_nonempty_string
+  )
+
+  if (identical(name$status, "present")) {
+    return(list(value = name$value, error = NULL))
+  }
+
+  detail <- switch(
+    name$status,
+    absent = "The name is absent.",
+    invalid = paste0(
+      "Expected one non-empty string; got <",
+      paste(class(name$value), collapse = "/"),
+      ">."
+    ),
+    unreadable = conditionMessage(name$error)
+  )
+
+  list(
+    value = "unknown",
+    error = tool_request_identity_error(request, detail)
+  )
+}

--- a/tests/testthat/_snaps/agent-events.md
+++ b/tests/testthat/_snaps/agent-events.md
@@ -1,0 +1,7 @@
+# malformed tool identity is rejected before permission checks
+
+    Code
+      agent$.__enclos_env__$private$on_tool_request(request)
+    Condition
+      Error in `ellmer::tool_reject()`:
+      ! Tool call rejected. Cannot execute tool request because its name could not be read. Request class: <ellmer::ContentToolRequest/ellmer::Content/S7_object>. Expected one non-empty string; got <list>.

--- a/tests/testthat/_snaps/hook-validation.md
+++ b/tests/testthat/_snaps/hook-validation.md
@@ -17,6 +17,15 @@
       ! Invalid callback for "SessionStart" hook.
       i Expected signature: function(context) or a callback accepting `...`.
 
+---
+
+    Code
+      HookMatcher$new(event = "SessionStart", callback = function(..., required) NULL)
+    Condition
+      Error in `validate_hook_callback()`:
+      ! Invalid callback for "SessionStart" hook.
+      i Expected signature: function(context) or a callback accepting `...`.
+
 # HookMatcher rejects invalid regex patterns at construction
 
     Code

--- a/tests/testthat/_snaps/hook-validation.md
+++ b/tests/testthat/_snaps/hook-validation.md
@@ -1,0 +1,36 @@
+# HookMatcher rejects callbacks that cannot accept an event
+
+    Code
+      HookMatcher$new(event = "PreToolUse", callback = function(tool_name) NULL)
+    Condition
+      Error in `validate_hook_callback()`:
+      ! Invalid callback for "PreToolUse" hook.
+      i Expected signature: function(tool_name, tool_input, context) or a callback accepting `...`.
+
+---
+
+    Code
+      HookMatcher$new(event = "SessionStart", callback = function(context, required)
+        NULL)
+    Condition
+      Error in `validate_hook_callback()`:
+      ! Invalid callback for "SessionStart" hook.
+      i Expected signature: function(context) or a callback accepting `...`.
+
+# HookMatcher rejects invalid regex patterns at construction
+
+    Code
+      HookMatcher$new(event = "PreToolUse", pattern = "[", callback = function(...)
+        NULL)
+    Condition
+      Error in `validate_hook_pattern()`:
+      ! Invalid hook pattern: "["
+
+---
+
+    Code
+      HookMatcher$new(event = "PreToolUse", pattern = c("read", "write"), callback = function(
+        ...) NULL)
+    Condition
+      Error in `validate_hook_pattern()`:
+      ! `pattern` must be NULL or one non-missing string

--- a/tests/testthat/test-agent-events.R
+++ b/tests/testthat/test-agent-events.R
@@ -507,3 +507,29 @@ test_that("pre-tool effects are applied before a real hook rejection", {
   )
   expect_match(mock$chat$get_system_prompt(), "Persist this hook context")
 })
+
+test_that("malformed tool identity is rejected before permission checks", {
+  checked <- new.env(parent = emptyenv())
+  checked$value <- FALSE
+  permissions <- Permissions$new(
+    mode = "standard",
+    can_use_tool = function(tool_name, tool_input, context) {
+      checked$value <- TRUE
+      PermissionResultAllow()
+    }
+  )
+  agent <- Agent$new(
+    chat = create_mock_chat(),
+    permissions = permissions
+  )
+  request <- create_mock_tool_request(name = "run_bash")
+  attr(request, "name") <- list("run_bash")
+
+  expect_snapshot(
+    agent$.__enclos_env__$private$on_tool_request(request),
+    error = TRUE
+  )
+
+  expect_false(checked$value)
+  expect_identical(agent$.__enclos_env__$private$current_tool_calls, 0L)
+})

--- a/tests/testthat/test-hook-validation.R
+++ b/tests/testthat/test-hook-validation.R
@@ -1,0 +1,51 @@
+test_that("HookMatcher rejects callbacks that cannot accept an event", {
+  expect_snapshot(
+    HookMatcher$new(
+      event = "PreToolUse",
+      callback = function(tool_name) NULL
+    ),
+    error = TRUE
+  )
+
+  expect_snapshot(
+    HookMatcher$new(
+      event = "SessionStart",
+      callback = function(context, required) NULL
+    ),
+    error = TRUE
+  )
+})
+
+test_that("HookMatcher accepts callbacks with dots or optional extras", {
+  dots <- HookMatcher$new(
+    event = "PreToolUse",
+    callback = function(...) NULL
+  )
+  optional <- HookMatcher$new(
+    event = "SessionStart",
+    callback = function(context, optional = TRUE) NULL
+  )
+
+  expect_s3_class(dots, "HookMatcher")
+  expect_s3_class(optional, "HookMatcher")
+})
+
+test_that("HookMatcher rejects invalid regex patterns at construction", {
+  expect_snapshot(
+    HookMatcher$new(
+      event = "PreToolUse",
+      pattern = "[",
+      callback = function(...) NULL
+    ),
+    error = TRUE
+  )
+
+  expect_snapshot(
+    HookMatcher$new(
+      event = "PreToolUse",
+      pattern = c("read", "write"),
+      callback = function(...) NULL
+    ),
+    error = TRUE
+  )
+})

--- a/tests/testthat/test-hook-validation.R
+++ b/tests/testthat/test-hook-validation.R
@@ -14,6 +14,14 @@ test_that("HookMatcher rejects callbacks that cannot accept an event", {
     ),
     error = TRUE
   )
+
+  expect_snapshot(
+    HookMatcher$new(
+      event = "SessionStart",
+      callback = function(..., required) NULL
+    ),
+    error = TRUE
+  )
 })
 
 test_that("HookMatcher accepts callbacks with dots or optional extras", {
@@ -25,9 +33,14 @@ test_that("HookMatcher accepts callbacks with dots or optional extras", {
     event = "SessionStart",
     callback = function(context, optional = TRUE) NULL
   )
+  dots_optional <- HookMatcher$new(
+    event = "SessionStart",
+    callback = function(..., optional = TRUE) NULL
+  )
 
   expect_s3_class(dots, "HookMatcher")
   expect_s3_class(optional, "HookMatcher")
+  expect_s3_class(dots_optional, "HookMatcher")
 })
 
 test_that("HookMatcher rejects invalid regex patterns at construction", {

--- a/tests/testthat/test-hooks.R
+++ b/tests/testthat/test-hooks.R
@@ -1123,7 +1123,7 @@ test_that("HookRegistry tracks errors in last_errors()", {
   hook <- HookMatcher$new(
     event = "PostToolUse",
     timeout = 0,
-    callback = function(tool_name, tool_input, tool_result, context) {
+    callback = function(tool_name, tool_result, tool_error, context) {
       stop("Logging failed!")
     }
   )
@@ -1140,8 +1140,8 @@ test_that("HookRegistry tracks errors in last_errors()", {
     registry$fire(
       "PostToolUse",
       tool_name = "test_tool",
-      tool_input = list(),
       tool_result = "result",
+      tool_error = NULL,
       context = list()
     )
   )

--- a/tests/testthat/test-skills.R
+++ b/tests/testthat/test-skills.R
@@ -262,6 +262,21 @@ test_that("check_requirements rejects unknown provider names", {
   expect_equal(check$current_provider, "anthropc")
 })
 
+test_that("check_requirements matches generic provider identities", {
+  skill <- Skill$new(
+    name = "test",
+    requires = list(providers = "deepseek")
+  )
+
+  matching <- skill$check_requirements(current_provider = "deepseek")
+  misspelled <- skill$check_requirements(current_provider = "deepseak")
+
+  expect_identical(matching$ok, TRUE)
+  expect_identical(matching$provider_mismatch, FALSE)
+  expect_identical(misspelled$ok, FALSE)
+  expect_identical(misspelled$provider_mismatch, TRUE)
+})
+
 test_that("check_requirements handles normalized provider names", {
   skill <- Skill$new(
     name = "test",

--- a/tests/testthat/test-skills.R
+++ b/tests/testthat/test-skills.R
@@ -195,7 +195,7 @@ test_that("normalize_provider_name handles edge cases", {
   expect_true(is.na(normalize_provider_name(NULL)))
   expect_true(is.na(normalize_provider_name(123)))
   expect_true(is.na(normalize_provider_name(c("openai", "anthropic"))))
-  expect_equal(normalize_provider_name("unknown_provider"), "unknown_provider")
+  expect_true(is.na(normalize_provider_name("unknown_provider")))
 })
 
 test_that("normalize_provider_name handles chat_* prefixes", {
@@ -247,6 +247,19 @@ test_that("check_requirements detects provider mismatch", {
   expect_true(check$provider_mismatch)
   expect_equal(check$current_provider, "anthropic")
   expect_equal(check$required_providers, "openai")
+})
+
+test_that("check_requirements rejects unknown provider names", {
+  skill <- Skill$new(
+    name = "test",
+    requires = list(providers = "openai")
+  )
+
+  check <- skill$check_requirements(current_provider = "anthropc")
+
+  expect_false(check$ok)
+  expect_true(check$provider_mismatch)
+  expect_equal(check$current_provider, "anthropc")
 })
 
 test_that("check_requirements handles normalized provider names", {


### PR DESCRIPTION
## Summary
- reject malformed provider tool identities before accounting, permissions, hooks, or execution
- return `NA` for unknown provider names and treat unknown skill providers as mismatches
- validate hook callback signatures and regex patterns when `HookMatcher` is constructed
- isolate the new validators and tests in focused files, avoiding further growth of the existing hook god files

## Validation
- `air format R/ tests/testthat/`
- `jarl check R/` (no new findings; the existing 7 match `main`)
- focused validation suite (467 passed)
- `Rscript -e "devtools::test()"` (2,048 passed, 6 skipped)
- `Rscript -e "devtools::check()"` (0 errors, 0 warnings, 1 environment clock note)
- `pkgdown::check_pkgdown()`
- `pkgdown::build_site(preview = FALSE)`

Closes #26
Closes #30
Closes #35
Closes #36