### PR TITLE
Prepare Deputy for first CRAN release

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -16,3 +16,4 @@
 ^Meta$
 ^dev$
 ^CONTEXT\.md$
+^cran-comments\.md$

--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -57,9 +57,7 @@ jobs:
         config:
           - {os: macos-latest,   r: 'release'}
           - {os: windows-latest, r: 'release'}
-          - {os: ubuntu-latest,   r: 'devel', http-user-agent: 'release'}
           - {os: ubuntu-latest,   r: 'release'}
-          - {os: ubuntu-latest,   r: 'oldrel-1'}
 
     env:
       GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -62,9 +62,8 @@ The repository includes a SessionStart hook (`.claude/setup-r.sh`) that automati
 # Install dependencies
 Rscript -e "devtools::install_deps(dependencies = TRUE)"
 
-# deputy tracks the DEVELOPMENT versions of ellmer and shinychat, not CRAN.
-# Install them from GitHub or you will be working against an older API.
-Rscript -e "pak::pak(c('tidyverse/ellmer', 'posit-dev/shinychat'))"
+# Install the released dependency set used by CRAN and CI.
+Rscript -e "pak::pak()"
 
 # Load package for development
 Rscript -e "devtools::load_all()"
@@ -126,10 +125,10 @@ deputy stays on `0.0.0.9xxx` until it is ready for CRAN.
 
 ### Upstream dependencies
 
-deputy develops against the **development** versions of ellmer and shinychat,
-not their CRAN releases — see `dev/adr/0004-track-upstream-development-versions.md`.
-Install them from GitHub before working on the package. An upstream break is
-something to absorb promptly and report upstream, not to work around locally.
+deputy's primary compatibility target is the released dependency set available
+from CRAN; see `dev/adr/0004-track-upstream-development-versions.md`. Test
+upstream development versions in focused compatibility work before raising a
+minimum version or adopting an unreleased API.
 
 ## Code Conventions
 

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,16 +1,17 @@
 Package: deputy
-Title: Agentic AI Workflows for R
+Title: Governed Agentic Artificial Intelligence Workflows
 Version: 0.0.0.9000
 Authors@R:
