### PR TITLE
Document runnable approval-gate recipes

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -39,7 +39,7 @@ deputy/
 │   └── utils.R             # Internal utilities
 ├── tests/testthat/         # Unit tests (testthat edition 3)
 ├── inst/skills/            # Built-in skills with YAML metadata
-├── inst/examples/          # Example apps (e.g., shiny-chat)
+├── inst/examples/          # Runnable recipes and example apps (e.g., shiny-chat)
 ├── exec/deputy.R           # Terminal CLI using Rapp
 ├── vignettes/              # User documentation (R Markdown)
 ├── man/                    # Auto-generated roxygen2 docs

--- a/inst/examples/approval-gates.R
+++ b/inst/examples/approval-gates.R
@@ -1,0 +1,79 @@
+# Source this file to create approval hooks for one Agent.
+# callback(questions, context) must return a named list of answers.
+# Omit callback for an interactive terminal prompt.
+library(deputy)
+
+approval_gate <- function(
+  callback = NULL,
+  pattern = "^(run_bash|write_file)$"
+) {
+  HookMatcher$new(
+    event = "PreToolUse",
+    pattern = pattern,
+    timeout = 0,
+    callback = function(tool_name, tool_input, context) {
+      ask <- tools_interactive(callback = callback, context = context)[[1]]
+      question <- paste0(
+        "Approve ",
+        tool_name,
+        " with these arguments?\n",
+        paste(capture.output(dput(tool_input)), collapse = "\n")
+      )
+      response <- ask(list(list(
+        question = question,
+        header = "Approval",
+        options = list(
+          list(label = "Deny", description = "Do not execute this call"),
+          list(label = "Approve", description = "Execute this exact call")
+        ),
+        multiSelect = FALSE
+      )))
+      approved <- identical(response$answers[[question]], "Approve")
+      HookResultPreToolUse(
+        permission = if (approved) "allow" else "deny",
+        reason = if (!approved) "The user did not approve this call"
+      )
+    }
+  )
+}
+
+# Named tools make the sequence explicit: do not parse arbitrary shell commands
+# to decide whether an installation or push happened.
+approval_after_install <- function(callback = NULL) {
+  installed_runs <- new.env(parent = emptyenv())
+  gate <- approval_gate(callback, pattern = "^push_changes$")
+  list(
+    HookMatcher$new(
+      event = "PostToolUse",
+      pattern = "^install_dependency$",
+      timeout = 0,
+      callback = function(tool_name, tool_result, tool_error, context) {
+        if (is.null(tool_error) && identical(tool_result$installed, TRUE)) {
+          installed_runs[[context$run_id]] <- TRUE
+        }
+        HookResultPostToolUse()
+      }
+    ),
+    HookMatcher$new(
+      event = "PreToolUse",
+      pattern = "^push_changes$",
+      timeout = 0,
+      callback = function(tool_name, tool_input, context) {
+        if (isTRUE(installed_runs[[context$run_id]])) {
+          return(gate$callback(tool_name, tool_input, context))
+        }
+        HookResultPreToolUse(permission = "allow")
+      }
+    ),
+    HookMatcher$new(
+      event = "Stop",
+      timeout = 0,
+      callback = function(reason, context) {
+        if (exists(context$run_id, envir = installed_runs, inherits = FALSE)) {
+          rm(list = context$run_id, envir = installed_runs)
+        }
+        NULL
+      }
+    )
+  )
+}

--- a/inst/examples/approval-gates.R
+++ b/inst/examples/approval-gates.R
@@ -29,9 +29,12 @@ approval_gate <- function(
         multiSelect = FALSE
       )))
       approved <- identical(response$answers[[question]], "Approve")
+      if (approved) {
+        return(NULL)
+      }
       HookResultPreToolUse(
-        permission = if (approved) "allow" else "deny",
-        reason = if (!approved) "The user did not approve this call"
+        permission = "deny",
+        reason = "The user did not approve this call"
       )
     }
   )
