### PR TITLE
Clarify the R tool's process-isolation boundary

### DIFF
--- a/R/tools-builtin.R
+++ b/R/tools-builtin.R
@@ -988,16 +988,16 @@ run_r_code_impl <- function(code, timeout = 30) {
 #' Execute R code
 #'
 #' @description
-#' A tool that executes R code and returns the result. By default, runs in
-#' a separate process for safety (requires the callr package).
+#' A tool that executes R code and returns the result. It runs in a separate
+#' process for fault isolation and timeout enforcement (requires callr).
 #'
 #' @details
 #' This tool intentionally uses R's code evaluation capabilities to execute
 #' arbitrary R code provided by the LLM. This is a core feature for agentic
 #' workflows where the agent needs to perform data analysis or other R tasks.
 #'
-#' For safety:
-#' - By default, code runs in a sandboxed subprocess via callr
+#' The execution boundary is explicit:
+#' - Code runs in a separate callr subprocess, not an OS security sandbox
 #' - A timeout prevents runaway execution
 #' - The Permissions system can disable this tool entirely
 #'
@@ -1021,10 +1021,13 @@ tool_run_r_code <- ellmer::tool(
     run_r_code_impl(code)
   },
   name = "run_r_code",
-  description = "Execute R code and return the output and result. By default runs in a sandboxed process for safety.",
+  description = paste(
+    "Execute R code in a separate process and return the output and result.",
+    "Process isolation is not an OS security sandbox."
+  ),
   arguments = list(
     code = ellmer::type_string("R code to execute")
-    # Note: sandbox and timeout are internal parameters, not exposed to LLM
+    # Note: process isolation and timeout are internal, not exposed to the LLM
   ),
   annotations = ellmer::tool_annotations(
     read_only_hint = FALSE,

--- a/R/tools-bundles.R
+++ b/R/tools-bundles.R
@@ -34,7 +34,7 @@ tools_file <- function() {
 #'
 #' @description
 #' Returns a list of tools for code execution:
-#' * `run_r_code` - Execute R code (sandboxed by default)
+#' * `run_r_code` - Execute R code in a separate process
 #' * `run_bash` - Execute bash commands
 #'
 #' **Note:** These tools require appropriate permissions. By default,

--- a/man/tool_run_r_code.Rd
+++ b/man/tool_run_r_code.Rd
@@ -17,17 +17,17 @@ When called directly, a character string containing captured output
 and the returned value.
 }
 \description{
-A tool that executes R code and returns the result. By default, runs in
-a separate process for safety (requires the callr package).
+A tool that executes R code and returns the result. It runs in a separate
+process for fault isolation and timeout enforcement (requires callr).
 }
 \details{
 This tool intentionally uses R's code evaluation capabilities to execute
 arbitrary R code provided by the LLM. This is a core feature for agentic
 workflows where the agent needs to perform data analysis or other R tasks.
 
-For safety:
+The execution boundary is explicit:
 \itemize{
-\item By default, code runs in a sandboxed subprocess via callr
+\item Code runs in a separate callr subprocess, not an OS security sandbox
 \item A timeout prevents runaway execution
 \item The Permissions system can disable this tool entirely
 }

--- a/man/tools_code.Rd
+++ b/man/tools_code.Rd
@@ -12,7 +12,7 @@ A list of tool definitions
 \description{
 Returns a list of tools for code execution:
 \itemize{
-\item \code{run_r_code} - Execute R code (sandboxed by default)
+\item \code{run_r_code} - Execute R code in a separate process
 \item \code{run_bash} - Execute bash commands
 }
 

--- a/tests/testthat/test-tools.R
+++ b/tests/testthat/test-tools.R
@@ -256,9 +256,14 @@ test_that("tool_list_files handles empty directory", {
 test_that("tool_run_r_code executes code", {
   skip_on_cran()
   skip_if_not_installed("callr")
-  # Note: sandbox parameter is no longer exposed (security fix)
   result <- tool_run_r_code("1 + 1")
   expect_true(grepl("2", result))
+})
+
+test_that("tool_run_r_code describes its process boundary accurately", {
+  expect_match(tool_run_r_code@description, "separate process")
+  expect_match(tool_run_r_code@description, "not an OS security sandbox")
+  expect_false(grepl("sandboxed", tool_run_r_code@description))
 })
 
 test_that("tool_run_r_code captures output", {
@@ -446,7 +451,7 @@ test_that("tool_run_bash handles command not found", {
   expect_true(is.character(result))
 })
 
-test_that("tool_run_r_code requires callr for sandbox", {
+test_that("tool_run_r_code requires callr for process isolation", {
   # Mock is_installed to return FALSE for callr
   local_mocked_bindings(
     is_installed = function(pkg) {


### PR DESCRIPTION
## Summary

- Describe `tool_run_r_code` as a separate callr process used for fault isolation and timeouts.
- State explicitly that process separation is not an operating-system security sandbox.
- Add regression coverage for the model-visible tool description.

## Verification

- `devtools::test()`
- `pkgdown::check_pkgdown()`
- `devtools::check()`
- `air format . --check`
- `git diff --check`
