### PR TITLE
Add standalone examples tested in CI

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -79,6 +79,10 @@ jobs:
           extra-packages: any::rcmdcheck
           needs: check
 
+      - name: Run standalone examples with deterministic provider responses
+        run: testthat::test_local(filter = "standalone-examples", stop_on_failure = TRUE)
+        shell: Rscript {0}
+
       - uses: r-lib/actions/check-r-package@v2
         with:
           upload-snapshots: true

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -39,7 +39,7 @@ deputy/
 │   └── utils.R             # Internal utilities
 ├── tests/testthat/         # Unit tests (testthat edition 3)
 ├── inst/skills/            # Built-in skills with YAML metadata
-├── inst/examples/          # Runnable recipes and example apps (e.g., shiny-chat)
+├── inst/examples/          # Runnable recipes, standalone scripts, and Shiny app
 ├── exec/deputy.R           # Terminal CLI using Rapp
 ├── vignettes/              # User documentation (R Markdown)
 ├── man/                    # Auto-generated roxygen2 docs
@@ -71,6 +71,10 @@ Rscript -e "pak::pak()"
 # Load package for development
 Rscript -e "devtools::load_all()"
 ```
+
+The scripts in `inst/examples/standalone/` are executed by
+`tests/testthat/test-standalone-examples.R` using deterministic provider responses.
+Keep examples independent and use the public Agent APIs.
 
 ## Common Commands
 

--- a/inst/examples/standalone/01-basic.R
+++ b/inst/examples/standalone/01-basic.R
@@ -1,0 +1,13 @@
+# Run with Rscript after installing deputy and setting OPENAI_API_KEY.
+library(deputy)
+chat <- ellmer::chat_openai(
+  model = Sys.getenv("DEPUTY_EXAMPLE_MODEL", "gpt-4o-mini")
+)
+
+agent <- Agent$new(
+  chat = chat,
+  tools = list(),
+  usage_limits = UsageLimits(max_requests = 3)
+)
+result <- agent$run_sync("Explain what an R vector is in one sentence.")
+cli::cli_text("{result$response}")

--- a/inst/examples/standalone/02-tools.R
+++ b/inst/examples/standalone/02-tools.R
@@ -1,0 +1,22 @@
+# Run with Rscript after installing deputy and setting OPENAI_API_KEY.
+library(deputy)
+chat <- ellmer::chat_openai(
+  model = Sys.getenv("DEPUTY_EXAMPLE_MODEL", "gpt-4o-mini")
+)
+
+workspace <- tempfile("deputy-tools-")
+dir.create(workspace)
+writeLines(
+  "Quarterly revenue increased by 12%.",
+  file.path(workspace, "input.txt")
+)
+agent <- Agent$new(
+  chat = chat,
+  tools = list(tool_read_file),
+  permissions = permissions_readonly(),
+  working_dir = workspace,
+  usage_limits = UsageLimits(max_requests = 3, max_tool_calls = 2)
+)
+result <- agent$run_sync("Use read_file to read input.txt, then summarize it.")
+cli::cli_text("{result$response}")
+print(result$tool_calls())

--- a/inst/examples/standalone/03-permissions.R
+++ b/inst/examples/standalone/03-permissions.R
@@ -1,0 +1,21 @@
+# Run with Rscript after installing deputy and setting OPENAI_API_KEY.
+library(deputy)
+chat <- ellmer::chat_openai(
+  model = Sys.getenv("DEPUTY_EXAMPLE_MODEL", "gpt-4o-mini")
+)
+
+workspace <- tempfile("deputy-permissions-")
+dir.create(workspace)
+agent <- Agent$new(
+  chat = chat,
+  tools = list(tool_write_file),
+  permissions = permissions_readonly(),
+  working_dir = workspace,
+  usage_limits = UsageLimits(max_requests = 3, max_tool_calls = 2)
+)
+# Registering a tool does not grant permission to execute it.
+result <- agent$run_sync("Use write_file to write hello to blocked.txt.")
+stopifnot(!file.exists(file.path(workspace, "blocked.txt")))
+cli::cli_text("{result$response}")
+# Switching modes may narrow authority, never widen it.
+print(agent$permissions$check("write_file", list(path = "blocked.txt")))

--- a/inst/examples/standalone/04-hooks.R
+++ b/inst/examples/standalone/04-hooks.R
@@ -1,0 +1,34 @@
+# Run with Rscript after installing deputy and setting OPENAI_API_KEY.
+library(deputy)
+chat <- ellmer::chat_openai(
+  model = Sys.getenv("DEPUTY_EXAMPLE_MODEL", "gpt-4o-mini")
+)
+
+workspace <- tempfile("deputy-hooks-")
+dir.create(workspace)
+writeLines(
+  "Quarterly revenue increased by 12%.",
+  file.path(workspace, "input.txt")
+)
+audit <- list()
+agent <- Agent$new(
+  chat = chat,
+  tools = list(tool_read_file),
+  permissions = permissions_readonly(),
+  working_dir = workspace,
+  usage_limits = UsageLimits(max_requests = 3, max_tool_calls = 2)
+)
+agent$add_hook(HookMatcher$new(
+  event = "PostToolUse",
+  timeout = 0,
+  callback = function(tool_name, tool_result, tool_error, context) {
+    audit[[length(audit) + 1L]] <<- list(
+      tool = tool_name,
+      run_id = context$run_id,
+      error = tool_error
+    )
+    HookResultPostToolUse()
+  }
+))
+result <- agent$run_sync("Use read_file to read input.txt, then summarize it.")
+print(audit)

--- a/inst/examples/standalone/05-delegation.R
+++ b/inst/examples/standalone/05-delegation.R
@@ -1,0 +1,33 @@
+# Run with Rscript after installing deputy and setting OPENAI_API_KEY.
+library(deputy)
+chat <- ellmer::chat_openai(
+  model = Sys.getenv("DEPUTY_EXAMPLE_MODEL", "gpt-4o-mini")
+)
+
+reviewer <- agent_definition(
+  name = "reviewer",
+  description = "Reviews a short R expression",
+  prompt = "Explain correctness concerns in the supplied R code.",
+  tools = list(),
+  permission_mode = "readonly",
+  max_requests = 2
+)
+lead <- LeadAgent$new(
+  chat = chat,
+  sub_agents = list(reviewer),
+  permissions = Permissions$new(
+    mode = "standard",
+    bash = FALSE,
+    r_code = FALSE,
+    file_write = FALSE,
+    web = FALSE,
+    install_packages = FALSE
+  ),
+  usage_limits = UsageLimits(max_requests = 6, max_tool_calls = 2)
+)
+result <- lead$run_sync(paste(
+  "Delegate a review of mean(c(1, NA)) to reviewer using delegate_to_agent.",
+  "Summarize the review."
+))
+cli::cli_text("{result$response}")
+print(lead$list_subagents())

--- a/inst/examples/standalone/06-structured-output.R
+++ b/inst/examples/standalone/06-structured-output.R
@@ -1,5 +1,6 @@
 # Run with Rscript after installing deputy and setting OPENAI_API_KEY.
 library(deputy)
+rlang::check_installed("jsonlite", reason = "to run this example")
 chat <- ellmer::chat_openai(
   model = Sys.getenv("DEPUTY_EXAMPLE_MODEL", "gpt-4o-mini")
 )

--- a/inst/examples/standalone/06-structured-output.R
+++ b/inst/examples/standalone/06-structured-output.R
@@ -1,0 +1,18 @@
+# Run with Rscript after installing deputy and setting OPENAI_API_KEY.
+library(deputy)
+chat <- ellmer::chat_openai(
+  model = Sys.getenv("DEPUTY_EXAMPLE_MODEL", "gpt-4o-mini")
+)
+
+agent <- Agent$new(
+  chat = chat,
+  tools = list(),
+  usage_limits = UsageLimits(max_requests = 3)
+)
+result <- agent$run_sync(
+  'Return a JSON object with status equal to "ok".',
+  output_format = list(type = "json_object")
+)
+# json_object parses JSON; it does not validate a JSON Schema.
+stopifnot(isTRUE(result$structured_output$valid))
+print(result$structured_output$parsed)

--- a/inst/examples/standalone/07-session-resume.R
+++ b/inst/examples/standalone/07-session-resume.R
@@ -1,0 +1,27 @@
+# Run with Rscript after installing deputy and setting OPENAI_API_KEY.
+library(deputy)
+chat <- ellmer::chat_openai(
+  model = Sys.getenv("DEPUTY_EXAMPLE_MODEL", "gpt-4o-mini")
+)
+
+agent <- Agent$new(
+  chat = chat,
+  tools = list(),
+  usage_limits = UsageLimits(max_requests = 3),
+  run_context = list(project = "session-example")
+)
+first <- agent$run_sync("Remember that my example project is called Cedar.")
+session_file <- tempfile(fileext = ".rds")
+agent$save_session(session_file)
+# A new Agent provides the backend and permission ceiling for the resumed chat.
+resumed <- Agent$new(
+  chat = ellmer::chat_openai(
+    model = Sys.getenv("DEPUTY_EXAMPLE_MODEL", "gpt-4o-mini")
+  ),
+  tools = list(),
+  usage_limits = UsageLimits(max_requests = 3)
+)
+resumed$load_session(session_file)
+result <- resumed$run_sync("What is my example project called?")
+cli::cli_text("{result$response}")
+unlink(session_file)

--- a/inst/examples/standalone/08-skills.R
+++ b/inst/examples/standalone/08-skills.R
@@ -1,5 +1,6 @@
 # Run with Rscript after installing deputy and setting OPENAI_API_KEY.
 library(deputy)
+rlang::check_installed("yaml", reason = "to run this example")
 chat <- ellmer::chat_openai(
   model = Sys.getenv("DEPUTY_EXAMPLE_MODEL", "gpt-4o-mini")
 )
@@ -24,3 +25,5 @@ agent <- Agent$new(
 agent$load_skill(skill_dir)
 result <- agent$run_sync("Review mean(c(1, NA)).")
 cli::cli_text("{result$response}")
+
+unlink(skill_dir, recursive = TRUE)

--- a/inst/examples/standalone/08-skills.R
+++ b/inst/examples/standalone/08-skills.R
@@ -1,0 +1,26 @@
+# Run with Rscript after installing deputy and setting OPENAI_API_KEY.
+library(deputy)
+chat <- ellmer::chat_openai(
+  model = Sys.getenv("DEPUTY_EXAMPLE_MODEL", "gpt-4o-mini")
+)
+
+skill_dir <- tempfile("deputy-skill-")
+dir.create(skill_dir)
+writeLines(
+  c(
+    "---",
+    "name: concise-review",
+    "description: Concise R reviews",
+    "---",
+    "Review code in two bullets: correctness, then readability."
+  ),
+  file.path(skill_dir, "SKILL.md")
+)
+agent <- Agent$new(
+  chat = chat,
+  tools = list(),
+  usage_limits = UsageLimits(max_requests = 3)
+)
+agent$load_skill(skill_dir)
+result <- agent$run_sync("Review mean(c(1, NA)).")
+cli::cli_text("{result$response}")

--- a/inst/examples/standalone/README.md
+++ b/inst/examples/standalone/README.md
@@ -1,7 +1,10 @@
 # Standalone Deputy examples
 
 Install the development versions of deputy and its ellmer dependency, set
-`OPENAI_API_KEY`, and run any script independently with `Rscript`. Live runs
+`OPENAI_API_KEY`, and run any script independently with `Rscript`. Install the
+optional packages `jsonlite` (structured output) and `yaml` (skills), for example
+with `install.packages(c("jsonlite", "yaml"))`. Those scripts check these
+dependencies before creating a chat. Live runs
 make billable model requests. Set `DEPUTY_EXAMPLE_MODEL` to choose another
 OpenAI model supported by your account.
 

--- a/inst/examples/standalone/README.md
+++ b/inst/examples/standalone/README.md
@@ -1,0 +1,37 @@
+# Standalone Deputy examples
+
+Install the development versions of deputy and its ellmer dependency, set
+`OPENAI_API_KEY`, and run any script independently with `Rscript`. Live runs
+make billable model requests. Set `DEPUTY_EXAMPLE_MODEL` to choose another
+OpenAI model supported by your account.
+
+```r
+example <- system.file("examples", "standalone", "01-basic.R", package = "deputy")
+source(example)
+```
+
+| Script | Demonstrates |
+| --- | --- |
+| 01-basic.R | Bounded run and final text |
+| 02-tools.R | Read an actual temporary file and inspect tool calls |
+| 03-permissions.R | A registered write tool remains denied in readonly mode |
+| 04-hooks.R | Capture an audit record in the caller process |
+| 05-delegation.R | LeadAgent and a bounded readonly reviewer |
+| 06-structured-output.R | Parse a JSON object with jsonlite |
+| 07-session-resume.R | Save, load into a fresh Agent, and continue |
+| 08-skills.R | Load YAML skill metadata and prompt with yaml |
+
+Scripts create their own temporary data and do not depend on the current
+working directory or on one another. File examples print or retain their
+temporary workspace paths in `workspace` for inspection. Session snapshots are
+removed after loading. Model wording and tool selection can vary in live runs.
+
+The package tests execute these same files in separate R environments with
+scripted provider responses. They exercise Agent runs, tool execution/denial,
+hook effects, delegation, structured parsing, session restoration, and skill
+loading without network calls. The regular R CMD check CI runs those tests on
+Linux, macOS, and Windows. This verifies the examples' runtime contracts, not
+live model quality.
+
+For synchronous human approval and stateful gates, see `../approval-gates.R`
+and the Hooks vignette.

--- a/tests/testthat/helper-runtime.R
+++ b/tests/testthat/helper-runtime.R
@@ -2,7 +2,8 @@ create_content_stream_chat <- function(
   tool_name = "read_file",
   tool_result = "contents",
   final_text = "done",
-  execute = NULL
+  execute = NULL,
+  use_execution_result = FALSE
 ) {
   state <- new.env(parent = emptyenv())
   state$turns <- list()
@@ -83,7 +84,13 @@ create_content_stream_chat <- function(
             )
             returned_result <- if (is.null(rejected)) {
               if (!is.null(execute)) {
-                execute(request)
+                value <- execute(request)
+                if (use_execution_result) {
+                  result <- ellmer::ContentToolResult(
+                    value = value,
+                    request = request
+                  )
+                }
               }
               state$tool_executed <- TRUE
               result
@@ -138,7 +145,8 @@ create_content_stream_chat <- function(
           tool_name = tool_name,
           tool_result = tool_result,
           final_text = final_text,
-          execute = execute
+          execute = execute,
+          use_execution_result = use_execution_result
         )$chat
       }
     ),

--- a/tests/testthat/test-standalone-examples.R
+++ b/tests/testthat/test-standalone-examples.R
@@ -1,0 +1,94 @@
+run_standalone_example <- function(
+  name,
+  chat,
+  env = new.env(parent = globalenv())
+) {
+  local_mocked_bindings(chat_openai = function(...) chat, .package = "ellmer")
+  path <- system.file("examples", "standalone", name, package = "deputy")
+  sys.source(path, envir = env)
+  env
+}
+
+test_that("basic, structured, session and skill scripts execute independently", {
+  skip_if_not_installed("jsonlite")
+  skip_if_not_installed("yaml")
+  basic <- run_standalone_example(
+    "01-basic.R",
+    create_mock_chat("An R vector.")
+  )
+  expect_identical(basic$result$response, "An R vector.")
+  structured <- run_standalone_example(
+    "06-structured-output.R",
+    create_mock_chat('{"status":"ok"}')
+  )
+  expect_identical(structured$result$structured_output$parsed$status, "ok")
+  session_chat <- create_mock_chat("Cedar")
+  saved_turns <- list(
+    create_mock_user_turn("My project is Cedar."),
+    create_mock_assistant_turn("I will remember Cedar.")
+  )
+  session_chat$set_turns(saved_turns)
+  session <- run_standalone_example("07-session-resume.R", session_chat)
+  expect_equal(session$resumed$get_turns(), saved_turns)
+  expect_identical(session$resumed$run_context$project, "session-example")
+  expect_identical(session$result$response, "Cedar")
+  expect_false(file.exists(session$session_file))
+  skill <- run_standalone_example(
+    "08-skills.R",
+    create_mock_chat("Two review bullets.")
+  )
+  expect_length(skill$agent$skills, 1L)
+  expect_match(
+    skill$agent$get_system_prompt(),
+    "correctness, then readability",
+    fixed = TRUE
+  )
+})
+
+test_that("file and hook examples perform the requested read", {
+  for (name in c("02-tools.R", "04-hooks.R")) {
+    env <- new.env(parent = globalenv())
+    read <- NULL
+    mock <- create_content_stream_chat(execute = function(request) {
+      read <<- tool_read_file(file.path(env$workspace, request@arguments$path))
+    })
+    example <- run_standalone_example(name, mock$chat, env)
+    expect_match(read, "revenue increased by 12%", fixed = TRUE)
+    expect_identical(mock$state$tool_executed, TRUE)
+    if (name == "04-hooks.R") {
+      expect_length(example$audit, 1L)
+      expect_identical(example$audit[[1]]$tool, "read_file")
+      expect_type(example$audit[[1]]$run_id, "character")
+    }
+  }
+})
+
+test_that("permissions example blocks a real attempted write", {
+  mock <- create_shiny_tool_chat(
+    "write_file",
+    list(path = "blocked.txt", content = "hello")
+  )
+  example <- run_standalone_example("03-permissions.R", mock$chat)
+  expect_identical(mock$state$rejected, TRUE)
+  expect_false(file.exists(file.path(example$workspace, "blocked.txt")))
+})
+
+test_that("delegation example runs its registered reviewer during the lead run", {
+  env <- new.env(parent = globalenv())
+  mock <- create_shiny_tool_chat(
+    "delegate_to_agent",
+    list(agent_name = "reviewer", task = "Review mean(c(1, NA))."),
+    execute = function(request) {
+      resolve_async_value(env$lead$get_tools()[["delegate_to_agent"]](
+        "reviewer",
+        "Review mean(c(1, NA))."
+      ))
+    }
+  )
+  example <- run_standalone_example("05-delegation.R", mock$chat, env)
+  expect_null(mock$state$rejection)
+  runs <- example$lead$list_subagents()
+  expect_equal(nrow(runs), 1L)
+  expect_identical(runs$agent_name, "reviewer")
+  expect_identical(runs$status, "completed")
+})

--- a/tests/testthat/test-standalone-examples.R
+++ b/tests/testthat/test-standalone-examples.R
@@ -1,9 +1,12 @@
 run_standalone_example <- function(
   name,
   chat,
-  env = new.env(parent = globalenv())
+  env = new.env(parent = as.environment("package:deputy"))
 ) {
-  local_mocked_bindings(chat_openai = function(...) chat, .package = "ellmer")
+  local_mocked_bindings(
+    chat_openai = function(...) if (is.function(chat)) chat() else chat,
+    .package = "ellmer"
+  )
   path <- system.file("examples", "standalone", name, package = "deputy")
   sys.source(path, envir = env)
   env
@@ -22,14 +25,35 @@ test_that("basic, structured, session and skill scripts execute independently", 
     create_mock_chat('{"status":"ok"}')
   )
   expect_identical(structured$result$structured_output$parsed$status, "ok")
-  session_chat <- create_mock_chat("Cedar")
-  saved_turns <- list(
-    create_mock_user_turn("My project is Cedar."),
-    create_mock_assistant_turn("I will remember Cedar.")
-  )
-  session_chat$set_turns(saved_turns)
-  session <- run_standalone_example("07-session-resume.R", session_chat)
-  expect_equal(session$resumed$get_turns(), saved_turns)
+  source_chat <- create_mock_chat("I will remember Cedar.")
+  source_stream <- source_chat$stream
+  source_chat$stream <- function(prompt) {
+    source_chat$set_turns(list(
+      create_mock_user_turn(prompt),
+      create_mock_assistant_turn("I will remember Cedar.")
+    ))
+    source_stream(prompt)
+  }
+  receiver_chat <- create_mock_chat("Cedar")
+  receiver_stream <- receiver_chat$stream
+  receiver_chat$stream <- function(prompt) {
+    history <- receiver_chat$get_turns()
+    if (length(history) != 2L) {
+      rlang::abort("Session turns were not restored")
+    }
+    if (!grepl("Cedar", history[[1]]@contents[[1]]@text, fixed = TRUE)) {
+      rlang::abort("Project name was not restored")
+    }
+    receiver_stream(prompt)
+  }
+  chats <- list(source_chat, receiver_chat)
+  index <- 0L
+  session <- run_standalone_example("07-session-resume.R", function() {
+    index <<- index + 1L
+    chats[[index]]
+  })
+  expect_equal(receiver_chat$get_turns(), source_chat$get_turns())
+  expect_identical(index, 2L)
   expect_identical(session$resumed$run_context$project, "session-example")
   expect_identical(session$result$response, "Cedar")
   expect_false(file.exists(session$session_file))
@@ -47,14 +71,26 @@ test_that("basic, structured, session and skill scripts execute independently", 
 
 test_that("file and hook examples perform the requested read", {
   for (name in c("02-tools.R", "04-hooks.R")) {
-    env <- new.env(parent = globalenv())
+    env <- new.env(parent = as.environment("package:deputy"))
     read <- NULL
-    mock <- create_content_stream_chat(execute = function(request) {
-      read <<- tool_read_file(file.path(env$workspace, request@arguments$path))
-    })
+    mock <- create_content_stream_chat(
+      use_execution_result = TRUE,
+      execute = function(request) {
+        read <<- do.call(
+          env$agent$get_tools()[["read_file"]],
+          request@arguments
+        )
+        read
+      }
+    )
     example <- run_standalone_example(name, mock$chat, env)
     expect_match(read, "revenue increased by 12%", fixed = TRUE)
     expect_identical(mock$state$tool_executed, TRUE)
+    expect_match(
+      as.character(example$result$tool_results()[[1]]$tool_result),
+      "revenue increased by 12%",
+      fixed = TRUE
+    )
     if (name == "04-hooks.R") {
       expect_length(example$audit, 1L)
       expect_identical(example$audit[[1]]$tool, "read_file")
@@ -74,7 +110,7 @@ test_that("permissions example blocks a real attempted write", {
 })
 
 test_that("delegation example runs its registered reviewer during the lead run", {
-  env <- new.env(parent = globalenv())
+  env <- new.env(parent = as.environment("package:deputy"))
   mock <- create_shiny_tool_chat(
     "delegate_to_agent",
     list(agent_name = "reviewer", task = "Review mean(c(1, NA))."),

--- a/vignettes/getting-started.Rmd
+++ b/vignettes/getting-started.Rmd
@@ -241,3 +241,21 @@ from that same path.
 The durable pattern is the same in every host: make the workspace, tools,
 permissions, and limits explicit; run one bounded job; then inspect the typed
 result before granting more authority.
+
+
+## Standalone scripts
+
+The package includes eight independent scripts for basic runs, tools,
+permissions, hooks, delegation, structured output, session resume, and skills.
+They are executed in CI with deterministic provider responses. To run one
+against OpenAI, set `OPENAI_API_KEY` and source the installed file:
+
+```{r, eval = FALSE}
+source(system.file("examples", "standalone", "01-basic.R", package = "deputy"))
+```
+
+Find the other scripts and their setup guide with:
+
+```{r, eval = FALSE}
+list.files(system.file("examples", "standalone", package = "deputy"))
+```


### PR DESCRIPTION
## Changes

Ship eight independent scripts covering basic runs, file tools, permission denial, hook auditing, delegation, structured output, session resume, and skills. Each includes its setup and bounded Agent configuration; Getting Started points to the installed examples.

CI executes the shipped scripts with deterministic provider responses on Linux, macOS, and Windows. Tests check actual file reads, denied writes, hook records, a completed delegated child run, JSON parsing, restored session turns/context, and loaded skill prompts. Live runs use the user's OpenAI credentials; CI requires no model access.

Closes #55

## Validation

- Full suite: 2,418 assertions passed; six skips and two existing invalid-path warnings.
- Focused standalone examples: 21 assertions passed.
- Air and Jarl passed.

Stacked above the approval recipe layer using GitHub's native stacked pull requests.
- R CMD check: zero errors and warnings; one NOTE for unavailable remote clock verification.
- pkgdown built successfully.
- Exact standalone-example CI command passed locally.
