### PR TITLE
Harden hook execution and file-write boundaries

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -49,9 +49,15 @@
   unreadable, or malformed before it reaches usage accounting, permissions,
   hooks, or execution (#26).
 
-* `HookMatcher$new()` now rejects callbacks that cannot accept an event's
-  arguments and regex patterns that do not compile, reporting both problems at
-  construction instead of during a run (#35, #36).
+* `hook_limit_file_writes()` now delegates path decisions to the canonical
+  permission policy, rejects sibling-prefix and symlink escapes, and covers all
+  native file mutation tools (#75).
+
+* `HookMatcher$new()` now runs callbacks in the caller's process by default,
+  validates timeout configuration at construction, and preserves detailed
+  subprocess errors when isolated execution is explicitly requested. It also
+  rejects callbacks that cannot accept an event's arguments and regex patterns
+  that do not compile (#35, #36, #74).
 
 * `Skill$check_requirements()` now treats malformed or unmatched provider names
   as mismatches while preserving compatibility when a skill and chat name the

--- a/R/hook-validation.R
+++ b/R/hook-validation.R
@@ -83,3 +83,17 @@ validate_hook_pattern <- function(pattern) {
 
   invisible(pattern)
 }
+
+validate_hook_timeout <- function(timeout) {
+  if (
+    !is.numeric(timeout) ||
+      length(timeout) != 1L ||
+      is.na(timeout) ||
+      !is.finite(timeout) ||
+      timeout < 0
+  ) {
+    cli_abort("{.arg timeout} must be one finite non-negative number")
+  }
+
+  as.numeric(timeout)
+}

--- a/R/hooks.R
+++ b/R/hooks.R
@@ -323,7 +323,10 @@ HookMatcher <- R6::R6Class(
     #'   * SessionEnd: `function(reason, context)`
     #' @param pattern Optional regex pattern to filter by tool name.
     #'   Only applies to PreToolUse and PostToolUse events.
-    #' @param timeout Maximum callback execution time in seconds
+    #' @param timeout Maximum callback execution time in seconds. The default,
+    #'   `0`, runs the callback in the caller's process. Positive values run the
+    #'   callback in a clean [callr::r()] subprocess, where caller-process state
+    #'   and side effects are not available.
     #' @return A new `HookMatcher` object
     #'
     #' @examples
@@ -341,7 +344,7 @@ HookMatcher <- R6::R6Class(
     #'   }
     #' )
     #' }
-    initialize = function(event, callback, pattern = NULL, timeout = 30) {
+    initialize = function(event, callback, pattern = NULL, timeout = 0) {
       if (!event %in% HookEvent) {
         cli_abort(c(
           "Invalid hook event: {.val {event}}",
@@ -355,6 +358,7 @@ HookMatcher <- R6::R6Class(
 
       validate_hook_callback(event, callback)
       validate_hook_pattern(pattern)
+      timeout <- validate_hook_timeout(timeout)
 
       private$.event <- event
       private$.callback <- callback
@@ -428,7 +432,9 @@ HookMatcher <- R6::R6Class(
       )
     },
 
-    #' @field timeout Maximum execution time for the callback in seconds. Read-only after construction.
+    #' @field timeout Maximum execution time for the callback in seconds. Zero
+    #'   runs in the caller's process; a positive value uses a clean subprocess.
+    #'   Read-only after construction.
     timeout = function(value) {
       if (missing(value)) {
         return(private$.timeout)
@@ -543,11 +549,13 @@ HookRegistry <- R6::R6Class(
             }
           },
           error = function(e) {
+            error_message <- conditionMessage(e)
+
             # Track the error for programmatic access
             error_info <- list(
               event = event,
               tool_name = tool_name,
-              error = e$message,
+              error = error_message,
               timestamp = Sys.time()
             )
             private$hook_errors <- c(private$hook_errors, list(error_info))
@@ -557,11 +565,11 @@ HookRegistry <- R6::R6Class(
             if (event == "PreToolUse") {
               cli::cli_alert_danger(c(
                 "PreToolUse hook failed - denying tool for safety",
-                "x" = e$message
+                "x" = error_message
               ))
               return(HookResultPreToolUse(
                 permission = "deny",
-                reason = paste("Hook error:", e$message)
+                reason = paste("Hook error:", error_message)
               ))
             }
 
@@ -578,7 +586,7 @@ HookRegistry <- R6::R6Class(
 
             cli::cli_alert_danger(c(
               severity,
-              "x" = e$message,
+              "x" = error_message,
               "i" = "Use registry$last_errors to inspect hook failures"
             ))
 
@@ -919,33 +927,43 @@ hook_block_dangerous_bash <- function(
 #' Create a hook that limits file writes to a directory
 #'
 #' @description
-#' Convenience function to create a PreToolUse hook that only allows
-#' file writes within a specified directory.
+#' Convenience function to create a PreToolUse hook that applies Deputy's
+#' canonical file-write permission policy to `write_file`, `edit_file`, and
+#' `multi_edit`. Prefer configuring [Permissions] as the Agent's authority
+#' policy; this helper is useful as an additional hook-level restriction.
 #'
-#' @param allowed_dir Directory where writes are allowed
+#' @param allowed_dir Existing directory where writes are allowed. The path is
+#'   canonicalized when the hook is created.
 #' @return A [HookMatcher] object
 #'
 #' @examples
 #' \dontrun{
-#' agent$add_hook(hook_limit_file_writes("./output"))
+#' dir.create("output", showWarnings = FALSE)
+#' agent$add_hook(hook_limit_file_writes("output"))
 #' }
 #'
+#' @seealso [Permissions]
 #' @export
 hook_limit_file_writes <- function(allowed_dir) {
-  allowed_dir <- normalizePath(allowed_dir, mustWork = FALSE)
+  allowed_dir <- normalizePath(allowed_dir, mustWork = TRUE)
+  permissions <- Permissions$new(
+    file_write = allowed_dir,
+    bash = FALSE,
+    r_code = FALSE,
+    web = FALSE,
+    install_packages = FALSE
+  )
 
   HookMatcher$new(
     event = "PreToolUse",
-    pattern = "^write_file$",
+    pattern = "^(write_file|edit_file|multi_edit)$",
     timeout = 0, # Run in main process
     callback = function(tool_name, tool_input, context) {
-      path <- tool_input$path %||% ""
-      full_path <- normalizePath(path, mustWork = FALSE)
-
-      if (!startsWith(full_path, allowed_dir)) {
+      result <- permissions$check(tool_name, tool_input, context)
+      if (identical(result$decision, "deny")) {
         HookResultPreToolUse(
           permission = "deny",
-          reason = paste("File writes only allowed in:", allowed_dir)
+          reason = result$reason
         )
       } else {
         HookResultPreToolUse(permission = "allow")

--- a/man/HookMatcher.Rd
+++ b/man/HookMatcher.Rd
@@ -41,7 +41,9 @@ HookMatcher$new(
 
     \item{\code{callback}}{The function to call when the hook fires. Read-only after construction.}
 
-    \item{\code{timeout}}{Maximum execution time for the callback in seconds. Read-only after construction.}
+    \item{\code{timeout}}{Maximum execution time for the callback in seconds. Zero
+runs in the caller's process; a positive value uses a clean subprocess.
+Read-only after construction.}
   }
   \if{html}{\out{</div>}}
 }
@@ -61,7 +63,7 @@ HookMatcher$new(
   Create a new HookMatcher.
   \subsection{Usage}{
     \if{html}{\out{<div class="r">}}
-    \preformatted{HookMatcher$new(event, callback, pattern = NULL, timeout = 30)}
+    \preformatted{HookMatcher$new(event, callback, pattern = NULL, timeout = 0)}
     \if{html}{\out{</div>}}
   }
   \subsection{Arguments}{
@@ -86,7 +88,10 @@ HookMatcher$new(
 }}
       \item{\code{pattern}}{Optional regex pattern to filter by tool name.
 Only applies to PreToolUse and PostToolUse events.}
-      \item{\code{timeout}}{Maximum callback execution time in seconds}
+      \item{\code{timeout}}{Maximum callback execution time in seconds. The default,
+\code{0}, runs the callback in the caller's process. Positive values run the
+callback in a clean \code{\link[callr:r]{callr::r()}} subprocess, where caller-process state
+and side effects are not available.}
     }
     \if{html}{\out{</div>}}
   }

--- a/man/hook_limit_file_writes.Rd
+++ b/man/hook_limit_file_writes.Rd
@@ -7,18 +7,25 @@
 hook_limit_file_writes(allowed_dir)
 }
 \arguments{
-\item{allowed_dir}{Directory where writes are allowed}
+\item{allowed_dir}{Existing directory where writes are allowed. The path is
+canonicalized when the hook is created.}
 }
 \value{
 A \link{HookMatcher} object
 }
 \description{
-Convenience function to create a PreToolUse hook that only allows
-file writes within a specified directory.
+Convenience function to create a PreToolUse hook that applies Deputy's
+canonical file-write permission policy to \code{write_file}, \code{edit_file}, and
+\code{multi_edit}. Prefer configuring \link{Permissions} as the Agent's authority
+policy; this helper is useful as an additional hook-level restriction.
 }
 \examples{
 \dontrun{
-agent$add_hook(hook_limit_file_writes("./output"))
+dir.create("output", showWarnings = FALSE)
+agent$add_hook(hook_limit_file_writes("output"))
 }
 
+}
+\seealso{
+\link{Permissions}
 }

--- a/tests/testthat/_snaps/hook-validation.md
+++ b/tests/testthat/_snaps/hook-validation.md
@@ -43,3 +43,35 @@
     Condition
       Error in `validate_hook_pattern()`:
       ! `pattern` must be NULL or one non-missing string
+
+# HookMatcher rejects invalid timeouts at construction
+
+    Code
+      HookMatcher$new("PreToolUse", callback, timeout = -1)
+    Condition
+      Error in `validate_hook_timeout()`:
+      ! `timeout` must be one finite non-negative number
+
+---
+
+    Code
+      HookMatcher$new("PreToolUse", callback, timeout = Inf)
+    Condition
+      Error in `validate_hook_timeout()`:
+      ! `timeout` must be one finite non-negative number
+
+---
+
+    Code
+      HookMatcher$new("PreToolUse", callback, timeout = c(1, 2))
+    Condition
+      Error in `validate_hook_timeout()`:
+      ! `timeout` must be one finite non-negative number
+
+---
+
+    Code
+      HookMatcher$new("PreToolUse", callback, timeout = "5")
+    Condition
+      Error in `validate_hook_timeout()`:
+      ! `timeout` must be one finite non-negative number

--- a/tests/testthat/test-agent-hooks-integration.R
+++ b/tests/testthat/test-agent-hooks-integration.R
@@ -71,8 +71,9 @@ test_that("Agent rejects tool when PreToolUse hook denies", {
   expect_equal(reject_reason, "Blocked by security hook")
 })
 
-test_that("Agent allows tool when PreToolUse hook permits", {
+test_that("Agent runs default PreToolUse hooks in the caller process", {
   reject_called <- FALSE
+  hook_called <- FALSE
 
   local_mocked_bindings(
     tool_reject = function(reason) {
@@ -88,17 +89,41 @@ test_that("Agent allows tool when PreToolUse hook permits", {
     tools = list(tool_read_file)
   )
 
-  agent$hooks$add(HookMatcher$new(
+  agent$add_hook(HookMatcher$new(
     event = "PreToolUse",
-    timeout = 0,
     callback = function(tool_name, tool_input, context) {
+      hook_called <<- TRUE
       HookResultPreToolUse(permission = "allow")
     }
   ))
 
   simulate_tool_request(mock$get_callback())
 
+  expect_equal(hook_called, TRUE)
   expect_false(reject_called)
+})
+
+test_that("Agent preserves isolated hook failure details", {
+  agent <- Agent$new(chat = create_mock_chat())
+  agent$add_hook(HookMatcher$new(
+    event = "PreToolUse",
+    timeout = 5,
+    callback = function(...) stop("isolated hook failed")
+  ))
+
+  result <- suppressMessages(agent$hooks$fire(
+    "PreToolUse",
+    tool_name = "read_file",
+    tool_input = list(path = "DESCRIPTION"),
+    context = list()
+  ))
+
+  expect_match(result$reason, "isolated hook failed", fixed = TRUE)
+  expect_match(
+    agent$hooks$last_errors()[[1]]$error,
+    "isolated hook failed",
+    fixed = TRUE
+  )
 })
 
 test_that("Hook denial takes precedence over permission allow", {

--- a/tests/testthat/test-hook-validation.R
+++ b/tests/testthat/test-hook-validation.R
@@ -62,3 +62,24 @@ test_that("HookMatcher rejects invalid regex patterns at construction", {
     error = TRUE
   )
 })
+
+test_that("HookMatcher rejects invalid timeouts at construction", {
+  callback <- function(...) NULL
+
+  expect_snapshot(
+    HookMatcher$new("PreToolUse", callback, timeout = -1),
+    error = TRUE
+  )
+  expect_snapshot(
+    HookMatcher$new("PreToolUse", callback, timeout = Inf),
+    error = TRUE
+  )
+  expect_snapshot(
+    HookMatcher$new("PreToolUse", callback, timeout = c(1, 2)),
+    error = TRUE
+  )
+  expect_snapshot(
+    HookMatcher$new("PreToolUse", callback, timeout = "5"),
+    error = TRUE
+  )
+})

--- a/tests/testthat/test-hooks.R
+++ b/tests/testthat/test-hooks.R
@@ -694,6 +694,87 @@ test_that("hook_limit_file_writes restricts directory", {
   expect_equal(outside_result$permission, "deny")
 })
 
+test_that("hook_limit_file_writes rejects prefix-collision siblings", {
+  withr::local_tempdir(pattern = "deputy-test") -> parent_dir
+  parent_dir <- normalizePath(parent_dir, mustWork = TRUE)
+  allowed_dir <- file.path(parent_dir, "allowed")
+  sibling_dir <- file.path(parent_dir, "allowed-outside")
+  dir.create(allowed_dir)
+  dir.create(sibling_dir)
+
+  hook <- hook_limit_file_writes(allowed_dir)
+  result <- hook$callback(
+    tool_name = "write_file",
+    tool_input = list(path = file.path(sibling_dir, "attack.txt")),
+    context = list()
+  )
+
+  expect_equal(result$permission, "deny")
+})
+
+test_that("hook_limit_file_writes covers every native file mutation tool", {
+  withr::local_tempdir(pattern = "deputy-test") -> allowed_dir
+  allowed_dir <- normalizePath(allowed_dir, mustWork = TRUE)
+  outside_dir <- paste0(allowed_dir, "-outside")
+  dir.create(outside_dir)
+  hook <- hook_limit_file_writes(allowed_dir)
+  mutation_tools <- c("write_file", "edit_file", "multi_edit")
+
+  matches <- vapply(
+    c(mutation_tools, "read_file"),
+    hook$matches,
+    logical(1)
+  )
+
+  expect_equal(
+    matches,
+    c(
+      write_file = TRUE,
+      edit_file = TRUE,
+      multi_edit = TRUE,
+      read_file = FALSE
+    )
+  )
+
+  for (tool_name in mutation_tools) {
+    inside <- hook$callback(
+      tool_name,
+      list(path = file.path(allowed_dir, "inside.txt")),
+      list()
+    )
+    outside <- hook$callback(
+      tool_name,
+      list(path = file.path(outside_dir, "outside.txt")),
+      list()
+    )
+
+    expect_equal(inside$permission, "allow", info = tool_name)
+    expect_equal(outside$permission, "deny", info = tool_name)
+  }
+})
+
+test_that("hook_limit_file_writes rejects symlink escapes", {
+  withr::local_tempdir(pattern = "deputy-test") -> parent_dir
+  parent_dir <- normalizePath(parent_dir, mustWork = TRUE)
+  allowed_dir <- file.path(parent_dir, "allowed")
+  outside_dir <- file.path(parent_dir, "outside")
+  link_path <- file.path(allowed_dir, "escape")
+  dir.create(allowed_dir)
+  dir.create(outside_dir)
+  if (!file.symlink(outside_dir, link_path)) {
+    skip("Symbolic links are unavailable on this platform")
+  }
+
+  hook <- hook_limit_file_writes(allowed_dir)
+  result <- hook$callback(
+    "write_file",
+    list(path = file.path(link_path, "attack.txt")),
+    list()
+  )
+
+  expect_equal(result$permission, "deny")
+})
+
 # Hook timeout tests
 test_that("HookMatcher stores timeout value", {
   hook <- HookMatcher$new(
@@ -709,7 +790,7 @@ test_that("HookMatcher stores timeout value", {
     event = "PreToolUse",
     callback = function(...) NULL
   )
-  expect_equal(hook_default$timeout, 30)
+  expect_equal(hook_default$timeout, 0)
 })
 
 test_that("HookMatcher with timeout=0 runs in main process", {

--- a/vignettes/hooks.Rmd
+++ b/vignettes/hooks.Rmd
@@ -57,6 +57,12 @@ Add hooks to an agent with `add_hook()`:
 agent$add_hook(hook)
 ```
 
+Hooks run in the caller's R process by default, so callbacks can use ordinary
+R state and side effects. Set a positive `timeout` only when you deliberately
+want a clean `callr` subprocess with a hard deadline. An isolated callback
+cannot rely on caller-process state; qualify package functions such as
+`deputy::HookResultPostToolUse()` when using that mode.
+
 ### Filtering by Tool Name
 
 The optional `pattern` argument is a regex that filters which tools the hook
@@ -112,10 +118,16 @@ agent$add_hook(hook_block_dangerous_bash(
 
 ### Limiting File Writes
 
-`hook_limit_file_writes()` restricts writes to a specific directory:
+Configure the Agent's `Permissions` when a directory is an authority boundary.
+`hook_limit_file_writes()` is a defense-in-depth convenience hook that delegates
+to the same canonical path policy for `write_file`, `edit_file`, and
+`multi_edit`. The directory must already exist:
 
 ```{r, eval = FALSE}
-agent$add_hook(hook_limit_file_writes(allowed_dir = "/safe/output/dir"))
+output_dir <- file.path(getwd(), "output")
+dir.create(output_dir, showWarnings = FALSE)
+
+agent$add_hook(hook_limit_file_writes(output_dir))
 ```
 
 ## Custom PreToolUse Hooks
@@ -214,8 +226,9 @@ agent$add_hook(HookMatcher$new(
 
 ## Error Handling in Hooks
 
-If a hook callback throws an error, the agent logs it and continues. The
-error does not crash the agent. You can inspect recent hook errors with:
+If a `PreToolUse` hook throws an error, Deputy fails closed and denies the tool
+call. Other hook errors are logged and the run continues. You can inspect
+recent hook errors with:
 
 ```{r, eval = FALSE}
 agent$hooks$last_errors()


### PR DESCRIPTION
Closes #74
Closes #75

## Summary

- Run hooks in the caller's process by default so documented callbacks can use ordinary R state, while retaining explicit positive-timeout subprocess execution.
- Validate hook timeouts at construction and preserve nested subprocess failure details in denials and hook error records.
- Delegate `hook_limit_file_writes()` to Deputy's canonical permission policy, cover all native file mutation tools, and reject sibling-prefix and symlink escapes.
- Document the execution boundary and position `Permissions` as the primary authority policy.

## Verification

- `Rscript -e 'devtools::test(reporter = "summary")'`
- `Rscript -e 'devtools::check(error_on = "error")'` — 0 errors, 0 warnings; one environment clock-verification note
- `jarl check R/` — no new findings; seven pre-existing findings remain
- `Rscript -e 'pkgdown::check_pkgdown()'`
- `Rscript -e 'pkgdown::build_site(preview = FALSE)'`