### PR TITLE
Docs: build a tested first-success journey

### DIFF
--- a/README.Rmd
+++ b/README.Rmd
@@ -9,8 +9,7 @@ knitr::opts_chunk$set(
   collapse = TRUE,
   comment = "#>",
   fig.path = "man/figures/README-",
-  out.width = "100%",
-  eval = FALSE
+  out.width = "100%"
 )
 ```
 
@@ -23,467 +22,151 @@ knitr::opts_chunk$set(
 [![Codecov test coverage](https://codecov.io/gh/JamesHWade/deputy/graph/badge.svg)](https://app.codecov.io/gh/JamesHWade/deputy)
 <!-- badges: end -->
 
-deputy is a provider-agnostic agent runtime for R, built on
-[ellmer](https://ellmer.tidyverse.org/). It enables you to create AI agents
-that can use tools to accomplish multi-step tasks, with built-in support for
-permissions, hooks, streaming output, explicit persistence, and multi-agent
-delegation.
+Deputy turns an [ellmer](https://ellmer.tidyverse.org/) chat into a governed R
+Agent. Give it tools, a workspace, and explicit limits; get back an observable
+run you can inspect, stream into Shiny, save, or delegate.
 
-## Features
-- **Provider-agnostic** - Works with OpenAI, Anthropic, Google, Ollama, and any provider ellmer supports
-- **Tool bundles** - Pre-built tools for file operations, code execution, and data analysis
-- **Permission system** - Fine-grained control over what agents can do
-- **Hooks** - Intercept and customize agent behavior at key points
-- **Semantic streaming** - Text, content, tool lifecycle, usage, and stop events with run IDs
-- **Run limits** - Request, tool-call, token, and estimated-cost limits
-- **File checkpoints** - Bounded, persisted byte-exact rewind for Deputy file tools
-- **Multi-agent** - Coordinate specialized sub-agents for complex tasks
-- **Explicit persistence** - Save and load conversations with native RDS files
+## Why Deputy?
+
+ellmer gives R a provider-independent chat interface and tools. Deputy adds the
+runtime around that chat when a tool-using conversation becomes a real job:
+
+| Start with ellmer | Add Deputy when you need |
+|---|---|
+| Chats and provider APIs | Explicit tool permissions and run limits |
+| Tool registration | Hooks, semantic events, and inspectable results |
+| Streaming model output | A stable stream for terminals and Shiny hosts |
+| Conversation state | Explicit session persistence and file checkpoints |
+| One tool-using chat | Correlated delegation to specialist Agents |
+
+The core object model stays small:
+
+```text
+ellmer Chat + Tools + Permissions + Limits
+                     |
+                  Deputy Agent
+                     |
+        AgentResult + Events + Checkpoints
+```
 
 ## Installation
 
-You can install the development version of deputy from GitHub:
+Deputy currently follows development versions of ellmer:
+
 ```r
 # install.packages("pak")
-pak::pak("JamesHWade/deputy")
+pak::pak(c("tidyverse/ellmer", "JamesHWade/deputy"))
 ```
 
-You'll also need ellmer:
+For the optional Shiny host, also install shinychat:
 
 ```r
-pak::pak("tidyverse/ellmer")
+pak::pak("posit-dev/shinychat")
 ```
 
-## Quick Start
+## A safe first run
 
-### Create an Agent
+Start with a small, read-only toolset and a bounded run. This setup is
+provider-independent and is executed whenever the README is rendered:
 
-```{r example}
+```{r first-policy}
 library(deputy)
 
-# Create an agent with file tools
+workspace <- normalizePath(getwd(), winslash = "/")
+first_tools <- tools_preset("minimal")
+first_permissions <- permissions_readonly()
+first_limits <- UsageLimits(max_requests = 6, max_tool_calls = 8)
+
+stopifnot(
+  length(first_tools) == 3L,
+  identical(first_permissions$mode, "readonly"),
+  identical(first_limits$max_requests, 6L)
+)
+```
+
+Then choose any provider supported by ellmer and run a task. The model call is
+not executed while building the documentation:
+
+```{r first-agent, eval = FALSE}
+chat <- ellmer::chat("openai")
+
 agent <- Agent$new(
-  chat = ellmer::chat("openai"),
-  tools = tools_file()
+  chat = chat,
+  tools = first_tools,
+  permissions = first_permissions,
+  usage_limits = first_limits,
+  working_dir = workspace
 )
 
-# Run a task (blocking)
-result <- agent$run_sync("What R files are in the current directory?")
+result <- agent$run_sync(
+  "Explain what this R package does. Support the answer with file paths."
+)
+```
+
+`run_sync()` returns an `AgentResult`, not just text:
+
+```{r inspect-result, eval = FALSE}
 cat(result$response)
+result$stop_reason
+result$usage
+result$tool_calls()
+result$tool_results()
 ```
 
