### PR TITLE
Fix Agent routing and human-input isolation

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -258,6 +258,21 @@ Permissions configured at construction are an immutable authority ceiling.
 `Agent$set_permission_mode()` may keep or narrow a policy but cannot widen it;
 delegated agents are bounded by the same rule and by their lead's restrictions.
 
+### AgentDefinition Routing
+
+`agent_definition()` canonicalizes names to lowercase routing keys. A
+`LeadAgent` keeps definitions in a private, uniquely keyed registry;
+`sub_agent_defs` is a read-only snapshot, and new definitions must go through
+`register_sub_agent()` so the registry and lead prompt stay synchronized.
+
+### Human Input
+
+Concurrent and hosted Agents bind their own handler with
+`tools_interactive(callback, context)`. The context carries stable routing
+values and may be resolved lazily. `set_ask_user_callback()` is only a legacy
+process-wide fallback for single-Agent scripts; do not use it for Shiny or
+other concurrent hosts.
+
 ### Tool Presets
 
 - `tools_preset("minimal")` - read_file, list_files

--- a/NEWS.md
+++ b/NEWS.md
@@ -45,6 +45,11 @@
   changes may only narrow authority. Delegated agents use the same rule and
   retain lead capability, tool-gate, callback, and write-root restrictions.
 
