### PR TITLE
Use standard checks for required feature dependencies

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,9 @@
 # deputy (development version)
 
+* Required packages now report standard installation guidance with the feature
+  that needs them; skill YAML frontmatter no longer silently loses metadata when
+  yaml is unavailable (#57).
+
 * `Agent` is now a governed, drop-in chat: `chat()`, `chat_async()`, `stream()`,
   `stream_async()`, `run_sync()`, and `run_async()` are adapters over one async
   run kernel. The public backend escape hatch and separate `run_shiny()` bridge

--- a/R/output-format.R
+++ b/R/output-format.R
@@ -88,9 +88,7 @@ extract_json_from_text <- function(text) {
     return(list(parsed = NULL, error = "Invalid response text"))
   }
 
-  if (!rlang::is_installed("jsonlite")) {
-    return(list(parsed = NULL, error = "jsonlite package is required"))
-  }
+  rlang::check_installed("jsonlite", reason = "to parse structured output")
 
   parsed <- tryCatch(
     jsonlite::fromJSON(text, simplifyVector = FALSE),

--- a/R/skills.R
+++ b/R/skills.R
@@ -543,7 +543,7 @@ skills_list <- function(path = "skills") {
             ))
           }
         )
-      } else if (file.exists(md_path)) {
+      } else if (file.exists(md_path) && rlang::is_installed("yaml")) {
         parsed <- parse_markdown_frontmatter(md_path)
         name <- parsed$meta$name %||% basename(dir)
       }