-### Streaming Output
+Read [Getting Started](https://jameshwade.github.io/deputy/articles/getting-started.html)
+to turn on a workspace-scoped write permission deliberately, create a file
+checkpoint, and recover from common failures.
 
-For real-time feedback as the agent works:
+## The safety boundary
 
-```{r streaming}
-events <- agent$run("Analyze the structure of this project")
-repeat {
-  event <- events()
-  if (coro::is_exhausted(event)) {
-    break
-  }
-  switch(
-    event$type,
-    "text" = cat(event$text),
-    "tool_start" = message("Calling ", event$tool_name, "..."),
-    "stop" = message("\nDone! Cost: $", round(event$cost$total, 4))
-  )
-}
-```
+Deputy enforces application-level policy at tool boundaries. It does not turn
+model-generated code into untrusted code you can execute safely:
 
-### Async Runs
+- `permissions_readonly()` denies Deputy's write, shell, R execution, web, and
+  package-install capabilities.
+- A directory-valued `file_write` permission confines Deputy's native file
+  writes to that canonical root. File reads remain limited by the R process,
+  not by an operating-system sandbox.
+- `run_r_code` uses a separate R process; that process separation is not an OS
+  security sandbox. `run_bash` executes with the current user's privileges.
+- File checkpoints cover Deputy's native write, edit, and multi-edit tools.
+  They are recovery machinery, not a substitute for version control or backups.
 
-`run_async()` runs a task without blocking the R process and returns a
-promise that resolves to an `AgentResult`. It uses the same
-callback-enforced permissions, hooks, and `UsageLimits` as `run_shiny()`,
-but collects the result instead of streaming to a UI. Reach for it when an
-Agent is a worker inside a larger async system, such as a sub-agent invoked
-from a tool of a chat that is itself streaming in Shiny:
+Start read-only, grant the narrowest capability that completes the job, and use
+a real isolation boundary for untrusted code.
 
-``` r
-worker <- Agent$new(
-  chat = parent_chat$clone()$set_turns(list()),
-  system_prompt = "You are a literature scout. Report sources with DOIs.",
-  tools = tools_web(),
-  usage_limits = UsageLimits(max_requests = 8, max_tool_calls = 12)
-)
+## Choose your path
 
-worker$run_async("Find three recent reviews on PFAS remediation") |>
-  promises::then(function(result) {
-    cat(result$stop_reason, "-", result$usage$tool_calls, "tool calls\n")
-    result$response
-  })
-```
+| Goal | Read next |
+|---|---|
+| Understand tools and presets | [Tools](https://jameshwade.github.io/deputy/articles/tools.html) |
+| Design a least-authority policy | [Permissions and Safety](https://jameshwade.github.io/deputy/articles/permissions.html) |
+| Observe or intervene in a run | [Hooks](https://jameshwade.github.io/deputy/articles/hooks.html) |
+| Embed an Agent in an app | [Shiny Chat](https://jameshwade.github.io/deputy/articles/example-shiny-chat.html) |
+| Delegate to specialist Agents | [Multi-Agent Orchestration](https://jameshwade.github.io/deputy/articles/multi-agent.html) |
+| Build a concrete workflow | [Recipes](https://jameshwade.github.io/deputy/articles/example-data-analysis.html) |
 
-With `UsageLimits(on_exceed = "error")` the promise is rejected with the
-structured limit error instead of resolving with a typed `stop_reason`.
-Structured `output_format` still requires `run()` or `run_sync()`.
+## Terminal use
 
-### CLI (`exec/deputy.R`)
-
-deputy ships a [Rapp](https://github.com/r-lib/Rapp) package executable that
-works with [`ir`](https://r-lib.github.io/ir/tools.html). Install `ir` once,
-then run the package directly from GitHub without installing deputy globally:
+Deputy also ships a [Rapp](https://github.com/r-lib/Rapp) package executable.
+Run it without a global Deputy installation, or install a persistent launcher:
 
 ```bash
 uv tool install r-lib-ir
 rx --from github::JamesHWade/deputy deputy --help
 rx --from github::JamesHWade/deputy deputy \
   --provider openai "Summarize the R files in this project"
-```
 
-For a persistent `deputy` command, install its launcher:
-
-```bash
 ir tool install github::JamesHWade/deputy
-deputy --provider openai --model gpt-4o --tools standard
+deputy --provider openai --tools minimal
 ```
 
-If deputy is already installed in an R library, Rapp can install the same
-launcher:
-
-```r
-Rapp::install_pkg_cli_apps("deputy")
-```
-
-The optional positional task selects non-interactive mode; omit it to start an
-interactive session. Common options include short aliases (`-p`, `-m`, `-t`,
-`-P`, `-n`, `-c`, `-d`, `-v`, etc.) and repeatable Rapp 0.4 flags:
-
-```bash
-deputy --mcp --mcp-server github --mcp-server slack
-deputy --debug --debug-file /tmp/deputy-debug.log
-```
-
-### Sessions and Persistence
-
-Every agent has a stable `session_id` for correlating results and events. Pass
-one at construction when another system owns the identifier, or let Deputy
-generate it:
-
-```{r sessions}
-agent <- Agent$new(
-  chat = ellmer::chat("openai"),
-  tools = tools_file(),
-  session_id = "session_research_001"
-)
-
-agent$session_id()
-result <- agent$run_sync("Summarize this package")
-result$session_id
-```
-
-`session_id` is correlation metadata, not a storage key. Persistence is an
-explicit file operation:
-
-```{r persistence}
-agent$save_session("research-session.rds")
-
-restored <- Agent$new(
-  chat = ellmer::chat("openai"),
-  tools = tools_file(),
-  permissions = permissions_readonly(),
-  session_id = "session_research_002"
-)
-restored$load_session("research-session.rds")
-```
-
-Loading restores the saved conversation, prompt, run context, and enabled file
-checkpoint state. The receiving agent keeps its own tools, permissions,
-working directory, and `session_id`.
-
-### Tools
-
-deputy provides tool presets for common use cases:
-
-```{r tools}
-# Use presets for quick setup
-tools_preset("minimal")   # read_file, list_files
-tools_preset("standard")  # + write_file, run_r_code
-tools_preset("dev")       # + run_bash (full development)
-tools_preset("data")      # read_file, list_files, read_csv, run_r_code
-tools_preset("full")      # all tools
-
-# Or use individual bundles
-tools_file()  # File operations
-tools_code()  # Code execution
-tools_data()  # Data reading
-tools_all()   # Everything
-
-# Optional: read selected pages from a PDF
-tool_read_file("report.pdf", pages = "1,3-5")
-
-# Optional: convert rich docs to markdown with MarkItDown
-tool_read_markdown("slides.pptx")
-```
-
-PDF page extraction uses `pdftools` when available, with a fallback to
-`reticulate` + Python `pypdf`.
-`tool_read_markdown()` uses `reticulate` + Python `markitdown`.
-
-### Permissions
-
-Control what your agent can do:
-
-```{r permissions}
-# Read-only: no writes, no code execution
-agent <- Agent$new(
-  chat = ellmer::chat("openai"),
-  tools = tools_file(),
-  permissions = permissions_readonly()
-)
-
-# Standard: accessible reads, workspace-scoped writes, R code, no bash
-agent <- Agent$new(
-  chat = ellmer::chat("openai"),
-  tools = tools_file(),
-  permissions = permissions_standard()
-)
-
-# Custom permissions
-agent <- Agent$new(
-  chat = ellmer::chat("openai"),
-  tools = tools_all(),
-  permissions = Permissions$new(
-    file_write = getwd(),
-    bash = FALSE,
-    r_code = TRUE
-  )
-)
-
-# Explicit tool policy gates
-agent <- Agent$new(
-  chat = ellmer::chat("openai"),
-  tools = tools_all(),
-  permissions = Permissions$new(
-    tool_allowlist = c("read_file", "list_files", "run_r_code"),
-    tool_denylist = c("run_bash"),
-    permission_prompt_tool_name = "ask_user"
-  )
-)
-
-# Planning mode: read-only tools plus ask_user
-agent <- Agent$new(
-  chat = ellmer::chat("openai"),
-  tools = tools_all(),
-  permissions = permissions_plan()
-)
-```
-
-When both are set, `tool_denylist` takes precedence over `tool_allowlist`.
-`permission_prompt_tool_name` identifies the tool that can request explicit
-human approval. `permissions_plan()` allows read-only annotated tools and
-`ask_user`.
-
-### Run Limits and File Rewind
-
-Limits are scoped to one run, so loading a saved conversation does not
-inherit usage from earlier runs:
-
-```{r usage-limits}
-agent <- Agent$new(
-  chat = ellmer::chat("openai"),
-  tools = tools_file(),
-  usage_limits = UsageLimits(
-    max_requests = 12,
-    max_tool_calls = 20,
-    max_total_tokens = 50000,
-    max_cost_usd = 1
-  )
-)
-
-result <- agent$run_sync("Inspect this package")
-result$run_id
-result$usage
-result$tool_calls()
-result$tool_results()
-```
-
-Request and tool-call limits are checked at model and tool boundaries. Token
-and cost limits use usage reported after a model response, so a run stops once
-an overage is observed and can exceed the configured threshold by one response.
-
-Enable reversible file journals when an agent may edit its workspace:
-
-```{r file-checkpoints}
-agent <- Agent$new(
-  chat = ellmer::chat("anthropic"),
-  tools = tools_file(),
-  enable_file_checkpointing = TRUE,
-  working_dir = getwd()
-)
-
-checkpoint_id <- agent$checkpoint("before refactor")
-agent$run_sync("Refactor R/parser.R")
-agent$rewind_files(checkpoint_id)
-```
-
-Deputy automatically creates a checkpoint at the beginning of each run and
-includes the journal when `save_session()` is called. Captures default to
-50 MiB per file. The default maximum aggregate serialized checkpoint-state size is
-250 MiB, counting journal records, checkpoint markers, metadata, and pending
-captures. The bounds apply to live captures and restored session state;
-violations signal
-`deputy_file_checkpoint_limit_error`. Lead agents and their delegated agents
-share one workspace journal, so child-agent edits participate in lead-level
-rewind. Rewind covers writes through Deputy's write, edit, and multi-edit
-tools; it does not capture writes performed by Bash, R code, or arbitrary
-custom tools.
-
-### Hooks
-
-Intercept agent behavior:
-
-```{r hooks}
-# Log all tool calls
-agent$add_hook(HookMatcher$new(
-  event = "PostToolUse",
-  callback = function(tool_name, tool_result, tool_error, context) {
-    message("[", Sys.time(), "] ", tool_name)
-    HookResultPostToolUse()
-  }
-))
-
-# Block dangerous bash commands
-agent$add_hook(HookMatcher$new(
-  event = "PreToolUse",
-  pattern = "^run_bash$",
-  callback = function(tool_name, tool_input, context) {
-    if (grepl("rm -rf|sudo", tool_input$command)) {
-      HookResultPreToolUse(permission = "deny", reason = "Dangerous command")
-    } else {
-      HookResultPreToolUse(permission = "allow")
-    }
-  }
-))
-
-# Replace emitted tool output without changing the model-visible result
-agent$add_hook(HookMatcher$new(
-  event = "PostToolUse",
-  pattern = "^read_file$",
-  callback = function(tool_name, tool_result, tool_error, context) {
-    HookResultPostToolUse(updated_tool_output = "File read completed")
-  }
-))
-```
-
-### Skills
-
-Skills bundle tools and prompt extensions. You can load them from disk or create
-them programmatically. deputy ships with a built-in example skill under
-`inst/skills`.
-
-```{r skills}
-# Discover bundled skills
-skills_dir <- system.file("skills", package = "deputy")
-skills_list(skills_dir)
-
-# Load a skill by path
-agent$load_skill(file.path(skills_dir, "data_analysis"))
-
-# Inspect loaded skills
-agent$skills()
-
-# Create and load a skill programmatically
-custom <- skill_create(
-  name = "my_skill",
-  description = "Custom helpers",
-  prompt = "You are a focused assistant for project-specific tasks."
-)
-agent$load_skill(custom)
-```
-
-### Structured Output
-
-Request JSON output that matches a schema:
-
-```{r structured_output}
-schema <- list(
-  type = "object",
-  properties = list(status = list(type = "string")),
-  required = list("status")
-)
-
-result <- agent$run_sync(
-  "Respond with status = ok",
-  output_format = list(type = "json_schema", schema = schema)
-)
-
-result$structured_output
-```
-
-### Error Handling
-
-deputy provides structured error types for programmatic error handling:
-
-```{r errors}
-# Detect Deputy errors while preserving their structured classes
-tryCatch(
-  agent$run_sync(
-    "task",
-    usage_limits = UsageLimits(max_requests = 2, on_exceed = "error")
-  ),
-  deputy_error = function(e) {
-    stopifnot(is_deputy_error(e))
-    message(conditionMessage(e))
-  }
-)
-```
-
-### Multi-Agent Systems
-
-Coordinate specialized agents:
-
-```{r multi-agent}
-# Define sub-agents
-code_agent <- agent_definition(
-  name = "code_analyst",
-  description = "Analyzes R code",
-  prompt = "You are an expert R programmer.",
-  tools = tools_file()
-)
-
-# Create lead agent that can delegate
-lead <- LeadAgent$new(
-  chat = ellmer::chat("openai"),
-  sub_agents = list(code_agent)
-)
-
-result <- lead$run_sync("Review the R code in this project")
-```
-
-Direct synchronous child usage is aggregated into `result$usage`. Each child
-inherits the lead run's remaining limits, and the lead enforces them after
-delegation. Parallel, background, transitive child-tree, and cross-run global
-usage accounting remain future work.
-
-## Provider Support
-
-deputy works with any LLM provider that ellmer supports:
-
-```{r providers}
-# OpenAI
-Agent$new(chat = ellmer::chat("openai"))
-
-# Anthropic
-Agent$new(chat = ellmer::chat("anthropic"))
-
-# Google
-Agent$new(chat = ellmer::chat("google_gemini"))
-
-# Local via Ollama
-Agent$new(chat = ellmer::chat("ollama/llama3.2"))
-```
-
-## Learn More
-
-- `vignette("getting-started")` - Comprehensive introduction
-- `vignette("permissions")` - Permission modes and custom policies
-- `vignette("hooks")` - Tool lifecycle hooks
-- `vignette("multi-agent")` - Delegation with `LeadAgent`
-- [ellmer documentation](https://ellmer.tidyverse.org/) - Underlying LLM framework
+## Status
+
+Deputy is experimental. Its contracts are being sharpened through real package,
+CLI, and Shiny integrations. Please report problems and design gaps in
+[GitHub Issues](https://github.com/JamesHWade/deputy/issues).
 
 ## License
 
-MIT
+MIT © James Wade

--- a/README.md
+++ b/README.md
@@ -13,478 +13,157 @@ experimental](https://img.shields.io/badge/lifecycle-experimental-orange.svg)](h
 coverage](https://codecov.io/gh/JamesHWade/deputy/graph/badge.svg)](https://app.codecov.io/gh/JamesHWade/deputy)
 <!-- badges: end -->
 
-deputy is a provider-agnostic agent runtime for R, built on
-[ellmer](https://ellmer.tidyverse.org/). It enables you to create AI
-agents that can use tools to accomplish multi-step tasks, with built-in
-support for permissions, hooks, streaming output, explicit persistence,
-and multi-agent delegation.
+Deputy turns an [ellmer](https://ellmer.tidyverse.org/) chat into a
+governed R Agent. Give it tools, a workspace, and explicit limits; get
+back an observable run you can inspect, stream into Shiny, save, or
+delegate.
 
-## Features
+## Why Deputy?
 
-- **Provider-agnostic** - Works with OpenAI, Anthropic, Google, Ollama,
-  and any provider ellmer supports
-- **Tool bundles** - Pre-built tools for file operations, code
-  execution, and data analysis
-- **Permission system** - Fine-grained control over what agents can do
-- **Hooks** - Intercept and customize agent behavior at key points
-- **Semantic streaming** - Text, content, tool lifecycle, usage, and
-  stop events with run IDs
-- **Run limits** - Request, tool-call, token, and estimated-cost limits
-- **File checkpoints** - Bounded, persisted byte-exact rewind for Deputy
-  file tools
-- **Multi-agent** - Coordinate specialized sub-agents for complex tasks
-- **Explicit persistence** - Save and load conversations with native RDS
-  files
+ellmer gives R a provider-independent chat interface and tools. Deputy
+adds the runtime around that chat when a tool-using conversation becomes
+a real job:
+
+| Start with ellmer       | Add Deputy when you need                          |
+|-------------------------|---------------------------------------------------|
+| Chats and provider APIs | Explicit tool permissions and run limits          |
+| Tool registration       | Hooks, semantic events, and inspectable results   |
+| Streaming model output  | A stable stream for terminals and Shiny hosts     |
+| Conversation state      | Explicit session persistence and file checkpoints |
+| One tool-using chat     | Correlated delegation to specialist Agents        |
+
+The core object model stays small:
+
+``` text
+ellmer Chat + Tools + Permissions + Limits
+                     |
+                  Deputy Agent
+                     |
+        AgentResult + Events + Checkpoints
+```
 
 ## Installation
 
-You can install the development version of deputy from GitHub:
+Deputy currently follows development versions of ellmer:
 
 ``` r
 # install.packages("pak")
-pak::pak("JamesHWade/deputy")
+pak::pak(c("tidyverse/ellmer", "JamesHWade/deputy"))
 ```
 
-You’ll also need ellmer:
+For the optional Shiny host, also install shinychat:
 
 ``` r
-pak::pak("tidyverse/ellmer")
+pak::pak("posit-dev/shinychat")
 ```
 
-## Quick Start
+## A safe first run
 
-### Create an Agent
+Start with a small, read-only toolset and a bounded run. This setup is
+provider-independent and is executed whenever the README is rendered:
 
 ``` r
 library(deputy)
 
-# Create an agent with file tools
+workspace <- normalizePath(getwd(), winslash = "/")
+first_tools <- tools_preset("minimal")
+first_permissions <- permissions_readonly()
+first_limits <- UsageLimits(max_requests = 6, max_tool_calls = 8)
+
+stopifnot(
+  length(first_tools) == 3L,
+  identical(first_permissions$mode, "readonly"),
+  identical(first_limits$max_requests, 6L)
+)
+```
+
+Then choose any provider supported by ellmer and run a task. The model
+call is not executed while building the documentation:
+
+``` r
+chat <- ellmer::chat("openai")
+
 agent <- Agent$new(
-  chat = ellmer::chat("openai"),
-  tools = tools_file()
+  chat = chat,
+  tools = first_tools,
+  permissions = first_permissions,
+  usage_limits = first_limits,
+  working_dir = workspace
 )
 
-# Run a task (blocking)
-result <- agent$run_sync("What R files are in the current directory?")
+result <- agent$run_sync(
+  "Explain what this R package does. Support the answer with file paths."
+)
+```
+
+`run_sync()` returns an `AgentResult`, not just text:
+
+``` r
 cat(result$response)
+result$stop_reason
+result$usage
+result$tool_calls()
+result$tool_results()
 ```
 
-### Streaming Output
+Read [Getting
+Started](https://jameshwade.github.io/deputy/articles/getting-started.html)
+to turn on a workspace-scoped write permission deliberately, create a
+file checkpoint, and recover from common failures.
 
-For real-time feedback as the agent works:
+## The safety boundary
 
-``` r
-events <- agent$run("Analyze the structure of this project")
-repeat {
-  event <- events()
-  if (coro::is_exhausted(event)) {
-    break
-  }
-  switch(
-    event$type,
-    "text" = cat(event$text),
-    "tool_start" = message("Calling ", event$tool_name, "..."),
-    "stop" = message("\nDone! Cost: $", round(event$cost$total, 4))
-  )
-}
-```
+Deputy enforces application-level policy at tool boundaries. It does not
+turn model-generated code into untrusted code you can execute safely:
 
-### Async Runs
+- `permissions_readonly()` denies Deputy’s write, shell, R execution,
+  web, and package-install capabilities.
+- A directory-valued `file_write` permission confines Deputy’s native
+  file writes to that canonical root. File reads remain limited by the R
+  process, not by an operating-system sandbox.
+- `run_r_code` uses a separate R process; that process separation is not
+  an OS security sandbox. `run_bash` executes with the current user’s
+  privileges.
+- File checkpoints cover Deputy’s native write, edit, and multi-edit
+  tools. They are recovery machinery, not a substitute for version
+  control or backups.
 
-`run_async()` runs a task without blocking the R process and returns a
-promise that resolves to an `AgentResult`. It uses the same
-callback-enforced permissions, hooks, and `UsageLimits` as `run_shiny()`,
-but collects the result instead of streaming to a UI. Reach for it when an
-Agent is a worker inside a larger async system, such as a sub-agent invoked
-from a tool of a chat that is itself streaming in Shiny:
+Start read-only, grant the narrowest capability that completes the job,
+and use a real isolation boundary for untrusted code.
 
-``` r
-worker <- Agent$new(
-  chat = parent_chat$clone()$set_turns(list()),
-  system_prompt = "You are a literature scout. Report sources with DOIs.",
-  tools = tools_web(),
-  usage_limits = UsageLimits(max_requests = 8, max_tool_calls = 12)
-)
+## Choose your path
 
-worker$run_async("Find three recent reviews on PFAS remediation") |>
-  promises::then(function(result) {
-    cat(result$stop_reason, "-", result$usage$tool_calls, "tool calls\n")
-    result$response
-  })
-```
+| Goal | Read next |
+|----|----|
+| Understand tools and presets | [Tools](https://jameshwade.github.io/deputy/articles/tools.html) |
+| Design a least-authority policy | [Permissions and Safety](https://jameshwade.github.io/deputy/articles/permissions.html) |
+| Observe or intervene in a run | [Hooks](https://jameshwade.github.io/deputy/articles/hooks.html) |
+| Embed an Agent in an app | [Shiny Chat](https://jameshwade.github.io/deputy/articles/example-shiny-chat.html) |
+| Delegate to specialist Agents | [Multi-Agent Orchestration](https://jameshwade.github.io/deputy/articles/multi-agent.html) |
+| Build a concrete workflow | [Recipes](https://jameshwade.github.io/deputy/articles/example-data-analysis.html) |
 
-With `UsageLimits(on_exceed = "error")` the promise is rejected with the
-structured limit error instead of resolving with a typed `stop_reason`.
-Structured `output_format` still requires `run()` or `run_sync()`.
+## Terminal use
 
-### CLI (`exec/deputy.R`)
-
-deputy ships a [Rapp](https://github.com/r-lib/Rapp) package executable
-that works with [`ir`](https://r-lib.github.io/ir/tools.html). Install
-`ir` once, then run the package directly from GitHub without installing
-deputy globally:
+Deputy also ships a [Rapp](https://github.com/r-lib/Rapp) package
+executable. Run it without a global Deputy installation, or install a
+persistent launcher:
 
 ``` bash
 uv tool install r-lib-ir
 rx --from github::JamesHWade/deputy deputy --help
 rx --from github::JamesHWade/deputy deputy \
   --provider openai "Summarize the R files in this project"
-```
 
-For a persistent `deputy` command, install its launcher:
-
-``` bash
 ir tool install github::JamesHWade/deputy
-deputy --provider openai --model gpt-4o --tools standard
+deputy --provider openai --tools minimal
 ```
 
-If deputy is already installed in an R library, Rapp can install the
-same launcher:
-
-``` r
-Rapp::install_pkg_cli_apps("deputy")
-```
-
-The optional positional task selects non-interactive mode; omit it to
-start an interactive session. Common options include short aliases
-(`-p`, `-m`, `-t`, `-P`, `-n`, `-c`, `-d`, `-v`, etc.) and repeatable
-Rapp 0.4 flags:
-
-``` bash
-deputy --mcp --mcp-server github --mcp-server slack
-deputy --debug --debug-file /tmp/deputy-debug.log
-```
-
-### Sessions and Persistence
-
-Every agent has a stable `session_id` for correlating results and
-events. Pass one at construction when another system owns the
-identifier, or let Deputy generate it:
-
-``` r
-agent <- Agent$new(
-  chat = ellmer::chat("openai"),
-  tools = tools_file(),
-  session_id = "session_research_001"
-)
-
-agent$session_id()
-result <- agent$run_sync("Summarize this package")
-result$session_id
-```
-
-`session_id` is correlation metadata, not a storage key. Persistence is
-an explicit file operation:
-
-``` r
-agent$save_session("research-session.rds")
-
-restored <- Agent$new(
-  chat = ellmer::chat("openai"),
-  tools = tools_file(),
-  permissions = permissions_readonly(),
-  session_id = "session_research_002"
-)
-restored$load_session("research-session.rds")
-```
-
-Loading restores the saved conversation, prompt, run context, and
-enabled file checkpoint state. The receiving agent keeps its own tools,
-permissions, working directory, and `session_id`.
-
-### Tools
-
-deputy provides tool presets for common use cases:
-
-``` r
-# Use presets for quick setup
-tools_preset("minimal")   # read_file, list_files
-tools_preset("standard")  # + write_file, run_r_code
-tools_preset("dev")       # + run_bash (full development)
-tools_preset("data")      # read_file, list_files, read_csv, run_r_code
-tools_preset("full")      # all tools
-
-# Or use individual bundles
-tools_file()  # File operations
-tools_code()  # Code execution
-tools_data()  # Data reading
-tools_all()   # Everything
-
-# Optional: read selected pages from a PDF
-tool_read_file("report.pdf", pages = "1,3-5")
-
-# Optional: convert rich docs to markdown with MarkItDown
-tool_read_markdown("slides.pptx")
-```
-
-PDF page extraction uses `pdftools` when available, with a fallback to
-`reticulate` + Python `pypdf`. `tool_read_markdown()` uses
-`reticulate` + Python `markitdown`.
-
-### Permissions
-
-Control what your agent can do:
-
-``` r
-# Read-only: no writes, no code execution
-agent <- Agent$new(
-  chat = ellmer::chat("openai"),
-  tools = tools_file(),
-  permissions = permissions_readonly()
-)
-
-# Standard: accessible reads, workspace-scoped writes, R code, no bash
-agent <- Agent$new(
-  chat = ellmer::chat("openai"),
-  tools = tools_file(),
-  permissions = permissions_standard()
-)
-
-# Custom permissions
-agent <- Agent$new(
-  chat = ellmer::chat("openai"),
-  tools = tools_all(),
-  permissions = Permissions$new(
-    file_write = getwd(),
-    bash = FALSE,
-    r_code = TRUE
-  )
-)
-
-# Explicit tool policy gates
-agent <- Agent$new(
-  chat = ellmer::chat("openai"),
-  tools = tools_all(),
-  permissions = Permissions$new(
-    tool_allowlist = c("read_file", "list_files", "run_r_code"),
-    tool_denylist = c("run_bash"),
-    permission_prompt_tool_name = "ask_user"
-  )
-)
-
-# Planning mode: read-only tools plus ask_user
-agent <- Agent$new(
-  chat = ellmer::chat("openai"),
-  tools = tools_all(),
-  permissions = permissions_plan()
-)
-```
-
-When both are set, `tool_denylist` takes precedence over
-`tool_allowlist`. `permission_prompt_tool_name` identifies the tool that
-can request explicit human approval. `permissions_plan()` allows
-read-only annotated tools and `ask_user`.
-
-### Run Limits and File Rewind
-
-Limits are scoped to one run, so loading a saved conversation does not
-inherit usage from earlier runs:
-
-``` r
-agent <- Agent$new(
-  chat = ellmer::chat("openai"),
-  tools = tools_file(),
-  usage_limits = UsageLimits(
-    max_requests = 12,
-    max_tool_calls = 20,
-    max_total_tokens = 50000,
-    max_cost_usd = 1
-  )
-)
-
-result <- agent$run_sync("Inspect this package")
-result$run_id
-result$usage
-result$tool_calls()
-result$tool_results()
-```
-
-Request and tool-call limits are checked at model and tool boundaries.
-Token and cost limits use usage reported after a model response, so a
-run stops once an overage is observed and can exceed the configured
-threshold by one response.
-
-Enable reversible file journals when an agent may edit its workspace:
-
-``` r
-agent <- Agent$new(
-  chat = ellmer::chat("anthropic"),
-  tools = tools_file(),
-  enable_file_checkpointing = TRUE,
-  working_dir = getwd()
-)
-
-checkpoint_id <- agent$checkpoint("before refactor")
-agent$run_sync("Refactor R/parser.R")
-agent$rewind_files(checkpoint_id)
-```
-
-Deputy automatically creates a checkpoint at the beginning of each run
-and includes the journal when `save_session()` is called. Captures
-default to 50 MiB per file. The default maximum aggregate serialized
-checkpoint-state size is 250 MiB, counting journal records, checkpoint
-markers, metadata, and pending captures. The bounds apply to live
-captures and restored session state; violations signal
-`deputy_file_checkpoint_limit_error`. Lead agents and their delegated
-agents share one workspace journal, so child-agent edits participate in
-lead-level rewind. Rewind covers writes through Deputy’s write, edit,
-and multi-edit tools; it does not capture writes performed by Bash, R
-code, or arbitrary custom tools.
-
-### Hooks
-
-Intercept agent behavior:
-
-``` r
-# Log all tool calls
-agent$add_hook(HookMatcher$new(
-  event = "PostToolUse",
-  callback = function(tool_name, tool_result, tool_error, context) {
-    message("[", Sys.time(), "] ", tool_name)
-    HookResultPostToolUse()
-  }
-))
-
-# Block dangerous bash commands
-agent$add_hook(HookMatcher$new(
-  event = "PreToolUse",
-  pattern = "^run_bash$",
-  callback = function(tool_name, tool_input, context) {
-    if (grepl("rm -rf|sudo", tool_input$command)) {
-      HookResultPreToolUse(permission = "deny", reason = "Dangerous command")
-    } else {
-      HookResultPreToolUse(permission = "allow")
-    }
-  }
-))
-
-# Replace emitted tool output without changing the model-visible result
-agent$add_hook(HookMatcher$new(
-  event = "PostToolUse",
-  pattern = "^read_file$",
-  callback = function(tool_name, tool_result, tool_error, context) {
-    HookResultPostToolUse(updated_tool_output = "File read completed")
-  }
-))
-```
-
-### Skills
-
-Skills bundle tools and prompt extensions. You can load them from disk
-or create them programmatically. deputy ships with a built-in example
-skill under `inst/skills`.
-
-``` r
-# Discover bundled skills
-skills_dir <- system.file("skills", package = "deputy")
-skills_list(skills_dir)
-
-# Load a skill by path
-agent$load_skill(file.path(skills_dir, "data_analysis"))
-
-# Inspect loaded skills
-agent$skills()
-
-# Create and load a skill programmatically
-custom <- skill_create(
-  name = "my_skill",
-  description = "Custom helpers",
-  prompt = "You are a focused assistant for project-specific tasks."
-)
-agent$load_skill(custom)
-```
-
-### Structured Output
-
-Request JSON output that matches a schema:
-
-``` r
-schema <- list(
-  type = "object",
-  properties = list(status = list(type = "string")),
-  required = list("status")
-)
-
-result <- agent$run_sync(
-  "Respond with status = ok",
-  output_format = list(type = "json_schema", schema = schema)
-)
-
-result$structured_output
-```
-
-### Error Handling
-
-deputy provides structured error types for programmatic error handling:
-
-``` r
-# Detect Deputy errors while preserving their structured classes
-tryCatch(
-  agent$run_sync(
-    "task",
-    usage_limits = UsageLimits(max_requests = 2, on_exceed = "error")
-  ),
-  deputy_error = function(e) {
-    stopifnot(is_deputy_error(e))
-    message(conditionMessage(e))
-  }
-)
-```
-
-### Multi-Agent Systems
-
-Coordinate specialized agents:
-
-``` r
-# Define sub-agents
-code_agent <- agent_definition(
-  name = "code_analyst",
-  description = "Analyzes R code",
-  prompt = "You are an expert R programmer.",
-  tools = tools_file()
-)
-
-# Create lead agent that can delegate
-lead <- LeadAgent$new(
-  chat = ellmer::chat("openai"),
-  sub_agents = list(code_agent)
-)
-
-result <- lead$run_sync("Review the R code in this project")
-```
-
-Direct synchronous child usage is aggregated into `result$usage`. Each
-child inherits the lead run’s remaining limits, and the lead enforces
-them after delegation. Parallel, background, transitive child-tree, and
-cross-run global usage accounting remain future work.
-
-## Provider Support
-
-deputy works with any LLM provider that ellmer supports:
-
-``` r
-# OpenAI
-Agent$new(chat = ellmer::chat("openai"))
-
-# Anthropic
-Agent$new(chat = ellmer::chat("anthropic"))
-
-# Google
-Agent$new(chat = ellmer::chat("google_gemini"))
-
-# Local via Ollama
-Agent$new(chat = ellmer::chat("ollama/llama3.2"))
-```
-
-## Learn More
-
-- `vignette("getting-started")` - Comprehensive introduction
-- `vignette("permissions")` - Permission modes and custom policies
-- `vignette("hooks")` - Tool lifecycle hooks
-- `vignette("multi-agent")` - Delegation with `LeadAgent`
-- [ellmer documentation](https://ellmer.tidyverse.org/) - Underlying LLM
-  framework
+## Status
+
+Deputy is experimental. Its contracts are being sharpened through real
+package, CLI, and Shiny integrations. Please report problems and design
+gaps in [GitHub Issues](https://github.com/JamesHWade/deputy/issues).
 
 ## License
 
-MIT
+MIT © James Wade

--- a/_pkgdown.yml
+++ b/_pkgdown.yml
@@ -12,9 +12,11 @@ navbar:
     articles:
       text: Articles
       menu:
+      - text: "Intro"
       - text: Getting Started
         href: articles/getting-started.html
       - text: "---"
+      - text: "Concepts"
       - text: Tools and Tool Bundles
         href: articles/tools.html
       - text: Permissions and Safety
@@ -22,20 +24,23 @@ navbar:
       - text: Hooks
         href: articles/hooks.html
       - text: "---"
+      - text: "Hosts"
+      - text: Shiny Chat
+        href: articles/example-shiny-chat.html
+      - text: "---"
+      - text: "Advanced"
       - text: Multi-Agent Orchestration
         href: articles/multi-agent.html
       - text: Structured Output
         href: articles/structured-output.html
       - text: "---"
-      - text: "Examples"
+      - text: "Recipes"
       - text: Data Analysis Agent
         href: articles/example-data-analysis.html
       - text: Extraction Pipeline
         href: articles/example-extraction-pipeline.html
       - text: Code Review (Multi-Agent)
         href: articles/example-code-review.html
-      - text: Shiny Chat
-        href: articles/example-shiny-chat.html
 
 reference:
 - title: Agent
@@ -122,22 +127,24 @@ reference:
   - is_deputy_error
 
 articles:
-- title: Getting Started
+- title: Intro
   navbar: ~
   contents:
   - getting-started
-- title: Core Concepts
+- title: Concepts
   contents:
   - tools
   - permissions
   - hooks
+- title: Hosts
+  contents:
+  - example-shiny-chat
 - title: Advanced
   contents:
   - multi-agent
   - structured-output
-- title: Examples
+- title: Recipes
   contents:
   - example-data-analysis
   - example-extraction-pipeline
   - example-code-review
-  - example-shiny-chat

--- a/tests/testthat/test-documentation-contracts.R
+++ b/tests/testthat/test-documentation-contracts.R
@@ -1,0 +1,24 @@
+test_that("first-success documentation policies stay executable", {
+  workspace <- normalizePath(getwd(), winslash = "/")
+  first_tools <- tools_preset("minimal")
+  first_permissions <- permissions_readonly()
+  first_limits <- UsageLimits(max_requests = 6, max_tool_calls = 8)
+
+  expect_length(first_tools, 3L)
+  expect_identical(first_permissions$mode, "readonly")
+  expect_identical(first_limits$max_requests, 6L)
+
+  write_permissions <- Permissions$new(
+    mode = "standard",
+    file_read = TRUE,
+    file_write = workspace,
+    bash = FALSE,
+    r_code = FALSE,
+    web = FALSE,
+    install_packages = FALSE
+  )
+
+  expect_identical(write_permissions$file_write, workspace)
+  expect_identical(write_permissions$r_code, FALSE)
+  expect_identical(write_permissions$bash, FALSE)
+})

--- a/vignettes/getting-started.Rmd
+++ b/vignettes/getting-started.Rmd
@@ -1,8 +1,8 @@
 ---
-title: "Getting Started with deputy"
+title: "Getting Started with Deputy"
 output: rmarkdown::html_vignette
 vignette: >
-  %\VignetteIndexEntry{Getting Started with deputy}
+  %\VignetteIndexEntry{Getting Started with Deputy}
   %\VignetteEngine{knitr::rmarkdown}
   %\VignetteEncoding{UTF-8}
 ---
@@ -10,390 +10,219 @@ vignette: >
 ```{r, include = FALSE}
 knitr::opts_chunk$set(
   collapse = TRUE,
-  comment = "#>",
-  eval = FALSE
+  comment = "#>"
 )
 ```
 
-deputy is an agentic AI framework for R that builds on
-[ellmer](https://ellmer.tidyverse.org/). It enables you to create AI agents
-that use tools to accomplish multi-step tasks, with built-in support for
-permissions, hooks, and streaming output. The core `Agent` and `LeadAgent`
-APIs are provider-agnostic.
+Deputy turns an ellmer chat into a governed R Agent. In this guide you will
+create a bounded, read-only Agent; inspect its result; then deliberately grant
+one workspace-scoped write capability and protect it with a checkpoint.
 
-## Installation
+## Before you begin
 
-```{r, eval = FALSE}
-# Install from GitHub
-pak::pak("JamesHWade/deputy")
+Install Deputy and the development version of ellmer:
+
+```r
+# install.packages("pak")
+pak::pak(c("tidyverse/ellmer", "JamesHWade/deputy"))
 ```
 
-## Quick Start
+You also need credentials for one
+[ellmer provider](https://ellmer.tidyverse.org/reference/index.html). The
+examples use OpenAI, but the Deputy API is provider-independent.
 
-An agent wraps an ellmer chat object and gives it tools, permissions, and
-lifecycle hooks:
+## 1. Define the workspace and limits
 
-```{r getting-started-quickstart}
+Make the authority for the first run visible before creating a chat. The
+`minimal` preset contains only `read_file`, `read_markdown`, and `list_files`.
+The permission policy denies writes, code execution, shell commands, web
+requests, and package installation. The run also has finite request and
+tool-call budgets.
+
+```{r first-policy}
 library(deputy)
 
-chat <- ellmer::chat_anthropic(model = "claude-sonnet-4-20250514")
-agent <- Agent$new(chat = chat, tools = tools_file())
+workspace <- normalizePath(getwd(), winslash = "/")
+first_tools <- tools_preset("minimal")
+first_permissions <- permissions_readonly()
+first_limits <- UsageLimits(max_requests = 6, max_tool_calls = 8)
 
-result <- agent$run_sync("List the files in the current directory")
-cat(result$response)
-```
-
-The agent sends your task to the LLM, which may call tools, and loops until
-the task is complete. `run_sync()` blocks until done and returns an
-`AgentResult`.
-
-## Tool Bundles
-
-deputy organises built-in tools into bundles you can mix and match:
-
-| Bundle | Tools | Purpose |
-|--------|-------|---------|
-| `tools_file()` | `read_file`, `read_markdown`, `write_file`, `list_files` | File operations |
-| `tools_code()` | `run_r_code`, `run_bash` | Code execution |
-| `tools_data()` | `read_csv`, `read_file`, `read_markdown` | Data reading |
-| `tools_web()` | `web_fetch`, `web_search` | Web access |
-| `tools_all()` | All of the above | Everything |
-
-```{r, eval = FALSE}
-# Combine bundles
-agent <- Agent$new(
-  chat = ellmer::chat_anthropic(),
-  tools = c(tools_file(), tools_code())
+stopifnot(
+  dir.exists(workspace),
+  length(first_tools) == 3L,
+  identical(first_permissions$mode, "readonly"),
+  identical(first_limits$max_tool_calls, 8L)
 )
 ```
 
-There are also named presets available via `tools_preset()`:
+Run this from the package you want to inspect, or replace `getwd()` with that
+package's absolute path.
 
-```{r, eval = FALSE}
-tools_preset("dev")
+`working_dir` gives relative paths a stable base. It does not create a read
+sandbox: a read permission can reach files that the R process can reach. Keep
+the task narrow and run Deputy with operating-system isolation when the input
+or generated code is untrusted.
+
+## 2. Create the Agent
+
+An `Agent` combines an ellmer chat with the runtime policy you just defined.
+This chunk makes a provider request, so it is displayed but not run while the
+vignette is built.
+
+```{r first-agent, eval = FALSE}
+chat <- ellmer::chat("openai")
+
+agent <- Agent$new(
+  chat = chat,
+  tools = first_tools,
+  permissions = first_permissions,
+  usage_limits = first_limits,
+  working_dir = workspace,
+  agent_name = "package-scout"
+)
 ```
 
-See `vignette("tools")` for custom tools, web tools, MCP integration, and
-human-in-the-loop.
+The chat owns provider interaction. Deputy owns the tool loop around it:
+permissions, hooks, limits, events, persistence, checkpoints, and delegation.
 
-## Streaming
+## 3. Run one useful task
 
-For real-time feedback, use `run()` which returns a generator:
+Ask for an answer that the available tools can support. A read-only package
+inspection is a better first task than an open-ended request to “improve the
+code.”
 
-```{r getting-started-streaming, eval = FALSE}
-chat <- ellmer::chat_anthropic(model = "claude-sonnet-4-20250514")
-agent <- Agent$new(chat = chat, tools = tools_file())
-
-events <- agent$run("What is the name of this package?")
-repeat {
-  event <- events()
-  if (coro::is_exhausted(event)) {
-    break
-  }
-  switch(event$type,
-    "text" = cat(event$text),
-    "tool_start" = cli::cli_alert_info("Calling {event$tool_name}..."),
-    "tool_end" = cli::cli_alert_success("Done"),
-    "stop" = cli::cli_alert("Finished!")
+```{r first-run, eval = FALSE}
+result <- agent$run_sync(
+  paste(
+    "Read DESCRIPTION and list the R/ directory.",
+    "Explain the package purpose and identify three good entry-point files.",
+    "Cite the paths you used. Do not propose or make edits."
   )
-}
-```
-
-Events stream as they happen -- you see text tokens arrive, tool calls start
-and finish, and a final stop event.
-
-## Permissions
-
-### Read-Only Permissions
-
-```{r}
-# Only allows reading files - no writes, no code execution
-agent <- Agent$new(
-  chat = ellmer::chat("openai"),
-  tools = tools_file(),
-  permissions = permissions_readonly()
 )
 ```
 
-### Full Permissions
+`run_sync()` blocks until the run stops and returns an `AgentResult`. The result
+keeps the outcome and the evidence needed to understand how it happened:
 
-```{r}
-# Allows everything - use with caution!
-agent <- Agent$new(
-  chat = ellmer::chat("openai"),
-  tools = tools_all(),
-  permissions = permissions_full()
-)
-
-# Planning mode: read-only tools plus ask_user
-agent <- Agent$new(
-  chat = ellmer::chat("openai"),
-  tools = tools_all(),
-  permissions = permissions_plan()
-)
-```
-
-### Custom Permissions
-
-For fine-grained control:
-
-```{r}
-perms <- Permissions$new(
-  file_read = TRUE,
-  file_write = "/path/to/allowed/dir", # Restrict to specific directory
-
-  bash = FALSE,
-  r_code = TRUE,
-  web = FALSE
-)
-
-agent <- Agent$new(
-  chat = ellmer::chat("openai"),
-  permissions = perms
-)
-```
-
-### Custom Permission Callbacks
-
-For complex permission logic:
-
-```{r}
-perms <- Permissions$new(
-  can_use_tool = function(tool_name, tool_input, context) {
-    # Block any file writes to sensitive directories
-    if (tool_name == "write_file") {
-      if (grepl("^\\.env|secrets|credentials", tool_input$path)) {
-        return(PermissionResultDeny(
-          reason = "Cannot write to sensitive files"
-        ))
-      }
-    }
-    PermissionResultAllow()
-  }
-)
-```
-
-### Tool Allow/Deny Lists
-
-Use allow/deny lists when you want an explicit tool policy that is separate from
-the broader mode flags:
-
-```{r}
-perms <- Permissions$new(
-  mode = "standard",
-  tool_allowlist = c("read_file", "list_files", "run_r_code"),
-  tool_denylist = c("run_bash"),
-  permission_prompt_tool_name = "ask_user"
-)
-
-agent <- Agent$new(
-  chat = ellmer::chat("openai"),
-  tools = tools_all(),
-  permissions = perms
-)
-```
-
-If both lists are present, `tool_denylist` wins. The
-`permission_prompt_tool_name` tool can request explicit human approval and
-appears in deny reasons when prompting is enabled.
-
-## Hooks
-
-Hooks let you intercept and customize agent behavior at key points:
-
-### Available Hook Events
-
-| Event | When it Fires | Can Modify |
-|-------|---------------|------------|
-| `PreToolUse` | Before a tool executes | Allow/deny, input |
-| `PostToolUse` | After a tool executes | Continue flag |
-| `Stop` | When agent stops | - |
-| `UserPromptSubmit` | When user sends a message | - |
-| `PreCompact` | Before conversation compaction | Summary |
-
-### Example: Logging All Tool Calls
-
-```{r}
-agent$add_hook(HookMatcher$new(
-  event = "PostToolUse",
-  callback = function(tool_name, tool_result, tool_error, context) {
-    cli::cli_alert_info("Tool {tool_name} completed")
-    HookResultPostToolUse()
-  }
-))
-```
-
-### Example: Block Dangerous Commands
-
-```{r}
-agent$add_hook(HookMatcher$new(
-  event = "PreToolUse",
-  pattern = "^run_bash$", # Only match bash tool
-  callback = function(tool_name, tool_input, context) {
-    if (grepl("rm -rf|sudo|chmod 777", tool_input$command)) {
-      HookResultPreToolUse(
-        permission = "deny",
-        reason = "Dangerous command pattern detected"
-      )
-    } else {
-      HookResultPreToolUse(permission = "allow")
-    }
-  }
-))
-```
-
-## Session Management
-
-Every `Agent` has a stable `session_id` used to correlate its events and
-results. Deputy generates one unless you provide it at construction:
-
-```{r}
-agent <- Agent$new(
-  chat = ellmer::chat("openai"),
-  tools = tools_file(),
-  session_id = "session_analysis_001"
-)
-
-agent$session_id()
-result <- agent$run_sync("Summarize this package")
-result$session_id
-```
-
-The identifier does not save or locate state. Save and load are explicit,
-path-based operations:
-
-```{r}
-agent$save_session("analysis-session.rds")
-
-restored <- Agent$new(
-  chat = ellmer::chat("openai"),
-  tools = tools_file(),
-  permissions = permissions_readonly(),
-  session_id = "session_analysis_002"
-)
-restored$load_session("analysis-session.rds")
-
-# Continue the conversation
-result <- restored$run_sync("Continue where we left off...")
-```
-
-`Agent$load_session()` restores the conversation, prompt, run context, and
-enabled file checkpoint state. Tools, permissions, hooks, the working
-directory, and the receiving agent's `session_id` remain authoritative.
-
-## Multi-Agent Systems
-
-For complex tasks, you can create a lead agent that delegates to specialized sub-agents:
-
-```{r}
-# Define specialized sub-agents
-code_agent <- agent_definition(
-  name = "code_analyst",
-  description = "Analyzes R code and suggests improvements",
-  prompt = "You are an expert R programmer. Analyze code for best practices.",
-  tools = tools_file()
-)
-
-data_agent <- agent_definition(
-  name = "data_analyst",
-  description = "Analyzes data files and provides statistical summaries",
-  prompt = "You are a data analyst. Provide clear statistical insights.",
-  tools = tools_data()
-)
-
-# Create a lead agent that can delegate
-lead <- LeadAgent$new(
-  chat = ellmer::chat("openai"),
-  sub_agents = list(code_agent, data_agent),
-  system_prompt = "You coordinate between specialized agents to complete tasks."
-)
-
-# The lead agent will automatically delegate to sub-agents as needed
-result <- lead$run_sync(
-  "Review the R code in src/ and analyze the data in data/"
-)
-```
-
-## Working with Results
-
-The `AgentResult` object contains useful information:
-
-```{r}
-result <- agent$run_sync("Analyze this project")
-
-# The final response
+```{r inspect-result, eval = FALSE}
 cat(result$response)
 
-# Cost information
-result$cost
-#> $input
-#> [1] 1250
-#> $output
-#> [1] 450
-#> $total
-#> [1] 0.0045
-
-# Execution duration
-result$duration
-#> [1] 3.45  # seconds
-
-# Stop reason
 result$stop_reason
-#> [1] "complete"
-
-# Stable session correlation
+result$usage
 result$session_id
-
-# All events (for detailed analysis)
-length(result$events)
-#> [1] 12
+result$run_id
+result$tool_calls()
+result$tool_results()
 ```
 
-## Provider Support
+Check `stop_reason` before treating the response as complete. A request,
+tool-call, token, or cost limit produces a typed stop reason rather than a
+silently truncated success.
 
-deputy works with any LLM provider that ellmer supports:
+## 4. Grant writes deliberately
 
-```{r}
-# OpenAI
-agent <- Agent$new(chat = ellmer::chat("openai"))
+When a task really needs to create a file, replace the read-only policy with an
+explicit one. This policy permits Deputy's native file tools to write only
+inside the canonical workspace. R execution, shell access, web access, and
+package installation remain off.
 
-# Anthropic
-agent <- Agent$new(chat = ellmer::chat("anthropic/claude-sonnet-4-5-20250929"))
+```{r write-policy}
+write_permissions <- Permissions$new(
+  mode = "standard",
+  file_read = TRUE,
+  file_write = workspace,
+  bash = FALSE,
+  r_code = FALSE,
+  web = FALSE,
+  install_packages = FALSE
+)
 
-# Google
-agent <- Agent$new(chat = ellmer::chat("google/gemini-1.5-pro"))
-
-# Local models via Ollama
-agent <- Agent$new(chat = ellmer::chat("ollama/llama3.1"))
-```
-
-## Best Practices
-
-1. **Start with minimal permissions** - Use `permissions_readonly()` or
-   `permissions_standard()` and only expand as needed.
-
-2. **Use hooks for logging** - Add a `PostToolUse` hook to track what your agent does.
-3. **Set run limits** - Use `UsageLimits()` to bound model requests, tool
-   calls, tokens, or estimated cost.
-
-4. **Save sessions** - For long-running tasks, save sessions periodically.
-
-5. **Use streaming for UX** - The `run()` method provides real-time feedback.
-
-```{r}
-# Example combining best practices
-agent <- Agent$new(
-  chat = ellmer::chat("openai"),
-  tools = tools_file(),
-  permissions = permissions_standard(),
-  usage_limits = UsageLimits(max_requests = 20, max_cost_usd = 1)
+stopifnot(
+  identical(write_permissions$file_write, workspace),
+  identical(write_permissions$r_code, FALSE),
+  identical(write_permissions$bash, FALSE)
 )
 ```
 
-## Next Steps
+Create a separate Agent with file checkpointing enabled. The checkpoint marks
+the state before the task. Deputy records preimages when its native write,
+edit, and multi-edit tools change files.
 
-- `vignette("tools")` -- Custom tools, web tools, MCP, and human-in-the-loop
-- `vignette("permissions")` -- Permission presets, modes, and custom policies
-- `vignette("hooks")` -- Lifecycle hooks for logging, blocking, and auditing
-- `vignette("multi-agent")` -- Multi-agent delegation with LeadAgent
-- `vignette("structured-output")` -- JSON schema output and validation
+```{r write-agent, eval = FALSE}
+write_agent <- Agent$new(
+  chat = chat$clone()$set_turns(list()),
+  tools = tools_file(),
+  permissions = write_permissions,
+  usage_limits = first_limits,
+  enable_file_checkpointing = TRUE,
+  working_dir = workspace,
+  agent_name = "summary-writer"
+)
+
+checkpoint_id <- write_agent$checkpoint("before package summary")
+
+write_result <- write_agent$run_sync(
+  paste(
+    "Read DESCRIPTION and write a concise package summary to deputy-summary.md.",
+    "Do not modify any other file."
+  )
+)
+```
+
+Review the result and the actual diff. If the native file-tool changes are not
+useful, rewind them:
+
+```{r rewind, eval = FALSE}
+write_result$stop_reason
+write_agent$list_checkpoints()
+write_agent$rewind_files(checkpoint_id)
+```
+
+Checkpoints do not capture changes made outside Deputy's native file tools, and
+they do not replace Git or backups.
+
+## Common failures
+
+### The provider cannot authenticate
+
+Configure the credential expected by your chosen ellmer provider, then verify a
+plain ellmer chat before adding Deputy. Deputy does not manage provider keys.
+
+### A tool call is denied
+
+Treat the denial as useful policy feedback. Check that the tool belongs in this
+task, that it is registered, and that the relevant capability is explicit. Do
+not switch to `permissions_full()` merely to make the error disappear.
+
+### The run stops at a limit
+
+Inspect `result$stop_reason` and `result$usage`. Tighten the task first; increase
+only the specific limit whose additional work is justified.
+
+### Code execution sounds safer than it is
+
+`run_r_code` starts a separate R process, but process separation is not an OS
+sandbox. `run_bash` runs with the current user's privileges. Use containers,
+virtual machines, or another real isolation boundary for untrusted code.
+
+### A Shiny task reads the wrong directory
+
+Shiny process working directories can differ from the app directory. Pass an
+existing absolute `working_dir` and construct any directory-valued write grant
+from that same path.
+
+## Where next?
+
+| If you want to... | Continue with... |
+|---|---|
+| Choose or build tools | `vignette("tools", package = "deputy")` |
+| Design permission policy | `vignette("permissions", package = "deputy")` |
+| Observe and intervene in runs | `vignette("hooks", package = "deputy")` |
+| Stream an Agent into an app | `vignette("example-shiny-chat", package = "deputy")` |
+| Delegate to specialist Agents | `vignette("multi-agent", package = "deputy")` |
+| Require typed model output | `vignette("structured-output", package = "deputy")` |
+| Build a concrete workflow | `vignette("example-data-analysis", package = "deputy")` |
+
+The durable pattern is the same in every host: make the workspace, tools,
+permissions, and limits explicit; run one bounded job; then inspect the typed
+result before granting more authority.


### PR DESCRIPTION
Closes #78

## Summary

- make the README a concise product front door with a clear Deputy-versus-ellmer explanation
- lead with a bounded read-only Agent and state the real execution safety boundary
- turn Getting Started into a progressive read, inspect, grant-write, checkpoint journey
- reorganize pkgdown articles into Intro, Concepts, Hosts, Advanced, and Recipes
- execute the documented permission and limit policies in the test suite

## Verification

- `air format R/ tests/testthat/`
- documentation contract test: 6 passed
- full test suite: 2,078 passed, 6 skipped, 2 known filesystem warnings
- `jarl check R/`: 7 pre-existing findings, no new findings
- `devtools::check()`: 0 errors, 0 warnings, 1 system-clock note
- `pkgdown::check_pkgdown()`: no problems
- `pkgdown::build_site(preview = FALSE)`: passed
- `git diff --check`