@@ -48,10 +51,14 @@ approval_after_install <- function(callback = NULL) {
       pattern = "^install_dependency$",
       timeout = 0,
       callback = function(tool_name, tool_result, tool_error, context) {
-        if (is.null(tool_error) && identical(tool_result$installed, TRUE)) {
+        if (
+          is.null(tool_error) &&
+            is.list(tool_result) &&
+            identical(tool_result$installed, TRUE)
+        ) {
           installed_runs[[context$run_id]] <- TRUE
         }
-        HookResultPostToolUse()
+        NULL
       }
     ),
     HookMatcher$new(
@@ -62,7 +69,7 @@ approval_after_install <- function(callback = NULL) {
         if (isTRUE(installed_runs[[context$run_id]])) {
           return(gate$callback(tool_name, tool_input, context))
         }
-        HookResultPreToolUse(permission = "allow")
+        NULL
       }
     ),
     HookMatcher$new(

--- a/tests/testthat/test-approval-recipes.R
+++ b/tests/testthat/test-approval-recipes.R
@@ -1,0 +1,60 @@
+load_approval_recipes <- function() {
+  env <- new.env(parent = globalenv())
+  sys.source(
+    system.file("examples", "approval-gates.R", package = "deputy"),
+    env
+  )
+  env
+}
+
+test_that("approval recipe fails closed through Agent hooks", {
+  recipes <- load_approval_recipes()
+  for (answer in list("Approve", "Deny", NULL, "approve")) {
+    seen <- NULL
+    handler <- function(questions, context) {
+      seen <<- list(questions = questions, context = context)
+      setNames(list(answer), questions[[1]]$question)
+    }
+    mock <- create_shiny_tool_chat("write_file", list(path = "report.txt"))
+    agent <- Agent$new(
+      chat = mock$chat,
+      tools = list(tool_write_file),
+      permissions = permissions_full()
+    )
+    agent$add_hook(recipes$approval_gate(handler))
+    agent$run_sync("Write a report")
+    expect_identical(mock$state$executed, identical(answer, "Approve"))
+    expect_match(seen$questions[[1]]$question, "report.txt", fixed = TRUE)
+    expect_type(seen$context$run_id, "character")
+  }
+})
+
+test_that("stateful recipe isolates runs and clears completed state", {
+  recipes <- load_approval_recipes()
+  asks <- 0L
+  hooks <- recipes$approval_after_install(function(questions, context) {
+    asks <<- asks + 1L
+    setNames(list("Deny"), questions[[1]]$question)
+  })
+  run <- list(run_id = "one")
+  other <- list(run_id = "two")
+  before_push <- function(context) {
+    hooks[[2]]$callback("push_changes", list(), context)
+  }
+  expect_identical(before_push(run)$permission, "allow")
+  hooks[[1]]$callback(
+    "install_dependency",
+    list(installed = TRUE),
+    "failed",
+    run
+  )
+  expect_identical(before_push(run)$permission, "allow")
+  hooks[[1]]$callback("install_dependency", list(installed = FALSE), NULL, run)
+  expect_identical(before_push(run)$permission, "allow")
+  hooks[[1]]$callback("install_dependency", list(installed = TRUE), NULL, run)
+  expect_identical(before_push(run)$permission, "deny")
+  expect_identical(before_push(other)$permission, "allow")
+  expect_identical(asks, 1L)
+  hooks[[3]]$callback("end_turn", run)
+  expect_identical(before_push(run)$permission, "allow")
+})

--- a/tests/testthat/test-approval-recipes.R
+++ b/tests/testthat/test-approval-recipes.R
@@ -1,5 +1,5 @@
 load_approval_recipes <- function() {
-  env <- new.env(parent = globalenv())
+  env <- new.env(parent = as.environment("package:deputy"))
   sys.source(
     system.file("examples", "approval-gates.R", package = "deputy"),
     env
@@ -41,20 +41,67 @@ test_that("stateful recipe isolates runs and clears completed state", {
   before_push <- function(context) {
     hooks[[2]]$callback("push_changes", list(), context)
   }
-  expect_identical(before_push(run)$permission, "allow")
+  expect_null(before_push(run))
   hooks[[1]]$callback(
     "install_dependency",
     list(installed = TRUE),
     "failed",
     run
   )
-  expect_identical(before_push(run)$permission, "allow")
+  expect_null(before_push(run))
   hooks[[1]]$callback("install_dependency", list(installed = FALSE), NULL, run)
-  expect_identical(before_push(run)$permission, "allow")
+  expect_null(before_push(run))
   hooks[[1]]$callback("install_dependency", list(installed = TRUE), NULL, run)
   expect_identical(before_push(run)$permission, "deny")
-  expect_identical(before_push(other)$permission, "allow")
+  expect_null(before_push(other))
   expect_identical(asks, 1L)
   hooks[[3]]$callback("end_turn", run)
-  expect_identical(before_push(run)$permission, "allow")
+  expect_null(before_push(run))
+})
+
+
+test_that("approval hooks preserve later denials and audit hooks", {
+  recipes <- load_approval_recipes()
+  for (armed in c(FALSE, TRUE)) {
+    agent <- Agent$new(chat = create_mock_chat())
+    hooks <- recipes$approval_after_install(function(questions, context) {
+      setNames(list("Approve"), questions[[1]]$question)
+    })
+    for (hook in hooks) {
+      agent$add_hook(hook)
+    }
+    audited <- 0L
+    agent$add_hook(HookMatcher$new(
+      event = "PostToolUse",
+      callback = function(tool_name, tool_result, tool_error, context) {
+        audited <<- audited + 1L
+        NULL
+      }
+    ))
+    agent$add_hook(HookMatcher$new(
+      event = "PreToolUse",
+      callback = function(tool_name, tool_input, context) {
+        HookResultPreToolUse(permission = "deny", reason = "Later policy")
+      }
+    ))
+    run <- list(run_id = "compose")
+    for (receipt in list("installed", NULL, list(installed = armed))) {
+      agent$hooks$fire(
+        "PostToolUse",
+        tool_name = "install_dependency",
+        tool_result = receipt,
+        tool_error = NULL,
+        context = run
+      )
+    }
+    expect_identical(audited, 3L)
+    expect_length(agent$hooks$last_errors(), 0L)
+    decision <- agent$hooks$fire(
+      "PreToolUse",
+      tool_name = "push_changes",
+      tool_input = list(),
+      context = run
+    )
+    expect_identical(decision$reason, "Later policy")
+  }
 })

--- a/vignettes/hooks.Rmd
+++ b/vignettes/hooks.Rmd
@@ -233,3 +233,80 @@ recent hook errors with:
 ```{r, eval = FALSE}
 agent$hooks$last_errors()
 ```
+
+## Approval before a tool call
+
+The installed recipe defines `approval_gate()` and `approval_after_install()`:
+
+```{r approval-recipe-load, eval = TRUE}
+source(system.file("examples", "approval-gates.R", package = "deputy"))
+```
+
+`approval_gate()` calls the `ask_user` tool from `tools_interactive()` directly
+inside a `PreToolUse` callback. The handler belongs to this hook instance; it
+does not use the process-wide callback. The question includes the exact tool
+name and arguments. Only the exact answer `"Approve"` permits execution;
+missing answers, cancellation, and handler errors cannot approve a call.
+
+Here is an executable dry run with a host that declines the request:
+
+```{r approval-simple-demo, eval = TRUE}
+decline <- function(questions, context) {
+  setNames(list("Deny"), questions[[1]]$question)
+}
+gate <- approval_gate(callback = decline)
+gate$callback(
+  "write_file", list(path = "report.txt", content = "Draft"),
+  context = list(run_id = "example-run")
+)$permission
+```
+
+Attach a fresh hook to an Agent whose permissions already allow the relevant
+operation. Hooks can narrow permissions; approval cannot widen that ceiling.
+In an interactive R terminal, omit `callback` to use the normal user prompt.
+In a hosted application, supply your own synchronous human-input handler.
+This recipe is not a durable pause/resume mechanism.
+
+```{r, eval = FALSE}
+agent$add_hook(approval_gate(callback = my_approval_handler))
+```
+
+## Approval after an earlier installation
+
+Hook context supplies `run_id`, not a mutable history of earlier calls.
+`approval_after_install()` accumulates successful installation receipts in its
+own environment, keyed by that run ID. Its `PreToolUse` callback reads that
+state before `push_changes`; `Stop` removes it. Create a fresh set per Agent.
+The callbacks use `timeout = 0` so they share caller-process state.
+
+This recipe assumes dedicated `install_dependency` and `push_changes` tools.
+The install tool must return `list(installed = TRUE)` only after success.
+A failed install does not arm the gate. Matching arbitrary shell text would
+not reliably identify these operations.
+
+```{r approval-stateful-demo, eval = TRUE}
+hooks <- approval_after_install(callback = decline)
+run <- list(run_id = "installation-run")
+hooks[[1]]$callback(
+  "install_dependency", list(installed = TRUE), NULL, run
+)
+hooks[[2]]$callback("push_changes", list(remote = "origin"), run)$permission
+# A different run has no installation receipt.
+hooks[[2]]$callback(
+  "push_changes", list(remote = "origin"), list(run_id = "another-run")
+)$permission
+hooks[[3]]$callback("end_turn", run)
+```
+
+Attach all three hooks together:
+
+```{r, eval = FALSE}
+for (hook in approval_after_install(callback = my_approval_handler)) {
+  agent$add_hook(hook)
+}
+```
+
+The example returns `"allow"` before an installation because it demonstrates
+that particular sequence policy. Use the unconditional gate if every push
+needs approval. Neither recipe grants permission or performs an installation
+or a push by itself.

--- a/vignettes/hooks.Rmd
+++ b/vignettes/hooks.Rmd
@@ -261,6 +261,12 @@ gate$callback(
 )$permission
 ```
 
+Register approval hooks **before all other matching hooks**, including audit
+and Stop hooks. The registry returns the first non-NULL result, so an earlier
+allow or audit result can bypass a later hook. These recipes return NULL after
+approval, for unarmed gates, and after recording receipts so later hooks still
+run and can deny the call.
+
 Attach a fresh hook to an Agent whose permissions already allow the relevant
 operation. Hooks can narrow permissions; approval cannot widen that ceiling.
 In an interactive R terminal, omit `callback` to use the normal user prompt.
@@ -294,7 +300,7 @@ hooks[[2]]$callback("push_changes", list(remote = "origin"), run)$permission
 # A different run has no installation receipt.
 hooks[[2]]$callback(
   "push_changes", list(remote = "origin"), list(run_id = "another-run")
-)$permission
+)
 hooks[[3]]$callback("end_turn", run)
 ```
 
@@ -306,7 +312,7 @@ for (hook in approval_after_install(callback = my_approval_handler)) {
 }
 ```
 
-The example returns `"allow"` before an installation because it demonstrates
+The example returns `NULL` before an installation because it demonstrates
 that particular sequence policy. Use the unconditional gate if every push
 needs approval. Neither recipe grants permission or performs an installation
 or a push by itself.


### PR DESCRIPTION
## Changes

Add runnable approval recipes using an instance-scoped ask_user tool inside PreToolUse hooks. The unconditional gate shows the requested tool and arguments and accepts only an explicit Approve answer. The stateful recipe requires approval for a dedicated push tool after a successful installation in the same run, and clears state at Stop.

The Hooks vignette executes dry-run examples and explains permission ceilings, synchronous handler requirements, and why arbitrary shell commands are not parsed as policy. Tests exercise allow/deny behavior through Agent hooks and verify failure receipts, run isolation, and cleanup.

Closes #54

## Validation

- Full suite: 2,397 assertions passed; six skips and two existing invalid-path warnings.
- Air and Jarl passed.
- R CMD check: zero errors and warnings; one NOTE for unavailable remote clock verification.
- pkgdown built successfully, including the executable approval examples.

Stacked above #92 using GitHub's native stacked pull requests.