+* `agent_definition()` now validates and canonicalizes AgentDefinition routing
+  keys and fields. `LeadAgent` rejects duplicate names and keeps its registry
+  private behind a read-only snapshot, so delegation, displayed definitions,
+  and the lead prompt cannot diverge (#79).
+
 * `Agent` now rejects a provider tool request whose name is missing,
   unreadable, or malformed before it reaches usage accounting, permissions,
   hooks, or execution (#26).
@@ -74,6 +79,11 @@
 * `tool_run_r_code()` now rejects timed-out or failed `callr` subprocesses with
   readable tool errors instead of failing later while formatting an unbound
   result (#27).
+
+* `tools_interactive()` now creates an `ask_user` tool with an instance-scoped
+  human-input handler and routing context, allowing concurrent Agents to remain
+  isolated. Missing handlers signal `deputy_human_input_unavailable`;
+  `set_ask_user_callback()` remains a legacy process-wide fallback (#76).
 
 # deputy 0.0.0.9000
 

--- a/R/agents-multi.R
+++ b/R/agents-multi.R
@@ -1,5 +1,97 @@
 # Multi-agent orchestration for deputy
 
+normalize_agent_definition_name <- function(name, arg = "name") {
+  if (!is_nonempty_string(name)) {
+    cli_abort("{.arg {arg}} must be one non-empty string")
+  }
+
+  name <- tolower(trimws(name))
+  if (!grepl("^[a-z][a-z0-9_-]*$", name)) {
+    cli_abort(c(
+      "{.arg {arg}} must be a valid AgentDefinition routing key",
+      "i" = paste(
+        "Use a letter first, followed only by lowercase letters, numbers,",
+        "underscores, or hyphens."
+      )
+    ))
+  }
+
+  name
+}
+
+validate_agent_definition_text <- function(value, arg, optional = FALSE) {
+  if (is.null(value) && optional) {
+    return(NULL)
+  }
+  if (!is_nonempty_string(value)) {
+    cli_abort("{.arg {arg}} must be one non-empty string")
+  }
+  value
+}
+
+validate_agent_definition_character <- function(
+  value,
+  arg,
+  optional = TRUE,
+  normalize = FALSE
+) {
+  if (is.null(value) && optional) {
+    return(NULL)
+  }
+  if (
+    !is.character(value) ||
+      anyNA(value) ||
+      !all(nzchar(trimws(value)))
+  ) {
+    cli_abort("{.arg {arg}} must be a character vector of non-empty strings")
+  }
+
+  value <- trimws(value)
+  if (normalize) {
+    value <- tolower(value)
+  }
+  unique(value)
+}
+
+copy_agent_definition <- function(definition, arg = "definition") {
+  if (!inherits(definition, "AgentDefinition")) {
+    cli_abort("{.arg {arg}} must be an AgentDefinition object")
+  }
+
+  fields <- setdiff(names(formals(agent_definition)), "...")
+  do.call(agent_definition, unclass(definition)[fields])
+}
+
+normalize_agent_definitions <- function(definitions, arg = "sub_agents") {
+  if (!is.list(definitions)) {
+    cli_abort("{.arg {arg}} must be a list of AgentDefinition objects")
+  }
+
+  definitions <- lapply(
+    seq_along(definitions),
+    function(index) {
+      copy_agent_definition(
+        definitions[[index]],
+        arg = paste0(arg, "[[", index, "]]")
+      )
+    }
+  )
+  keys <- vapply(
+    definitions,
+    function(definition) definition$name,
+    character(1)
+  )
+  duplicate_keys <- unique(keys[duplicated(keys)])
+  if (length(duplicate_keys) > 0) {
+    cli_abort(c(
+      "Duplicate AgentDefinition routing keys are not allowed",
+      "x" = "Duplicated: {.val {duplicate_keys}}"
+    ))
+  }
+
+  stats::setNames(definitions, keys)
+}
+
 #' Create an Agent Definition
 #'
 #' @description
@@ -7,7 +99,9 @@
 #' agent to delegate tasks. It bundles together a system prompt, tools, and
 #' metadata about what the agent can do.
 #'
-#' @param name Unique name for this agent type
+#' @param name Unique routing key for this Agent type. Names are trimmed,
+#'   converted to lowercase, and must start with a letter followed only by
+#'   letters, numbers, underscores, or hyphens.
 #' @param description Brief description of what this agent does (shown to lead agent)
 #' @param prompt System prompt for this agent
 #' @param tools Optional list of tools for this agent
@@ -55,6 +149,31 @@ agent_definition <- function(
   max_requests = NULL,
   permission_mode = NULL
 ) {
+  name <- normalize_agent_definition_name(name)
+  description <- validate_agent_definition_text(description, "description")
+  prompt <- validate_agent_definition_text(prompt, "prompt")
+  model <- validate_agent_definition_text(model, "model")
+  if (!is.list(tools)) {
+    cli_abort("{.arg tools} must be a list")
+  }
+  if (!is.list(skills)) {
+    cli_abort("{.arg skills} must be a list")
+  }
+  disallowed_tools <- validate_agent_definition_character(
+    disallowed_tools,
+    "disallowed_tools",
+    normalize = TRUE
+  )
+  memory <- validate_agent_definition_character(memory, "memory")
+  mcp_servers <- validate_agent_definition_character(
+    mcp_servers,
+    "mcp_servers"
+  )
+  initial_prompt <- validate_agent_definition_text(
+    initial_prompt,
+    "initial_prompt",
+    optional = TRUE
+  )
   if (!is.null(permission_mode)) {
     permission_mode <- validate_permission_mode_value(
       permission_mode,
@@ -114,9 +233,6 @@ LeadAgent <- R6::R6Class(
   inherit = Agent,
 
   public = list(
-    #' @field sub_agent_defs List of AgentDefinition objects
-    sub_agent_defs = NULL,
-
     #' @description
     #' Create a new LeadAgent.
     #'
@@ -158,17 +274,13 @@ LeadAgent <- R6::R6Class(
       agent_id = NULL,
       agent_name = NULL
     ) {
-      # Validate sub-agent definitions
-      for (def in sub_agents) {
-        if (!inherits(def, "AgentDefinition")) {
-          cli_abort("All sub_agents must be AgentDefinition objects")
-        }
-      }
-
-      self$sub_agent_defs <- sub_agents
+      private$.sub_agent_defs <- normalize_agent_definitions(sub_agents)
 
       # Build enhanced system prompt
-      enhanced_prompt <- private$build_lead_prompt(system_prompt, sub_agents)
+      enhanced_prompt <- private$build_lead_prompt(
+        system_prompt,
+        private$.sub_agent_defs
+      )
 
       # Create the delegate tool
       delegate_tool <- private$create_delegate_tool()
@@ -204,13 +316,22 @@ LeadAgent <- R6::R6Class(
         cli_abort("{.arg definition} must be an AgentDefinition object")
       }
 
-      self$sub_agent_defs <- c(self$sub_agent_defs, list(definition))
+      definition <- copy_agent_definition(definition)
+      if (definition$name %in% names(private$.sub_agent_defs)) {
+        cli_abort(
+          "AgentDefinition {.val {definition$name}} is already registered"
+        )
+      }
+      private$.sub_agent_defs[[definition$name]] <- definition
 
       # Rebuild and update system prompt to include new sub-agent
       # Extract base prompt (before sub-agent section) if possible
       current_prompt <- self$chat$get_system_prompt()
       base_prompt <- private$extract_base_prompt(current_prompt)
-      new_prompt <- private$build_lead_prompt(base_prompt, self$sub_agent_defs)
+      new_prompt <- private$build_lead_prompt(
+        base_prompt,
+        private$.sub_agent_defs
+      )
       self$chat$set_system_prompt(new_prompt)
 
       cli_alert_info("Registered sub-agent: {.val {definition$name}}")
@@ -222,7 +343,11 @@ LeadAgent <- R6::R6Class(
     #'
     #' @return Character vector of sub-agent names
     available_sub_agents = function() {
-      sapply(self$sub_agent_defs, function(d) d$name)
+      unname(vapply(
+        private$.sub_agent_defs,
+        function(definition) definition$name,
+        character(1)
+      ))
     },
 
     #' @description
@@ -324,12 +449,22 @@ LeadAgent <- R6::R6Class(
     #' Print the lead agent.
     print = function() {
       super$print()
-      cat("  sub_agents:", length(self$sub_agent_defs), "\n")
-      if (length(self$sub_agent_defs) > 0) {
+      cat("  sub_agents:", length(private$.sub_agent_defs), "\n")
+      if (length(private$.sub_agent_defs) > 0) {
         names <- self$available_sub_agents()
         cat("    ", paste(names, collapse = ", "), "\n")
       }
       invisible(self)
+    }
+  ),
+
+  active = list(
+    #' @field sub_agent_defs Read-only snapshot of registered AgentDefinitions.
+    sub_agent_defs = function(value) {
+      if (!missing(value)) {
+        cli_abort("{.field sub_agent_defs} is read-only")
+      }
+      unname(lapply(private$.sub_agent_defs, copy_agent_definition))
     }
   ),
 
@@ -401,14 +536,12 @@ LeadAgent <- R6::R6Class(
         fun = function(agent_name, task) {
           correlation <- private$claim_delegation()
 
-          # Find the agent definition
-          def <- NULL
-          for (d in lead_agent$sub_agent_defs) {
-            if (d$name == agent_name) {
-              def <- d
-              break
-            }
+          route_key <- if (is_nonempty_string(agent_name)) {
+            tolower(trimws(agent_name))
+          } else {
+            ""
           }
+          def <- private$.sub_agent_defs[[route_key]]
 
           if (is.null(def)) {
             available <- lead_agent$available_sub_agents()
@@ -809,6 +942,7 @@ LeadAgent <- R6::R6Class(
       tools[keep]
     },
 
+    .sub_agent_defs = list(),
     subagent_runs = list()
   )
 )

--- a/R/errors.R
+++ b/R/errors.R
@@ -26,6 +26,8 @@
 #'     - `deputy_session_load` - Failed to load session
 #'     - `deputy_session_save` - Failed to save session
 #'   - **deputy_hook** - Hook execution failures
+#'   - **deputy_human_input_unavailable** - No interactive or bound handler
+#'     is available for an `ask_user` request
 #'
 #' @section Usage:
 #'

--- a/R/tools-interactive.R
+++ b/R/tools-interactive.R
@@ -6,16 +6,46 @@
 # - Each option has: label, description
 # - Returns: answers mapping question text to selected label(s)
 
-# Package-level storage for the user input callback
+# Package-level storage for the legacy user input callback
 .deputy_env <- new.env(parent = emptyenv())
 .deputy_env$ask_user_callback <- NULL
+
+validate_ask_user_callback <- function(callback, arg = "callback") {
+  if (!is.null(callback) && !is.function(callback)) {
+    cli::cli_abort("{.arg {arg}} must be a function or NULL")
+  }
+  callback
+}
+
+validate_ask_user_context <- function(context, arg = "context") {
+  if (is.function(context)) {
+    return(context)
+  }
+  if (!is.list(context)) {
+    cli::cli_abort("{.arg {arg}} must be a named list or a function")
+  }
+  if (
+    length(context) > 0 &&
+      (is.null(names(context)) || !all(nzchar(names(context))))
+  ) {
+    cli::cli_abort("{.arg {arg}} must have non-empty names")
+  }
+  context
+}
+
+resolve_ask_user_context <- function(context) {
+  if (is.function(context)) {
+    context <- context()
+  }
+  validate_ask_user_context(context)
+}
 
 #' Set callback for non-interactive user input
 #'
 #' @description
-#' In non-interactive sessions (scripts, Shiny apps, etc.), set a callback
-#' function that will be called when the agent needs user input via
-#' `ask_user`.
+#' Sets a legacy process-wide callback for non-interactive sessions. This
+#' fallback cannot isolate concurrent Agents or Shiny sessions. New code should
+#' bind a handler to a tool instance with [tools_interactive()].
 #'
 #' @param callback A function that takes `questions` in Deputy's structured
 #'   question format. Each question has `question`, `header`,
@@ -28,13 +58,12 @@
 #'
 #' @examples
 #' \dontrun{
-#' # For a Shiny app:
+#' # Legacy fallback for a single-Agent script:
 #' set_ask_user_callback(function(questions) {
 #'   # Display questions in modal and collect answers
 #'   answers <- list()
 #'   for (q in questions) {
-#'     # Show q$question with q$options
-#'     # Collect user selection
+#'     # Collect one answer for each question.
 #'     answers[[q$question]] <- selected_label
 #'   }
 #'   answers
@@ -43,9 +72,7 @@
 #'
 #' @export
 set_ask_user_callback <- function(callback) {
-  if (!is.null(callback) && !is.function(callback)) {
-    cli::cli_abort("{.arg callback} must be a function or NULL")
-  }
+  callback <- validate_ask_user_callback(callback)
   old <- .deputy_env$ask_user_callback
   .deputy_env$ask_user_callback <- callback
   invisible(old)
@@ -74,7 +101,7 @@ parse_user_response <- function(response, options, multi_select = FALSE) {
     parts <- strsplit(response_trimmed, ",")[[1]]
     indices <- suppressWarnings(as.integer(trimws(parts)))
 
-    if (!any(is.na(indices))) {
+    if (!anyNA(indices)) {
       # All parts are valid numbers
       valid_indices <- indices[indices >= 1 & indices <= length(options)]
       if (length(valid_indices) > 0) {
@@ -101,21 +128,37 @@ parse_user_response <- function(response, options, multi_select = FALSE) {
 #' Ask user questions (internal implementation)
 #'
 #' @param questions List of structured question objects
+#' @param callback Optional instance-scoped handler. It receives `questions`
+#'   and the resolved `context`. When omitted, the legacy process-wide fallback
+#'   is used.
+#' @param context Named routing context or a zero-argument function that returns
+#'   it.
 #' @return Named list mapping question text to selected answers
 #' @keywords internal
-ask_user_impl <- function(questions) {
-  # Check for custom callback first
-  callback <- get_ask_user_callback()
+ask_user_impl <- function(questions, callback = NULL, context = list()) {
   if (!is.null(callback)) {
-    return(callback(questions))
+    return(callback(questions, resolve_ask_user_context(context)))
+  }
+
+  legacy_callback <- get_ask_user_callback()
+  if (!is.null(legacy_callback)) {
+    return(legacy_callback(questions))
   }
 
   # Check if we're in an interactive session
   if (!interactive()) {
-    cli::cli_abort(c(
-      "Cannot ask user: session is not interactive",
-      "i" = "Use {.fn set_ask_user_callback} to provide a callback for non-interactive use"
-    ))
+    abort_deputy(
+      c(
+        "Cannot ask user: no human-input handler is available",
+        "i" = paste(
+          "Use {.fn tools_interactive} with an instance-scoped",
+          "{.arg callback} in non-interactive hosts."
+        )
+      ),
+      class = "human_input_unavailable",
+      questions = questions,
+      context = resolve_ask_user_context(context)
+    )
   }
 
   answers <- list()
@@ -158,6 +201,97 @@ ask_user_impl <- function(questions) {
   }
 
   answers
+}
+
+ask_user_tool_impl <- function(questions, callback = NULL, context = list()) {
+  if (is.character(questions) && length(questions) == 1) {
+    parsed <- tryCatch(
+      jsonlite::fromJSON(questions, simplifyVector = FALSE),
+      error = function(e) {
+        ellmer::tool_reject(paste(
+          "Failed to parse questions JSON:",
+          e$message
+        ))
+      }
+    )
+    if (is.null(parsed)) {
+      ellmer::tool_reject("JSON parsing returned NULL unexpectedly")
+    }
+    questions <- parsed
+  }
+
+  validate_questions(questions)
+
+  tryCatch(
+    {
+      answers <- ask_user_impl(
+        questions,
+        callback = callback,
+        context = context
+      )
+      list(
+        questions = questions,
+        answers = answers
+      )
+    },
+    interrupt = function(e) {
+      rlang::cnd_signal(e)
+    },
+    error = function(e) {
+      if (inherits(e, "deputy_human_input_unavailable")) {
+        rlang::cnd_signal(e)
+      }
+      error_class <- paste(class(e), collapse = ", ")
+      ellmer::tool_reject(paste0(
+        "Failed to get user input: ",
+        e$message,
+        " [",
+        error_class,
+        "]"
+      ))
+    }
+  )
+}
+
+new_ask_user_tool <- function(callback = NULL, context = list()) {
+  callback <- validate_ask_user_callback(callback)
+  context <- validate_ask_user_context(context)
+
+  ellmer::tool(
+    fun = function(questions) {
+      ask_user_tool_impl(
+        questions,
+        callback = callback,
+        context = context
+      )
+    },
+    name = "ask_user",
+    description = paste(
+      "Ask the user clarifying questions when you need more information to proceed.",
+      "Present 1-4 questions with 2-4 options each.",
+      "Format: JSON array of question objects, each with:",
+      "- question (string): The full question text",
+      "- header (string, max 12 chars): Short label",
+      "- options (array of 2-4 objects with 'label' and 'description')",
+      "- multiSelect (boolean, optional): Allow multiple selections",
+      "Example: [{\"question\": \"Which format?\", \"header\": \"Format\",",
+      "\"options\": [{\"label\": \"JSON\", \"description\": \"JavaScript Object Notation\"},",
+      "{\"label\": \"YAML\", \"description\": \"YAML format\"}]}]"
+    ),
+    arguments = list(
+      questions = ellmer::type_string(
+        paste(
+          "JSON array of 1-4 question objects. Each object has: question, header,",
+          "options (array of {label, description}), and optionally multiSelect."
+        )
+      )
+    ),
+    annotations = ellmer::tool_annotations(
+      read_only_hint = TRUE,
+      destructive_hint = FALSE,
+      open_world_hint = FALSE
+    )
+  )
 }
 
 #' Validate questions structure
@@ -246,9 +380,10 @@ validate_questions <- function(questions) {
 #' - For multi-select, labels are joined with ", "
 #' - Users can also type free-form responses
 #'
-#' In interactive R sessions, the tool uses `readline()` to get input.
-#' For non-interactive use (scripts, Shiny apps), set a callback with
-#' [set_ask_user_callback()].
+#' In interactive R sessions, the tool uses `readline()` to get input. The
+#' exported object uses [set_ask_user_callback()] only as a legacy process-wide
+#' fallback. Non-interactive and concurrent hosts should create an isolated
+#' tool with [tools_interactive()].
 #'
 #' @examples
 #' \dontrun{
@@ -272,108 +407,53 @@ validate_questions <- function(questions) {
 #' # }
 #' }
 #'
-#' @seealso [set_ask_user_callback()] for non-interactive usage
+#' @seealso [tools_interactive()] for instance-scoped non-interactive usage
 #'
 #' @export
-tool_ask_user <- ellmer::tool(
-  fun = function(questions) {
-    # Handle JSON string input (from LLMs that pass stringified JSON)
-    if (is.character(questions) && length(questions) == 1) {
-      parsed <- tryCatch(
-        jsonlite::fromJSON(questions, simplifyVector = FALSE),
-        error = function(e) {
-          ellmer::tool_reject(paste(
-            "Failed to parse questions JSON:",
-            e$message
-          ))
-        }
-      )
-      # Guard against unexpected NULL from parsing
-      if (is.null(parsed)) {
-        ellmer::tool_reject("JSON parsing returned NULL unexpectedly")
-      }
-      questions <- parsed
-    }
-
-    # Validate the questions structure
-    validate_questions(questions)
-
-    # Get user answers with specific error handling
-    tryCatch(
-      {
-        answers <- ask_user_impl(questions)
-
-        # Return in the expected format
-        list(
-          questions = questions,
-          answers = answers
-        )
-      },
-      interrupt = function(e) {
-        # Let user interrupts (Ctrl+C) propagate normally
-        stop(e)
-      },
-      error = function(e) {
-        # Include error class for debugging callback issues
-        error_class <- paste(class(e), collapse = ", ")
-        ellmer::tool_reject(paste0(
-          "Failed to get user input: ",
-          e$message,
-          " [",
-          error_class,
-          "]"
-        ))
-      }
-    )
-  },
-  name = "ask_user",
-  description = paste(
-    "Ask the user clarifying questions when you need more information to proceed.",
-    "Present 1-4 questions with 2-4 options each.",
-    "Format: JSON array of question objects, each with:",
-    "- question (string): The full question text",
-    "- header (string, max 12 chars): Short label",
-    "- options (array of 2-4 objects with 'label' and 'description')",
-    "- multiSelect (boolean, optional): Allow multiple selections",
-    "Example: [{\"question\": \"Which format?\", \"header\": \"Format\",",
-    "\"options\": [{\"label\": \"JSON\", \"description\": \"JavaScript Object Notation\"},",
-    "{\"label\": \"YAML\", \"description\": \"YAML format\"}]}]"
-  ),
-  arguments = list(
-    questions = ellmer::type_string(
-      paste(
-        "JSON array of 1-4 question objects. Each object has: question, header,",
-        "options (array of {label, description}), and optionally multiSelect."
-      )
-    )
-  ),
-  annotations = ellmer::tool_annotations(
-    read_only_hint = TRUE,
-    destructive_hint = FALSE,
-    open_world_hint = FALSE
-  )
-)
+tool_ask_user <- new_ask_user_tool()
 
 #' Tools for interactive workflows
 #'
 #' @description
 #' Returns a list of tools that enable human-in-the-loop interactions.
 #' Currently includes `tool_ask_user` (`ask_user`) for asking
-#' clarifying questions.
+#' clarifying questions. Supply `callback` in non-interactive or concurrent
+#' hosts so each Agent receives its own handler.
+#'
+#' @param callback Optional handler with signature `function(questions,
+#'   context)`. It should return a named list that maps each question text to
+#'   the selected label or labels. When omitted, interactive sessions use
+#'   `readline()` and non-interactive sessions may use the legacy callback from
+#'   [set_ask_user_callback()].
+#' @param context Named list of stable host routing values, such as `agent_id`
+#'   and `session_id`, or a zero-argument function returning that list. A
+#'   function is resolved for each question request.
 #'
 #' @return A list of tool definitions.
 #'
 #' @examples
 #' \dontrun{
+#' agent_id <- "agent-review"
+#' session_id <- "session-review"
 #' agent <- Agent$new(
 #'   chat = ellmer::chat("openai/gpt-4o"),
-#'   tools = c(tools_file(), tools_interactive())
+#'   tools = c(
+#'     tools_file(),
+#'     tools_interactive(
+#'       callback = function(questions, context) {
+#'         collect_answers(questions, route = context$session_id)
+#'       },
+#'       context = list(agent_id = agent_id, session_id = session_id)
+#'     )
+#'   ),
+#'   agent_id = agent_id,
+#'   session_id = session_id
 #' )
 #' }
 #'
 #' @seealso [tool_ask_user], [set_ask_user_callback()]
 #'
 #' @export
-tools_interactive <- function() {
-  list(tool_ask_user)
+tools_interactive <- function(callback = NULL, context = list()) {
+  list(new_ask_user_tool(callback = callback, context = context))
 }

--- a/man/LeadAgent.Rd
+++ b/man/LeadAgent.Rd
@@ -11,10 +11,10 @@ sub-agents based on registered AgentDefinitions.
 \section{Super class}{
 \code{\link[deputy:Agent]{Agent}} -> \code{LeadAgent}
 }
-\section{Public fields}{
-  \if{html}{\out{<div class="r6-fields">}}
+\section{Active bindings}{
+  \if{html}{\out{<div class="r6-active-bindings">}}
   \describe{
-    \item{\code{sub_agent_defs}}{List of AgentDefinition objects}
+    \item{\code{sub_agent_defs}}{Read-only snapshot of registered AgentDefinitions.}
   }
   \if{html}{\out{</div>}}
 }

--- a/man/agent_definition.Rd
+++ b/man/agent_definition.Rd
@@ -20,7 +20,9 @@ agent_definition(
 )
 }
 \arguments{
-\item{name}{Unique name for this agent type}
+\item{name}{Unique routing key for this Agent type. Names are trimmed,
+converted to lowercase, and must start with a letter followed only by
+letters, numbers, underscores, or hyphens.}
 
 \item{description}{Brief description of what this agent does (shown to lead agent)}
 

--- a/man/ask_user_impl.Rd
+++ b/man/ask_user_impl.Rd
@@ -4,10 +4,17 @@
 \alias{ask_user_impl}
 \title{Ask user questions (internal implementation)}
 \usage{
-ask_user_impl(questions)
+ask_user_impl(questions, callback = NULL, context = list())
 }
 \arguments{
 \item{questions}{List of structured question objects}
+
+\item{callback}{Optional instance-scoped handler. It receives \code{questions}
+and the resolved \code{context}. When omitted, the legacy process-wide fallback
+is used.}
+
+\item{context}{Named routing context or a zero-argument function that returns
+it.}
 }
 \value{
 Named list mapping question text to selected answers

--- a/man/deputy-errors.Rd
+++ b/man/deputy-errors.Rd
@@ -34,6 +34,8 @@ information for debugging. Errors use cli formatting for readable output.
 \item \code{deputy_session_save} - Failed to save session
 }
 \item \strong{deputy_hook} - Hook execution failures
+\item \strong{deputy_human_input_unavailable} - No interactive or bound handler
+is available for an \code{ask_user} request
 }
 }
 }

--- a/man/set_ask_user_callback.Rd
+++ b/man/set_ask_user_callback.Rd
@@ -18,19 +18,18 @@ Set to NULL to clear the callback.}
 Invisibly returns the previous callback (or NULL).
 }
 \description{
-In non-interactive sessions (scripts, Shiny apps, etc.), set a callback
-function that will be called when the agent needs user input via
-\code{ask_user}.
+Sets a legacy process-wide callback for non-interactive sessions. This
+fallback cannot isolate concurrent Agents or Shiny sessions. New code should
+bind a handler to a tool instance with \code{\link[=tools_interactive]{tools_interactive()}}.
 }
 \examples{
 \dontrun{
-# For a Shiny app:
+# Legacy fallback for a single-Agent script:
 set_ask_user_callback(function(questions) {
   # Display questions in modal and collect answers
   answers <- list()
   for (q in questions) {
-    # Show q$question with q$options
-    # Collect user selection
+    # Collect one answer for each question.
     answers[[q$question]] <- selected_label
   }
   answers

--- a/man/tool_ask_user.Rd
+++ b/man/tool_ask_user.Rd
@@ -44,9 +44,10 @@ the agent can request clarification or choices from the user.
 \item Users can also type free-form responses
 }
 
-In interactive R sessions, the tool uses \code{readline()} to get input.
-For non-interactive use (scripts, Shiny apps), set a callback with
-\code{\link[=set_ask_user_callback]{set_ask_user_callback()}}.
+In interactive R sessions, the tool uses \code{readline()} to get input. The
+exported object uses \code{\link[=set_ask_user_callback]{set_ask_user_callback()}} only as a legacy process-wide
+fallback. Non-interactive and concurrent hosts should create an isolated
+tool with \code{\link[=tools_interactive]{tools_interactive()}}.
 }
 \examples{
 \dontrun{
@@ -72,5 +73,5 @@ agent <- Agent$new(
 
 }
 \seealso{
-\code{\link[=set_ask_user_callback]{set_ask_user_callback()}} for non-interactive usage
+\code{\link[=tools_interactive]{tools_interactive()}} for instance-scoped non-interactive usage
 }

--- a/man/tools_interactive.Rd
+++ b/man/tools_interactive.Rd
@@ -4,7 +4,17 @@
 \alias{tools_interactive}
 \title{Tools for interactive workflows}
 \usage{
-tools_interactive()
+tools_interactive(callback = NULL, context = list())
+}
+\arguments{
+\item{callback}{Optional handler with signature \verb{function(questions, context)}. It should return a named list that maps each question text to
+the selected label or labels. When omitted, interactive sessions use
+\code{readline()} and non-interactive sessions may use the legacy callback from
+\code{\link[=set_ask_user_callback]{set_ask_user_callback()}}.}
+
+\item{context}{Named list of stable host routing values, such as \code{agent_id}
+and \code{session_id}, or a zero-argument function returning that list. A
+function is resolved for each question request.}
 }
 \value{
 A list of tool definitions.
@@ -12,13 +22,26 @@ A list of tool definitions.
 \description{
 Returns a list of tools that enable human-in-the-loop interactions.
 Currently includes \code{tool_ask_user} (\code{ask_user}) for asking
-clarifying questions.
+clarifying questions. Supply \code{callback} in non-interactive or concurrent
+hosts so each Agent receives its own handler.
 }
 \examples{
 \dontrun{
+agent_id <- "agent-review"
+session_id <- "session-review"
 agent <- Agent$new(
   chat = ellmer::chat("openai/gpt-4o"),
-  tools = c(tools_file(), tools_interactive())
+  tools = c(
+    tools_file(),
+    tools_interactive(
+      callback = function(questions, context) {
+        collect_answers(questions, route = context$session_id)
+      },
+      context = list(agent_id = agent_id, session_id = session_id)
+    )
+  ),
+  agent_id = agent_id,
+  session_id = session_id
 )
 }
 

--- a/tests/testthat/test-agents-multi.R
+++ b/tests/testthat/test-agents-multi.R
@@ -59,6 +59,54 @@ test_that("agent_definition accepts custom model", {
   expect_equal(def$model, "anthropic/claude-sonnet-4-20250514")
 })
 
+test_that("agent_definition canonicalizes routing keys", {
+  def <- agent_definition(
+    name = "  Review-Agent_1  ",
+    description = "Reviews code",
+    prompt = "Review the code"
+  )
+
+  expect_identical(def$name, "review-agent_1")
+})
+
+test_that("agent_definition validates scalar and collection fields", {
+  base <- list(
+    name = "reviewer",
+    description = "Reviews code",
+    prompt = "Review the code"
+  )
+  invalid <- list(
+    list(args = list(name = "two words"), field = "name"),
+    list(args = list(name = "1reviewer"), field = "name"),
+    list(args = list(description = ""), field = "description"),
+    list(args = list(prompt = NA_character_), field = "prompt"),
+    list(args = list(model = character()), field = "model"),
+    list(args = list(tools = tool_read_file), field = "tools"),
+    list(args = list(skills = "review"), field = "skills"),
+    list(
+      args = list(disallowed_tools = list("run_bash")),
+      field = "disallowed_tools"
+    ),
+    list(args = list(memory = list("memory")), field = "memory"),
+    list(
+      args = list(mcp_servers = c("github", NA_character_)),
+      field = "mcp_servers"
+    ),
+    list(
+      args = list(initial_prompt = c("one", "two")),
+      field = "initial_prompt"
+    )
+  )
+
+  for (case in invalid) {
+    condition <- rlang::catch_cnd(
+      do.call(agent_definition, utils::modifyList(base, case$args))
+    )
+    expect_s3_class(condition, "error")
+    expect_match(conditionMessage(condition), case$field, fixed = TRUE)
+  }
+})
+
 test_that("agent_definition print works", {
   def <- agent_definition(
     name = "print_test",
@@ -765,8 +813,7 @@ test_that("LeadAgent with no sub-agents is valid", {
   expect_equal(length(lead$available_sub_agents()), 0)
 })
 
-test_that("LeadAgent duplicate sub-agent names allowed", {
-  # Not validated - this is a user mistake but doesn't crash
+test_that("LeadAgent rejects duplicate normalized routing keys", {
   mock_chat <- create_mock_chat()
 
   agent1 <- agent_definition(
@@ -775,20 +822,68 @@ test_that("LeadAgent duplicate sub-agent names allowed", {
     prompt = "Prompt 1"
   )
   agent2 <- agent_definition(
-    name = "duplicate",
+    name = "DUPLICATE",
     description = "Second agent with same name",
     prompt = "Prompt 2"
   )
 
-  lead <- LeadAgent$new(
-    chat = mock_chat,
-    sub_agents = list(agent1, agent2)
+  condition <- rlang::catch_cnd(
+    LeadAgent$new(
+      chat = mock_chat,
+      sub_agents = list(agent1, agent2)
+    )
   )
 
-  available <- lead$available_sub_agents()
-  # Both are in the list (though this could cause confusion)
-  expect_equal(length(available), 2)
-  expect_true(all(available == "duplicate"))
+  expect_s3_class(condition, "error")
+  expect_match(conditionMessage(condition), "Duplicate", fixed = TRUE)
+  expect_match(conditionMessage(condition), "duplicate", fixed = TRUE)
+})
+
+test_that("LeadAgent registry is a read-only snapshot", {
+  definition <- agent_definition(
+    name = "helper",
+    description = "Helps with tasks",
+    prompt = "Help"
+  )
+  lead <- LeadAgent$new(
+    chat = create_mock_chat(),
+    sub_agents = list(definition)
+  )
+
+  snapshot <- lead$sub_agent_defs
+  snapshot[[1]]$name <- "changed"
+  definition$name <- "also-changed"
+
+  expect_identical(lead$available_sub_agents(), "helper")
+  expect_identical(lead$sub_agent_defs[[1]]$name, "helper")
+
+  condition <- rlang::catch_cnd({
+    lead$sub_agent_defs <- list()
+  })
+  expect_s3_class(condition, "error")
+  expect_match(conditionMessage(condition), "read-only", fixed = TRUE)
+})
+
+test_that("LeadAgent rejects duplicate registration", {
+  lead <- LeadAgent$new(
+    chat = create_mock_chat(),
+    sub_agents = list(agent_definition(
+      name = "helper",
+      description = "Helps",
+      prompt = "Help"
+    ))
+  )
+
+  duplicate <- agent_definition(
+    name = "HELPER",
+    description = "Also helps",
+    prompt = "Help again"
+  )
+  condition <- rlang::catch_cnd(lead$register_sub_agent(duplicate))
+
+  expect_s3_class(condition, "error")
+  expect_match(conditionMessage(condition), "already registered", fixed = TRUE)
+  expect_identical(lead$available_sub_agents(), "helper")
 })
 
 test_that("LeadAgent registers additional tools", {

--- a/tests/testthat/test-tools-interactive.R
+++ b/tests/testthat/test-tools-interactive.R
@@ -1,5 +1,17 @@
 # Tests for interactive tools
 
+interaction_test_questions <- function() {
+  list(list(
+    question = "Which format?",
+    header = "Format",
+    options = list(
+      list(label = "JSON", description = "Structured JSON"),
+      list(label = "YAML", description = "Readable YAML")
+    ),
+    multiSelect = FALSE
+  ))
+}
+
 test_that("tool_ask_user has correct structure", {
   expect_true(inherits(tool_ask_user, "ellmer::ToolDef"))
 
@@ -18,6 +30,115 @@ test_that("tools_interactive returns tool list", {
 
   tool_names <- vapply(tools, function(t) t@name, character(1))
   expect_true("ask_user" %in% tool_names)
+})
+
+test_that("tools_interactive isolates handlers and routing context", {
+  set_ask_user_callback(NULL)
+  seen <- list()
+  make_handler <- function(key) {
+    force(key)
+    function(questions, context) {
+      seen[[key]] <<- context
+      stats::setNames(list(key), questions[[1]]$question)
+    }
+  }
+
+  chat_a <- create_mock_chat()
+  chat_b <- create_mock_chat()
+  agent_a <- Agent$new(
+    chat = chat_a,
+    tools = tools_interactive(
+      callback = make_handler("agent-a"),
+      context = list(agent_id = "agent-a", session_id = "session-a")
+    ),
+    agent_id = "agent-a",
+    session_id = "session-a"
+  )
+  agent_b <- Agent$new(
+    chat = chat_b,
+    tools = tools_interactive(
+      callback = make_handler("agent-b"),
+      context = list(agent_id = "agent-b", session_id = "session-b")
+    ),
+    agent_id = "agent-b",
+    session_id = "session-b"
+  )
+
+  result_a <- chat_a$get_tools()[["ask_user"]](interaction_test_questions())
+  result_b <- chat_b$get_tools()[["ask_user"]](interaction_test_questions())
+
+  expect_s3_class(agent_a, "Agent")
+  expect_s3_class(agent_b, "Agent")
+  expect_identical(result_a$answers[["Which format?"]], "agent-a")
+  expect_identical(result_b$answers[["Which format?"]], "agent-b")
+  expect_identical(seen[["agent-a"]]$session_id, "session-a")
+  expect_identical(seen[["agent-b"]]$session_id, "session-b")
+})
+
+test_that("per-tool handler takes precedence over the legacy global fallback", {
+  set_ask_user_callback(function(questions) {
+    stats::setNames(list("global"), questions[[1]]$question)
+  })
+  withr::defer(set_ask_user_callback(NULL))
+
+  tool <- tools_interactive(
+    callback = function(questions, context) {
+      stats::setNames(list(context$route), questions[[1]]$question)
+    },
+    context = list(route = "instance")
+  )[[1]]
+  result <- tool(interaction_test_questions())
+
+  expect_identical(result$answers[["Which format?"]], "instance")
+})
+
+test_that("tools_interactive resolves dynamic context for each request", {
+  current_run <- "run-one"
+  seen <- character()
+  tool <- tools_interactive(
+    callback = function(questions, context) {
+      seen <<- c(seen, context$run_id)
+      stats::setNames(list(context$run_id), questions[[1]]$question)
+    },
+    context = function() list(run_id = current_run)
+  )[[1]]
+
+  first <- tool(interaction_test_questions())
+  current_run <- "run-two"
+  second <- tool(interaction_test_questions())
+
+  expect_identical(first$answers[["Which format?"]], "run-one")
+  expect_identical(second$answers[["Which format?"]], "run-two")
+  expect_identical(seen, c("run-one", "run-two"))
+})
+
+test_that("tools_interactive validates handler dependencies", {
+  callback_condition <- rlang::catch_cnd(
+    tools_interactive(callback = "not a function")
+  )
+  context_condition <- rlang::catch_cnd(
+    tools_interactive(
+      callback = function(questions, context) list(),
+      context = "route"
+    )
+  )
+
+  expect_s3_class(callback_condition, "error")
+  expect_match(conditionMessage(callback_condition), "callback", fixed = TRUE)
+  expect_s3_class(context_condition, "error")
+  expect_match(conditionMessage(context_condition), "context", fixed = TRUE)
+})
+
+test_that("missing non-interactive handler is a structured Deputy error", {
+  set_ask_user_callback(NULL)
+  skip_if(interactive(), "Test requires non-interactive session")
+  tool <- tools_interactive()[[1]]
+
+  condition <- rlang::catch_cnd(tool(interaction_test_questions()))
+
+  expect_s3_class(condition, "deputy_human_input_unavailable")
+  expect_s3_class(condition, "deputy_error")
+  expect_match(conditionMessage(condition), "handler", fixed = TRUE)
 })
 
 test_that("set_ask_user_callback validates input", {
@@ -112,7 +233,7 @@ test_that("ask_user_impl uses callback when set", {
   expect_equal(result[["What format do you prefer?"]], "JSON")
 })
 
-test_that("ask_user_impl errors in non-interactive without callback", {
+test_that("ask_user_impl reports missing non-interactive handler", {
   # Ensure no callback is set
   set_ask_user_callback(NULL)
 
@@ -130,10 +251,10 @@ test_that("ask_user_impl errors in non-interactive without callback", {
     )
   )
 
-  expect_error(
-    ask_user_impl(test_questions),
-    "not interactive"
-  )
+  condition <- rlang::catch_cnd(ask_user_impl(test_questions))
+
+  expect_s3_class(condition, "deputy_human_input_unavailable")
+  expect_match(conditionMessage(condition), "handler", fixed = TRUE)
 })
 
 test_that("tool_ask_user works with callback", {

--- a/vignettes/multi-agent.Rmd
+++ b/vignettes/multi-agent.Rmd
@@ -60,7 +60,7 @@ Fields:
 
 | Field | Description |
 |-------|-------------|
-| `name` | Unique identifier (used by the lead to delegate) |
+| `name` | Unique routing key: lowercase letter first, then letters, numbers, `_`, or `-` |
 | `description` | What this agent does (shown to the lead LLM) |
 | `prompt` | System prompt for the sub-agent |
 | `tools` | Tools available to the sub-agent |
@@ -120,6 +120,11 @@ lead <- LeadAgent$new(
 lead$available_sub_agents()
 #> [1] "code_reviewer" "data_analyst"
 ```
+
+Names are trimmed and converted to lowercase by `agent_definition()`. A
+`LeadAgent` rejects duplicate normalized names at construction and registration.
+Its `sub_agent_defs` field returns a read-only snapshot; use
+`register_sub_agent()` so the registry and lead prompt stay synchronized.
 
 ## Running a Delegation Task
 

--- a/vignettes/tools.Rmd
+++ b/vignettes/tools.Rmd
@@ -176,20 +176,31 @@ execution. This is useful for confirmations, clarifications, or collecting
 input:
 
 ```{r, eval = FALSE}
+agent_id <- "agent-analysis"
+session_id <- "session-analysis"
+
 agent <- Agent$new(
   chat = ellmer::chat_openai(),
-  tools = c(tools_file(), tools_interactive())
+  tools = c(
+    tools_file(),
+    tools_interactive(
+      callback = function(questions, context) {
+        # Route a modal to this Agent's host session and collect its answers.
+        collect_answers(questions, route = context$session_id)
+      },
+      context = list(agent_id = agent_id, session_id = session_id)
+    )
+  ),
+  agent_id = agent_id,
+  session_id = session_id
 )
-
-# In interactive sessions, a readline prompt appears.
-# For non-interactive use, set a custom callback:
-set_ask_user_callback(function(questions) {
-  answers <- list()
-  for (question in questions) {
-    answers[[question$question]] <- question$options[[1]]$label
-  }
-  answers
-})
 ```
 
-The `tools_interactive()` function returns a list containing `tool_ask_user`.
+`tools_interactive()` creates a fresh `tool_ask_user` instance. Its handler and
+routing context belong to that tool, so concurrent Agents cannot overwrite one
+another. The context may also be a zero-argument function when routing values
+must be resolved for each request. Omit the callback in an interactive console
+to use `readline()`.
+
+`set_ask_user_callback()` remains a process-wide compatibility fallback for
+single-Agent scripts. Do not use it to route Shiny or other concurrent hosts.


### PR DESCRIPTION
Closes #76
Closes #79

## Summary

- canonicalize and validate AgentDefinition routing keys and all declared fields
- reject duplicate normalized definitions at LeadAgent construction and registration
- keep the LeadAgent registry private behind a read-only snapshot and route by one canonical key
- let `tools_interactive()` bind a distinct human-input handler and routing context to each tool instance
- preserve `set_ask_user_callback()` only as a documented single-Agent compatibility fallback
- signal a structured `deputy_human_input_unavailable` condition when no handler exists
- update NEWS, contributor guidance, reference documentation, and vignettes

## Verification

- focused AgentDefinition and human-input tests: 234 passed
- full test suite: 2,125 passed, 6 skipped, 2 known filesystem warnings
- `air format R/ tests/testthat/`
- `jarl check R/`: 6 pre-existing findings, down from 7; no new findings
- `devtools::check()`: 0 errors, 0 warnings, 1 system-clock note
- `pkgdown::check_pkgdown()`: no problems
- `pkgdown::build_site(preview = FALSE)`: passed
- `git diff --check`