-    person("James", "Wade", , "github@jameshwade.com", role = c("aut", "cre"),
+    person("James", "Wade", , "github@jameshwade.com", role = c("aut", "cre", "cph"),
            comment = c(ORCID = "0000-0002-9740-1905"))
-Author: James Wade [aut, cre] (ORCID: <https://orcid.org/0000-0002-9740-1905>)
-Maintainer: James Wade <github@jameshwade.com>
-Description: A provider-agnostic framework for building agentic AI workflows
-    in R. Built on ellmer, it enables multi-step reasoning with tool use,
-    permissions, hooks, and human-in-the-loop capabilities. Works with any
-    LLM provider that ellmer supports including OpenAI, Anthropic, Google,
-    and local models via Ollama.
+Description: Run provider-agnostic, agentic artificial intelligence (AI)
+    workflows with explicit boundaries for tools, permissions, budgets, and
+    filesystem access. Builds on 'ellmer' to provide multi-step reasoning,
+    lifecycle hooks, structured events, human input, session persistence, and
+    delegation. Returns inspectable results and supports synchronous,
+    asynchronous, terminal, and 'Shiny' hosts. Designed for applications that
+    need governance and observability around tool-using language models in
+    'R'.
 URL: https://github.com/JamesHWade/deputy, https://jameshwade.github.io/deputy/
 BugReports: https://github.com/JamesHWade/deputy/issues
 License: MIT + file LICENSE

--- a/R/run-usage.R
+++ b/R/run-usage.R
@@ -32,6 +32,9 @@
 #'   event and then signals a structured Deputy limit error.
 #'
 #' @return A `UsageLimits` object.
+#' @examples
+#' UsageLimits(max_requests = 5, max_tool_calls = 10)
+#' UsageLimits(max_cost_usd = 0.25, on_exceed = "error")
 #' @export
 UsageLimits <- function(
   max_requests = NULL,
@@ -109,6 +112,14 @@ print.UsageLimits <- function(x, ...) {
 #' @param cost_usd Provider-reported estimated cost in US dollars.
 #'
 #' @return An `AgentUsage` object.
+#' @examples
+#' AgentUsage(
+#'   requests = 2,
+#'   tool_calls = 1,
+#'   input_tokens = 120,
+#'   output_tokens = 30,
+#'   cost_usd = 0.002
+#' )
 #' @export
 AgentUsage <- function(
   requests = 0L,

--- a/R/tools-builtin.R
+++ b/R/tools-builtin.R
@@ -266,6 +266,8 @@ glob_relative_paths <- function(path = ".", pattern = "*", recursive = TRUE) {
 #' A tool that reads the contents of a file and returns it as a string.
 #'
 #' @format A tool definition created with `ellmer::tool()`.
+#' @return When called directly, a character string with the file contents, or
+#'   a structured list when selected PDF pages are requested.
 #'
 #' @param path Path to the file to read (tool argument, not R function argument)
 #' @param pages Optional PDF page selection. Accepts comma-separated pages and
@@ -359,6 +361,8 @@ tool_read_file <- ellmer::tool(
 #' a markdown representation instead of raw file text.
 #'
 #' @format A tool definition created with `ellmer::tool()`.
+#' @return When called directly, a character string containing the converted
+#'   markdown.
 #'
 #' @param path Path to the file to convert (tool argument, not R function argument)
 #'
@@ -406,6 +410,8 @@ tool_read_markdown <- ellmer::tool(
 #' A tool that writes content to a file, creating it if it doesn't exist.
 #'
 #' @format A tool definition created with `ellmer::tool()`.
+#' @return When called directly, a character status message describing the
+#'   write.
 #'
 #' @param path Path to the file to write (tool argument)
 #' @param content Content to write to the file (tool argument)
@@ -465,12 +471,20 @@ tool_write_file <- ellmer::tool(
 #' Replace a specific text span in an existing file.
 #'
 #' @format A tool definition created with `ellmer::tool()`.
+#' @return When called directly, a character status message describing the
+#'   edit and replacement count.
 #'
 #' @param path Path to the file to edit (tool argument)
 #' @param old_text Existing text to replace (tool argument)
 #' @param new_text Replacement text (tool argument)
 #' @param replace_all If TRUE, replace all matches instead of requiring a
 #'   unique match (tool argument)
+#'
+#' @examples
+#' path <- tempfile(fileext = ".txt")
+#' writeLines("alpha", path)
+#' tool_edit_file(path, "alpha", "beta")
+#' unlink(path)
 #'
 #' @export
 tool_edit_file <- ellmer::tool(
@@ -528,9 +542,20 @@ tool_edit_file <- ellmer::tool(
 #' Apply a sequence of exact-match text replacements to a file.
 #'
 #' @format A tool definition created with `ellmer::tool()`.
+#' @return When called directly, a character status message describing the
+#'   edits and total replacement count.
 #'
 #' @param path Path to the file to edit (tool argument)
 #' @param edits List or JSON string of edit operations (tool argument)
+#'
+#' @examples
+#' path <- tempfile(fileext = ".txt")
+#' writeLines(c("alpha", "beta"), path)
+#' tool_multi_edit(
+#'   path,
+#'   list(list(old_text = "alpha", new_text = "gamma"))
+#' )
+#' unlink(path)
 #'
 #' @export
 tool_multi_edit <- ellmer::tool(
@@ -596,6 +621,8 @@ tool_multi_edit <- ellmer::tool(
 #' A tool that lists files and directories within a specified path.
 #'
 #' @format A tool definition created with `ellmer::tool()`.
+#' @return When called directly, a character summary of the matching files and
+#'   directories.
 #'
 #' @param path Directory path to list (tool argument)
 #' @param pattern Optional regex pattern to filter files (tool argument)
@@ -701,10 +728,19 @@ tool_list_files <- ellmer::tool(
 #' Search for files under a directory using shell-style glob matching.
 #'
 #' @format A tool definition created with `ellmer::tool()`.
+#' @return When called directly, a character summary of paths matching the
+#'   glob pattern.
 #'
 #' @param pattern Glob pattern to match (tool argument)
 #' @param path Base directory to search (tool argument)
 #' @param recursive If TRUE, search subdirectories recursively (tool argument)
+#'
+#' @examples
+#' directory <- tempfile()
+#' dir.create(directory)
+#' writeLines("example", file.path(directory, "example.txt"))
+#' tool_glob_files("*.txt", directory)
+#' unlink(directory, recursive = TRUE)
 #'
 #' @export
 tool_glob_files <- ellmer::tool(
@@ -761,12 +797,20 @@ tool_glob_files <- ellmer::tool(
 #' Search text files under a directory and return matching lines.
 #'
 #' @format A tool definition created with `ellmer::tool()`.
+#' @return When called directly, a character summary of matching file lines.
 #'
 #' @param pattern Regex pattern to search for (tool argument)
 #' @param path Base directory to search (tool argument)
 #' @param recursive If TRUE, search subdirectories recursively (tool argument)
 #' @param ignore_case If TRUE, ignore case when matching (tool argument)
 #' @param max_matches Maximum matching lines to return (tool argument)
+#'
+#' @examples
+#' directory <- tempfile()
+#' dir.create(directory)
+#' writeLines("needle", file.path(directory, "example.txt"))
+#' tool_grep_files("needle", directory)
+#' unlink(directory, recursive = TRUE)
 #'
 #' @export
 tool_grep_files <- ellmer::tool(
@@ -958,6 +1002,8 @@ run_r_code_impl <- function(code, timeout = 30) {
 #' - The Permissions system can disable this tool entirely
 #'
 #' @format A tool definition created with `ellmer::tool()`.
+#' @return When called directly, a character string containing captured output
+#'   and the returned value.
 #'
 #' @param code R code to execute (tool argument)
 #'
@@ -994,6 +1040,8 @@ tool_run_r_code <- ellmer::tool(
 #' **Use with caution!** This can execute arbitrary system commands.
 #'
 #' @format A tool definition created with `ellmer::tool()`.
+#' @return When called directly, a character string containing command output
+#'   or a success message.
 #'
 #' @param command The bash command to execute (tool argument)
 #'
@@ -1081,6 +1129,8 @@ tool_run_bash <- ellmer::tool(
 #' along with the first few rows.
 #'
 #' @format A tool definition created with `ellmer::tool()`.
+#' @return When called directly, a character summary of the CSV structure and
+#'   preview rows.
 #'
 #' @param path Path to the CSV file to read (tool argument)
 #' @param n_max Maximum number of rows to read (tool argument)

--- a/R/tools-interactive.R
+++ b/R/tools-interactive.R
@@ -229,6 +229,8 @@ validate_questions <- function(questions) {
 #'   `multiSelect` (logical).
 #'
 #' @format A tool definition created with `ellmer::tool()`.
+#' @return When called directly, a list containing the original `questions`
+#'   and a named `answers` list.
 #'
 #' @details
 #' **Input format:**

--- a/R/tools-web.R
+++ b/R/tools-web.R
@@ -10,6 +10,8 @@
 #' with a custom tool implementation.
 #'
 #' @format A tool definition created with `ellmer::tool()`.
+#' @return When called directly, a character string containing the fetched and
+#'   normalized page content.
 #'
 #' @param url The URL of the web page to fetch (tool argument)
 #'
@@ -107,6 +109,8 @@ tool_web_fetch <- ellmer::tool(
 #' HTML search results by default.
 #'
 #' @format A tool definition created with `ellmer::tool()`.
+#' @return When called directly, a character string containing formatted search
+#'   results.
 #'
 #' @param query The search query (tool argument)
 #' @param num_results Maximum number of results to return (tool argument)

--- a/README.Rmd
+++ b/README.Rmd
@@ -51,7 +51,15 @@ ellmer Chat + Tools + Permissions + Limits
 
 ## Installation
 
-Install Deputy and its required dependencies from CRAN:
+Before Deputy's first CRAN release, install the development version from
+GitHub:
+
+```r
+# install.packages("pak")
+pak::pak("JamesHWade/deputy")
+```
+
+After the release is available from CRAN, install the released package with:
 
 ```r
 install.packages("deputy")
@@ -61,13 +69,6 @@ For the optional Shiny host, also install shinychat:
 
 ```r
 install.packages("shinychat")
-```
-
-You can install the development version of Deputy from GitHub with:
-
-```r
-# install.packages("pak")
-pak::pak("JamesHWade/deputy")
 ```
 
 ## A safe first run

--- a/README.Rmd
+++ b/README.Rmd
@@ -51,17 +51,23 @@ ellmer Chat + Tools + Permissions + Limits
 
 ## Installation
 
-Deputy currently follows development versions of ellmer:
+Install Deputy and its required dependencies from CRAN:
 
 ```r
-# install.packages("pak")
-pak::pak(c("tidyverse/ellmer", "JamesHWade/deputy"))
+install.packages("deputy")
 ```
 
 For the optional Shiny host, also install shinychat:
 
 ```r
-pak::pak("posit-dev/shinychat")
+install.packages("shinychat")
+```
+
+You can install the development version of Deputy from GitHub with:
+
+```r
+# install.packages("pak")
+pak::pak("JamesHWade/deputy")
 ```
 
 ## A safe first run

--- a/README.md
+++ b/README.md
@@ -44,7 +44,16 @@ ellmer Chat + Tools + Permissions + Limits
 
 ## Installation
 
-Install Deputy and its required dependencies from CRAN:
+Before Deputy’s first CRAN release, install the development version from
+GitHub:
+
+``` r
+# install.packages("pak")
+pak::pak("JamesHWade/deputy")
+```
+
+After the release is available from CRAN, install the released package
+with:
 
 ``` r
 install.packages("deputy")
@@ -54,13 +63,6 @@ For the optional Shiny host, also install shinychat:
 
 ``` r
 install.packages("shinychat")
-```
-
-You can install the development version of Deputy from GitHub with:
-
-``` r
-# install.packages("pak")
-pak::pak("JamesHWade/deputy")
 ```
 
 ## A safe first run

--- a/README.md
+++ b/README.md
@@ -44,17 +44,23 @@ ellmer Chat + Tools + Permissions + Limits
 
 ## Installation
 
-Deputy currently follows development versions of ellmer:
+Install Deputy and its required dependencies from CRAN:
 
 ``` r
-# install.packages("pak")
-pak::pak(c("tidyverse/ellmer", "JamesHWade/deputy"))
+install.packages("deputy")
 ```
 
 For the optional Shiny host, also install shinychat:
 
 ``` r
-pak::pak("posit-dev/shinychat")
+install.packages("shinychat")
+```
+
+You can install the development version of Deputy from GitHub with:
+
+``` r
+# install.packages("pak")
+pak::pak("JamesHWade/deputy")
 ```
 
 ## A safe first run

--- a/cran-comments.md
+++ b/cran-comments.md
@@ -1,0 +1,24 @@
+## R CMD check results
+
+0 errors | 0 warnings | 1 note
+
+* This is a new submission.
+
+## Test environments
+
+* local macOS 26.6, R 4.6.1
+* GitHub Actions: Ubuntu, macOS, and Windows with release R
+
+## First submission
+
+This is the first CRAN submission of deputy.
+
+## Method references
+
+There are no published references describing the methods in this package.
+Deputy provides original runtime and governance functionality around
+tool-using language-model workflows built with 'ellmer'.
+
+## Downstream dependencies
+
+There are currently no downstream CRAN dependencies.

--- a/dev/adr/0003-shinychat-owns-conversation-persistence.md
+++ b/dev/adr/0003-shinychat-owns-conversation-persistence.md
@@ -18,11 +18,15 @@ The store also works headless. `FileConversationStore$new(dir)` instantiates and
 
 ## Timing
 
-The store is **unreleased**. `ConversationStore`, `FileConversationStore`, `chat_enable_history()` and `history_options()` are all in shinychat's development version (upstream #264, #266); CRAN has 0.4.0, which has none of it.
+The store API described here is not part of the released shinychat dependency
+targeted by deputy 0.1.0. This decision therefore describes planned integration,
+not functionality in the CRAN package.
 
-That is fortunate rather than a problem. An API that has not shipped can still change shape, so the export request in issue #66 arrives while it is cheap to act on — and better still as a pull request than an issue. After a release the same request competes against backward compatibility.
+Before deputy can depend on the store:
 
-It does mean two things must be true before deputy can depend on this:
-
-- CI has to test against shinychat's development version. Today it installs from CRAN, where the store does not exist, so nothing deputy writes against it would be exercised.
-- deputy needs actual shinychat integration tests. There are currently none, despite ADR-0002 naming it the primary host.
+- The required API must ship in a shinychat release and deputy must declare that
+  released version as its minimum. Focused checks against upstream development
+  versions can inform the integration work, but they do not replace the
+  released-dependency CI policy in ADR-0004.
+- deputy needs actual shinychat integration tests. There are currently none,
+  despite ADR-0002 naming it the primary host.

--- a/dev/adr/0004-track-upstream-development-versions.md
+++ b/dev/adr/0004-track-upstream-development-versions.md
@@ -1,19 +1,37 @@
-# Track the development versions of ellmer and shinychat
+# Track released versions of ellmer and shinychat
 
-deputy develops and tests against the **development** versions of ellmer and shinychat, not their CRAN releases. `DESCRIPTION` should declare development floors and a `Remotes:` field pointing at the upstream repositories, and CI should install from those sources.
+deputy's primary compatibility target is the released dependency set available
+from CRAN. `DESCRIPTION`, contributor setup, and the required CI matrix must be
+installable without `Remotes:` or development-only version floors.
+
+This supersedes the development-only policy originally recorded here. That
+policy was deliberately temporary: it expired when deputy began preparing its
+first CRAN submission and its required upstream versions were available on
+CRAN.
 
 ## Why
 
-deputy is built on ellmer and hosted by shinychat (ADR-0002), and defers conversation persistence to shinychat's store (ADR-0003). That store is development-only — CRAN's shinychat 0.4.0 does not have it. Building against releases would mean deferring every capability by a release cycle, and designing against an API a cycle behind the one the maintainers are actually shaping.
+A CRAN package must be reproducible from released dependencies. Making that
+environment the primary target catches dependency floors, accidental use of
+unreleased APIs, and installation failures before submission. It also gives
+users and contributors one supported setup rather than a GitHub-only graph.
 
-Staying current also changes when problems surface. An upstream change that breaks deputy is found the week it lands, while the maintainer still has it in mind and the fix is a conversation. Found at release time it is deputy's emergency, and the window for influencing the design has closed.
-
-The same currency is what makes upstream contribution possible. The export request in issue #66 is only well timed because deputy is looking at unreleased code.
+Focused compatibility work against upstream development versions remains
+valuable. It is an early-warning signal, but it cannot define the required
+installation path or silently raise deputy's supported floor before an
+upstream release exists.
 
 ## Consequences
 
-- **`Remotes:` must be removed before CRAN submission.** CRAN does not accept it, and every dependency must be a released version. This ADR therefore has an expiry: at submission time deputy must be buildable against CRAN releases of ellmer and shinychat, which means those releases must have landed first. That is a real scheduling dependency on two other packages, and it is accepted deliberately.
-- **CI must install from development sources**, otherwise it tests something nobody runs. See issue #67.
-- **Version floors should name development versions** — `ellmer (>= 0.4.2.9000)`, `shinychat (>= 0.4.0.9000)` — so an install that silently resolved to CRAN fails loudly rather than at first use.
-- **Upstream breaking changes are deputy's to absorb promptly**, not to work around. See ADR-0003 on why insulation is the wrong instinct.
-- **Contributors need the dev versions installed.** This should be stated in the development setup instructions, not discovered through a confusing failure.
+- `DESCRIPTION` does not contain `Remotes:` and names only released minimum
+  versions.
+- Required CI checks release R on Ubuntu, macOS, and Windows against released
+  dependencies.
+- Upstream development versions may be tested in an explicitly experimental
+  job or local compatibility pass, but that signal does not replace the
+  released-dependency matrix.
+- Features that require unreleased upstream APIs wait behind a release or use
+  a documented optional boundary; they do not enter the CRAN package through
+  an undeclared development dependency.
+- Issue #67's development-only dependency target is superseded by this release
+  policy.

--- a/man/AgentUsage.Rd
+++ b/man/AgentUsage.Rd
@@ -36,3 +36,12 @@ An \code{AgentUsage} object.
 run \code{usage}/\code{stop} events are scoped to that run, while \link{Agent}\verb{$usage()}
 describes the complete in-memory conversation at the time it is called.
 }
+\examples{
+AgentUsage(
+  requests = 2,
+  tool_calls = 1,
+  input_tokens = 120,
+  output_tokens = 30,
+  cost_usd = 0.002
+)
+}

--- a/man/UsageLimits.Rd
+++ b/man/UsageLimits.Rd
@@ -53,3 +53,7 @@ response. A \code{NULL} field leaves that limit unset on this object; when the
 object configures or overrides an \link{Agent}, Deputy may fill unset fields from
 the agent's defaults.
 }
+\examples{
+UsageLimits(max_requests = 5, max_tool_calls = 10)
+UsageLimits(max_cost_usd = 0.25, on_exceed = "error")
+}

--- a/man/deputy-package.Rd
+++ b/man/deputy-package.Rd
@@ -4,11 +4,11 @@
 \name{deputy-package}
 \alias{deputy-package}
 \alias{deputy}
-\title{deputy: Agentic AI Workflows for R}
+\title{deputy: Governed Agentic Artificial Intelligence Workflows}
 \description{
 \if{html}{\figure{logo.svg}{options: style='float: right' alt='logo' width='120'}}
 
-A provider-agnostic framework for building agentic AI workflows in R. Built on ellmer, it enables multi-step reasoning with tool use, permissions, hooks, and human-in-the-loop capabilities. Works with any LLM provider that ellmer supports including OpenAI, Anthropic, Google, and local models via Ollama.
+Run provider-agnostic, agentic artificial intelligence (AI) workflows with explicit boundaries for tools, permissions, budgets, and filesystem access. Builds on 'ellmer' to provide multi-step reasoning, lifecycle hooks, structured events, human input, session persistence, and delegation. Returns inspectable results and supports synchronous, asynchronous, terminal, and 'Shiny' hosts. Designed for applications that need governance and observability around tool-using language models in 'R'.
 
 A provider-agnostic framework for building agentic AI workflows in R.
 Built on ellmer, it enables multi-step reasoning with tool use,
@@ -59,11 +59,11 @@ Useful links:
 
 }
 \author{
-\strong{Maintainer}: James Wade \email{github@jameshwade.com} (\href{https://orcid.org/0000-0002-9740-1905}{ORCID})
+\strong{Maintainer}: James Wade \email{github@jameshwade.com} (\href{https://orcid.org/0000-0002-9740-1905}{ORCID}) [copyright holder]
 
 Authors:
 \itemize{
-  \item James Wade \email{github@jameshwade.com} (\href{https://orcid.org/0000-0002-9740-1905}{ORCID})
+  \item James Wade \email{github@jameshwade.com} (\href{https://orcid.org/0000-0002-9740-1905}{ORCID}) [copyright holder]
 }
 
 }

--- a/man/tool_ask_user.Rd
+++ b/man/tool_ask_user.Rd
@@ -15,6 +15,10 @@ Each question should have: \code{question} (string), \code{header} (string, max 
 \code{options} (list of objects with \code{label} and \code{description}), and optionally
 \code{multiSelect} (logical).}
 }
+\value{
+When called directly, a list containing the original \code{questions}
+and a named \code{answers} list.
+}
 \description{
 A tool that allows the agent to ask the user clarifying questions and
 receive their responses. This enables human-in-the-loop workflows where

--- a/man/tool_edit_file.Rd
+++ b/man/tool_edit_file.Rd
@@ -19,6 +19,17 @@ tool_edit_file(path, old_text, new_text, replace_all = FALSE)
 \item{replace_all}{If TRUE, replace all matches instead of requiring a
 unique match (tool argument)}
 }
+\value{
+When called directly, a character status message describing the
+edit and replacement count.
+}
 \description{
 Replace a specific text span in an existing file.
+}
+\examples{
+path <- tempfile(fileext = ".txt")
+writeLines("alpha", path)
+tool_edit_file(path, "alpha", "beta")
+unlink(path)
+
 }

--- a/man/tool_glob_files.Rd
+++ b/man/tool_glob_files.Rd
@@ -16,6 +16,18 @@ tool_glob_files(pattern = "*", path = ".", recursive = TRUE)
 
 \item{recursive}{If TRUE, search subdirectories recursively (tool argument)}
 }
+\value{
+When called directly, a character summary of paths matching the
+glob pattern.
+}
 \description{
 Search for files under a directory using shell-style glob matching.
+}
+\examples{
+directory <- tempfile()
+dir.create(directory)
+writeLines("example", file.path(directory, "example.txt"))
+tool_glob_files("*.txt", directory)
+unlink(directory, recursive = TRUE)
+
 }

--- a/man/tool_grep_files.Rd
+++ b/man/tool_grep_files.Rd
@@ -26,6 +26,17 @@ tool_grep_files(
 
 \item{max_matches}{Maximum matching lines to return (tool argument)}
 }
+\value{
+When called directly, a character summary of matching file lines.
+}
 \description{
 Search text files under a directory and return matching lines.
+}
+\examples{
+directory <- tempfile()
+dir.create(directory)
+writeLines("needle", file.path(directory, "example.txt"))
+tool_grep_files("needle", directory)
+unlink(directory, recursive = TRUE)
+
 }

--- a/man/tool_list_files.Rd
+++ b/man/tool_list_files.Rd
@@ -23,6 +23,10 @@ tool_list_files(
 
 \item{full_names}{If TRUE, return full paths (tool argument)}
 }
+\value{
+When called directly, a character summary of the matching files and
+directories.
+}
 \description{
 A tool that lists files and directories within a specified path.
 }

--- a/man/tool_multi_edit.Rd
+++ b/man/tool_multi_edit.Rd
@@ -14,6 +14,20 @@ tool_multi_edit(path, edits)
 
 \item{edits}{List or JSON string of edit operations (tool argument)}
 }
+\value{
+When called directly, a character status message describing the
+edits and total replacement count.
+}
 \description{
 Apply a sequence of exact-match text replacements to a file.
+}
+\examples{
+path <- tempfile(fileext = ".txt")
+writeLines(c("alpha", "beta"), path)
+tool_multi_edit(
+  path,
+  list(list(old_text = "alpha", new_text = "gamma"))
+)
+unlink(path)
+
 }

--- a/man/tool_read_csv.Rd
+++ b/man/tool_read_csv.Rd
@@ -16,6 +16,10 @@ tool_read_csv(path, n_max = 1000, show_head = 10)
 
 \item{show_head}{Number of rows to show in preview (tool argument)}
 }
+\value{
+When called directly, a character summary of the CSV structure and
+preview rows.
+}
 \description{
 A tool that reads a CSV file and returns a summary of its structure
 along with the first few rows.

--- a/man/tool_read_file.Rd
+++ b/man/tool_read_file.Rd
@@ -15,6 +15,10 @@ tool_read_file(path, pages = NULL)
 \item{pages}{Optional PDF page selection. Accepts comma-separated pages and
 ranges (e.g. \code{"1,3-5"}). Only supported for PDF files.}
 }
+\value{
+When called directly, a character string with the file contents, or
+a structured list when selected PDF pages are requested.
+}
 \description{
 A tool that reads the contents of a file and returns it as a string.
 }

--- a/man/tool_read_markdown.Rd
+++ b/man/tool_read_markdown.Rd
@@ -12,6 +12,10 @@ tool_read_markdown(path)
 \arguments{
 \item{path}{Path to the file to convert (tool argument, not R function argument)}
 }
+\value{
+When called directly, a character string containing the converted
+markdown.
+}
 \description{
 Converts a local file to markdown text using Python
 \href{https://github.com/microsoft/markitdown}{MarkItDown} via \code{reticulate}.

--- a/man/tool_run_bash.Rd
+++ b/man/tool_run_bash.Rd
@@ -12,6 +12,10 @@ tool_run_bash(command)
 \arguments{
 \item{command}{The bash command to execute (tool argument)}
 }
+\value{
+When called directly, a character string containing command output
+or a success message.
+}
 \description{
 A tool that executes bash/shell commands and returns the output.
 \strong{Use with caution!} This can execute arbitrary system commands.

--- a/man/tool_run_r_code.Rd
+++ b/man/tool_run_r_code.Rd
@@ -12,6 +12,10 @@ tool_run_r_code(code)
 \arguments{
 \item{code}{R code to execute (tool argument)}
 }
+\value{
+When called directly, a character string containing captured output
+and the returned value.
+}
 \description{
 A tool that executes R code and returns the result. By default, runs in
 a separate process for safety (requires the callr package).

--- a/man/tool_web_fetch.Rd
+++ b/man/tool_web_fetch.Rd
@@ -12,6 +12,10 @@ tool_web_fetch(url)
 \arguments{
 \item{url}{The URL of the web page to fetch (tool argument)}
 }
+\value{
+When called directly, a character string containing the fetched and
+normalized page content.
+}
 \description{
 A tool that fetches the content of a web page and returns it as text
 or markdown. Requires the httr2 package for HTTP requests.

--- a/man/tool_web_search.Rd
+++ b/man/tool_web_search.Rd
@@ -14,6 +14,10 @@ tool_web_search(query, num_results = 10)
 
 \item{num_results}{Maximum number of results to return (tool argument)}
 }
+\value{
+When called directly, a character string containing formatted search
+results.
+}
 \description{
 A tool that performs a web search and returns results. Uses DuckDuckGo's
 HTML search results by default.

--- a/man/tool_write_file.Rd
+++ b/man/tool_write_file.Rd
@@ -16,6 +16,10 @@ tool_write_file(path, content, append = FALSE)
 
 \item{append}{If TRUE, append to existing file (tool argument)}
 }
+\value{
+When called directly, a character status message describing the
+write.
+}
 \description{
 A tool that writes content to a file, creating it if it doesn't exist.
 }

--- a/vignettes/getting-started.Rmd
+++ b/vignettes/getting-started.Rmd
@@ -20,7 +20,15 @@ one workspace-scoped write capability and protect it with a checkpoint.
 
 ## Before you begin
 
-Install Deputy and its required dependencies from CRAN:
+Before Deputy's first CRAN release, install the development version from
+GitHub:
+
+```r
+# install.packages("pak")
+pak::pak("JamesHWade/deputy")
+```
+
+After the release is available from CRAN, install the released package with:
 
 ```r
 install.packages("deputy")

--- a/vignettes/getting-started.Rmd
+++ b/vignettes/getting-started.Rmd
@@ -20,11 +20,10 @@ one workspace-scoped write capability and protect it with a checkpoint.
 
 ## Before you begin
 
-Install Deputy and the development version of ellmer:
+Install Deputy and its required dependencies from CRAN:
 
 ```r
-# install.packages("pak")
-pak::pak(c("tidyverse/ellmer", "JamesHWade/deputy"))
+install.packages("deputy")
 ```
 
 You also need credentials for one

--- a/vignettes/tools.Rmd
+++ b/vignettes/tools.Rmd
@@ -155,7 +155,7 @@ DuckDuckGo).
 
 deputy can load tools from
 [Model Context Protocol](https://modelcontextprotocol.io/) servers via
-the [mcptools](https://github.com/tidyverse/mcptools) package:
+the [mcptools](https://github.com/posit-dev/mcptools) package:
 
 ```{r, eval = FALSE}
 # Load tools from selected configured servers


### PR DESCRIPTION
## Summary

- prepare DESCRIPTION, README installation guidance, CRAN comments, and generated package metadata for first submission
- make released CRAN dependencies the primary compatibility target and use release R on Ubuntu, macOS, and Windows
- complete callable export return values and examples, and update the moved mcptools URL
- document the release dependency policy that supersedes the temporary development-only ADR

## Verification

- full released-dependency R CMD check --as-cran, including examples, tests, vignettes, and the PDF manual
- PDF and HTML manual checks with modern HTML Tidy
- CRAN remote incoming check; expected first-submission and development-version note only
- pkgdown check and complete site build
- URL audit and formatting checks

## Submission gate

Keep version 0.0.0.9000 until the actual submission, then bump to 0.1.0.

Closes #83
Closes #67