@@ -561,9 +561,11 @@ skills_list <- function(path = "skills") {
 
   # Include standalone markdown skills in the root
   for (md_path in md_files) {
-    parsed <- parse_markdown_frontmatter(md_path)
-    name <- parsed$meta$name %||%
-      tools::file_path_sans_ext(basename(md_path))
+    name <- tools::file_path_sans_ext(basename(md_path))
+    if (rlang::is_installed("yaml")) {
+      parsed <- parse_markdown_frontmatter(md_path)
+      name <- parsed$meta$name %||% name
+    }
     skills <- rbind(
       skills,
       data.frame(

--- a/R/skills.R
+++ b/R/skills.R
@@ -294,12 +294,7 @@ skill_load <- function(path, check_requirements = TRUE) {
 
   # Parse SKILL.yaml when present
   if (file.exists(yaml_path)) {
-    if (!rlang::is_installed("yaml")) {
-      cli_abort(c(
-        "Package {.pkg yaml} is required to load SKILL.yaml",
-        "i" = "Install with: {.code install.packages('yaml')}"
-      ))
-    }
+    rlang::check_installed("yaml", reason = "to load SKILL.yaml")
     meta <- yaml::read_yaml(yaml_path)
     if (is.null(meta$name)) {
       cli_abort("SKILL.yaml must contain a 'name' field")

--- a/R/tools-builtin.R
+++ b/R/tools-builtin.R
@@ -78,17 +78,13 @@ read_pdf_text_pages <- function(path) {
     return(text)
   }
 
-  cli_abort(c(
-    "Reading PDF content requires {.pkg pdftools}.",
-    "i" = "Alternatively, install {.pkg reticulate} with the Python module {.pkg pypdf}."
-  ))
+  rlang::check_installed("pdftools", reason = "to read PDF content")
+  pdftools::pdf_text(path)
 }
 
 # Convert a local file to markdown using Python MarkItDown via reticulate
 convert_to_markdown_markitdown <- function(path) {
-  if (!rlang::is_installed("reticulate")) {
-    cli_abort("{.pkg reticulate} is required for MarkItDown conversion.")
-  }
+  rlang::check_installed("reticulate", reason = "for MarkItDown conversion")
 
   available <- tryCatch(
     reticulate::py_module_available("markitdown"),
@@ -176,9 +172,7 @@ parse_multi_edits <- function(edits) {
   parsed <- edits
 
   if (is.character(edits) && length(edits) == 1) {
-    if (!rlang::is_installed("jsonlite")) {
-      cli_abort("Parsing JSON edits requires {.pkg jsonlite}.")
-    }
+    rlang::check_installed("jsonlite", reason = "to parse JSON edits")
 
     parsed <- tryCatch(
       jsonlite::fromJSON(edits, simplifyVector = FALSE),
@@ -333,7 +327,7 @@ tool_read_file <- ellmer::tool(
         )
       },
       error = function(e) {
-        ellmer::tool_reject(paste("Error reading file:", e$message))
+        ellmer::tool_reject(paste("Error reading file:", conditionMessage(e)))
       }
     )
   },
@@ -388,7 +382,7 @@ tool_read_markdown <- ellmer::tool(
       error = function(e) {
         ellmer::tool_reject(paste(
           "Error converting file to markdown:",
-          e$message
+          conditionMessage(e)
         ))
       }
     )
@@ -596,7 +590,7 @@ tool_multi_edit <- ellmer::tool(
         )
       },
       error = function(e) {
-        ellmer::tool_reject(paste("Error applying edits:", e$message))
+        ellmer::tool_reject(paste("Error applying edits:", conditionMessage(e)))
       }
     )
   },
@@ -926,14 +920,7 @@ tool_grep_files <- ellmer::tool(
 )
 
 run_r_code_impl <- function(code, timeout = 30, working_dir = getwd()) {
-  if (!rlang::is_installed("callr")) {
-    ellmer::tool_reject(
-      paste(
-        "Cannot execute R code: package 'callr' is required for",
-        "subprocess execution. Install with install.packages('callr')"
-      )
-    )
-  }
+  rlang::check_installed("callr", reason = "to execute R code in a subprocess")
 
   result <- tryCatch(
     callr::r(

--- a/R/tools-mcp.R
+++ b/R/tools-mcp.R
@@ -152,9 +152,7 @@ tools_mcp_repl <- function(
   ) {
     cli_abort("{.arg server} must be one non-empty string")
   }
-  if (!rlang::is_installed("jsonlite")) {
-    cli_abort("{.pkg jsonlite} is required to validate MCP configuration")
-  }
+  rlang::check_installed("jsonlite", reason = "to validate MCP configuration")
 
   config <- path.expand(
     config %||%

--- a/R/tools-web.R
+++ b/R/tools-web.R
@@ -36,11 +36,7 @@
 #' @export
 tool_web_fetch <- ellmer::tool(
   fun = function(url) {
-    if (!rlang::is_installed("httr2")) {
-      return(ellmer::tool_reject(
-        "Cannot fetch web content: package 'httr2' is required. Install with install.packages('httr2')"
-      ))
-    }
+    rlang::check_installed("httr2", reason = "to fetch web content")
 
     tryCatch(
       {
@@ -133,11 +129,7 @@ tool_web_fetch <- ellmer::tool(
 #' @export
 tool_web_search <- ellmer::tool(
   fun = function(query, num_results = 10) {
-    if (!rlang::is_installed("httr2")) {
-      return(ellmer::tool_reject(
-        "Cannot perform web search: package 'httr2' is required. Install with install.packages('httr2')"
-      ))
-    }
+    rlang::check_installed("httr2", reason = "to search the web")
 
     tryCatch(
       {

--- a/R/utils.R
+++ b/R/utils.R
@@ -586,19 +586,17 @@ parse_markdown_frontmatter <- function(path) {
   meta_lines <- lines[2:(end_idx - 1)]
   body_lines <- lines[(end_idx + 1):length(lines)]
 
-  meta <- list()
-  if (rlang::is_installed("yaml")) {
-    meta <- tryCatch(
-      yaml::read_yaml(text = paste(meta_lines, collapse = "\n")),
-      error = function(e) {
-        cli::cli_warn(c(
-          "Failed to parse YAML frontmatter in {.path {path}}",
-          "x" = e$message
-        ))
-        list()
-      }
-    )
-  }
+  rlang::check_installed("yaml", reason = "to parse skill YAML frontmatter")
+  meta <- tryCatch(
+    yaml::read_yaml(text = paste(meta_lines, collapse = "\n")),
+    error = function(e) {
+      cli::cli_warn(c(
+        "Failed to parse YAML frontmatter in {.path {path}}",
+        "x" = e$message
+      ))
+      list()
+    }
+  )
 
   list(
     meta = meta %||% list(),

--- a/dev/package-check-audit.md
+++ b/dev/package-check-audit.md
@@ -1,0 +1,40 @@
+# Package availability audit (#57)
+
+Audited against main at 64e6c37. The historical issue count has changed as the
+runtime evolved; this covers all availability checks currently in R/.
+
+## Requirements
+
+These paths use `rlang::check_installed()` with a feature-specific reason:
+
+| Path | Package | Requirement |
+| --- | --- | --- |
+| `convert_to_markdown_markitdown()` | reticulate | Execute the requested converter |
+| `parse_multi_edits()` with JSON input | jsonlite | Parse edits; list input needs no package |
+| `run_r_code_impl()` | callr | Preserve subprocess isolation |
+| `tools_mcp_repl()` | jsonlite | Validate MCP configuration |
+| `tool_web_fetch`, `tool_web_search` | httr2 | Execute the HTTP request |
+| `skill_load()` with SKILL.yaml | yaml | Read skill metadata |
+| `parse_markdown_frontmatter()` with frontmatter | yaml | Avoid silently discarding metadata |
+| `extract_json_from_text()` | jsonlite | Parse structured output |
+| `read_pdf_text_pages()` after backend selection fails | pdftools | Offer the preferred backend, then retry reading after interactive installation |
+
+## Branches retained
+
+| Path | Package checks | Alternative behavior |
+| --- | --- | --- |
+| `read_pdf_text_pages()` | pdftools, reticulate | Choose between R and Python PDF backends |
+| `run_bash_impl()` | callr | Existing system-command fallback |
+| CSV tool | readr | Base R CSV reader |
+| `HookRegistry` timeout selection and warning | callr (two sites) | Existing in-process callback with explicit timeout warning |
+| `Skill$check_requirements()` | declared packages | Return an availability report rather than interrupt it |
+| `skills_list()` | yaml | Directory basename when optional YAML name lookup is unavailable |
+| `format_schema_json()` | jsonlite | Text representation for display |
+| `validate_output_schema()` | jsonvalidate | Explicit unknown validity and `schema_validation_skipped`, rather than claiming validity |
+| `extract_web_content()` | rvest, xml2 | Basic HTML extraction |
+| `parse_duckduckgo_results()` | rvest, xml2 | Regex search-result extraction |
+| `has_pandoc()` | rmarkdown | Report unavailable converter so caller can choose another path |
+
+The namespace import directive is not a runtime check. Python-module and system
+executable checks are not R package requirements. Existing fallback policies
+are preserved; this audit does not introduce new timeout or validation policy.

--- a/tests/testthat/_snaps/required-packages.md
+++ b/tests/testthat/_snaps/required-packages.md
@@ -1,0 +1,56 @@
+# required feature dependencies provide installation guidance
+
+    Code
+      tool_web_fetch("https://example.com")
+    Condition
+      Error in `rlang::check_installed()`:
+      ! The package "httr2" (>= 9999) is required to fetch web content
+
+---
+
+    Code
+      tool_web_search("deputy")
+    Condition
+      Error in `rlang::check_installed()`:
+      ! The package "httr2" (>= 9999) is required to search the web
+
+---
+
+    Code
+      tools_mcp_repl()
+    Condition
+      Error in `rlang::check_installed()`:
+      ! The package "jsonlite" (>= 9999) is required to validate MCP configuration
+
+---
+
+    Code
+      parse_multi_edits("[]")
+    Condition
+      Error in `rlang::check_installed()`:
+      ! The package "jsonlite" (>= 9999) is required to parse JSON edits
+
+---
+
+    Code
+      parse_structured_output("{}", list(type = "json_object"))
+    Condition
+      Error in `rlang::check_installed()`:
+      ! The package "jsonlite" (>= 9999) is required to parse structured output
+
+---
+
+    Code
+      skill_load(skill_dir)
+    Condition
+      Error in `rlang::check_installed()`:
+      ! The package "yaml" (>= 9999) is required to load SKILL.yaml
+
+---
+
+    Code
+      parse_markdown_frontmatter(markdown)
+    Condition
+      Error in `rlang::check_installed()`:
+      ! The package "yaml" (>= 9999) is required to parse skill YAML frontmatter
+

--- a/tests/testthat/_snaps/tools.md
+++ b/tests/testthat/_snaps/tools.md
@@ -16,3 +16,11 @@
       Error in `ellmer::tool_reject()`:
       ! Tool call rejected. Command timed out after 0.05 seconds
 
+# tool_run_r_code requires callr for process isolation
+
+    Code
+      tool_run_r_code("1 + 1")
+    Condition
+      Error in `rlang::check_installed()`:
+      ! The package "callr" (>= 9999) is required to execute R code in a subprocess
+

--- a/tests/testthat/test-required-packages.R
+++ b/tests/testthat/test-required-packages.R
@@ -1,0 +1,33 @@
+test_that("required feature dependencies provide installation guidance", {
+  # Exercise real dependency errors without uninstalling loaded packages.
+  check_installed <- rlang::check_installed
+  local_mocked_bindings(
+    check_installed = function(pkg, reason) {
+      check_installed(pkg, reason = reason, version = "9999")
+    },
+    is_interactive = function() FALSE,
+    .package = "rlang"
+  )
+
+  expect_snapshot(error = TRUE, tool_web_fetch("https://example.com"))
+  expect_snapshot(error = TRUE, tool_web_search("deputy"))
+  expect_snapshot(error = TRUE, tools_mcp_repl())
+  expect_snapshot(error = TRUE, parse_multi_edits("[]"))
+  expect_snapshot(
+    error = TRUE,
+    parse_structured_output("{}", list(type = "json_object"))
+  )
+
+  skill_dir <- withr::local_tempdir()
+  writeLines("name: example", file.path(skill_dir, "SKILL.yaml"))
+  expect_snapshot(error = TRUE, skill_load(skill_dir))
+
+  markdown <- file.path(skill_dir, "SKILL.md")
+  writeLines(c("---", "name: example", "---", "Prompt"), markdown)
+  expect_snapshot(error = TRUE, parse_markdown_frontmatter(markdown))
+  writeLines("Prompt without frontmatter", markdown)
+  expect_equal(
+    parse_markdown_frontmatter(markdown)$body,
+    "Prompt without frontmatter"
+  )
+})

--- a/tests/testthat/test-skills.R
+++ b/tests/testthat/test-skills.R
@@ -585,3 +585,21 @@ test_that("Conflicting tool is actually replaced with allow_conflicts = TRUE", {
   )
   expect_equal(desc, "Replacement")
 })
+
+
+test_that("skill discovery preserves basename fallbacks without yaml", {
+  root <- withr::local_tempdir()
+  dir.create(file.path(root, "directory-skill"))
+  writeLines(
+    c("---", "name: metadata-name", "---", "Prompt"),
+    file.path(root, "directory-skill", "SKILL.md")
+  )
+  writeLines(
+    c("---", "name: other-name", "---", "Prompt"),
+    file.path(root, "standalone.md")
+  )
+  local_mocked_bindings(is_installed = function(pkg) FALSE, .package = "rlang")
+  listed <- skills_list(root)
+  expect_setequal(listed$name, c("directory-skill", "standalone"))
+  expect_equal(nrow(listed), 2L)
+})

--- a/tests/testthat/test-tools.R
+++ b/tests/testthat/test-tools.R
@@ -131,9 +131,11 @@ test_that("tool_read_markdown rejects missing files", {
 })
 
 test_that("tool_read_markdown rejects when reticulate is unavailable", {
+  check_installed <- rlang::check_installed
+  local_mocked_bindings(is_interactive = function() FALSE, .package = "rlang")
   local_mocked_bindings(
-    is_installed = function(pkg) {
-      if (pkg == "reticulate") FALSE else TRUE
+    check_installed = function(pkg, reason) {
+      check_installed(pkg, reason = reason, version = "9999")
     },
     .package = "rlang"
   )
@@ -466,20 +468,16 @@ test_that("tool_run_bash handles command not found", {
 })
 
 test_that("tool_run_r_code requires callr for process isolation", {
-  # Mock is_installed to return FALSE for callr
+  check_installed <- rlang::check_installed
+  local_mocked_bindings(is_interactive = function() FALSE, .package = "rlang")
   local_mocked_bindings(
-    is_installed = function(pkg) {
-      if (pkg == "callr") FALSE else TRUE
+    check_installed = function(pkg, reason) {
+      check_installed(pkg, reason = reason, version = "9999")
     },
     .package = "rlang"
   )
 
-  # Should reject because callr is "not installed"
-  # tool_reject throws an error with class ellmer_tool_reject
-  expect_error(
-    tool_run_r_code("1 + 1"),
-    class = "ellmer_tool_reject"
-  )
+  expect_snapshot(error = TRUE, tool_run_r_code("1 + 1"))
 })
 
 # Tool preset tests


### PR DESCRIPTION
## Changes

Required dependency paths now use `rlang::check_installed()` with feature-specific installation guidance. Skill YAML frontmatter can no longer silently lose its metadata when yaml is unavailable. Tool wrappers preserve dynamically formatted dependency errors through `conditionMessage()`.

Audited every current availability check in `dev/package-check-audit.md`. Genuine backend selection, optional display/parsing fallbacks, requirement reporting, and explicitly skipped schema validation retain their existing behavior.

Closes #57

## Validation

- Air formatting and Jarl passed.
- Full test suite: 2,378 passed, six skipped; two warnings from the existing invalid-path write test.
- Focused dependency and tool tests passed.
- R CMD check: zero errors, zero warnings, one NOTE because the sandbox could not verify the current time remotely.
- pkgdown site built successfully.
