### PR TITLE
Skip unsupported automatic Claude review on fork PRs

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -12,12 +12,8 @@ on:
 
 jobs:
   claude-review:
-    # Optional: Filter by PR author
-    # if: |
-    #   github.event.pull_request.user.login == 'external-contributor' ||
-    #   github.event.pull_request.user.login == 'new-developer' ||
-    #   github.event.pull_request.author_association == 'FIRST_TIME_CONTRIBUTOR'
-
+    # Fork pull_request runs cannot supply the credentials/OIDC this action needs.
+    if: github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -42,3 +38,18 @@ jobs:
           # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
           # or https://code.claude.com/docs/en/cli-reference for available options
 
+  fork-review-notice:
+    if: github.event.pull_request.head.repo.full_name != github.repository
+    runs-on: ubuntu-latest
+    permissions: {}
+    steps:
+      - name: Explain unsupported automatic fork review
+        run: |
+          cat >> "$GITHUB_STEP_SUMMARY" <<'EOF'
+          ### Claude review skipped for a fork pull request
+
+          Automatic Claude review requires credentials unavailable to fork PR workflows.
+          A maintainer must review this PR manually. Other configured CI checks still run.
+
+          This job does not check out PR code, request an OIDC token, or access repository secrets.
+          EOF

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -516,3 +516,11 @@ GitHub Actions workflows in `.github/workflows/`:
 - `pkgdown.yaml` - Documentation site
 - `format-suggest.yaml` - Code formatting suggestions
 - `claude.yml` / `claude-code-review.yml` - Claude integration
+
+The automatic Claude review workflow runs only for PR branches in this
+repository. Fork PRs receive an explicit skip explanation in the workflow
+summary and require maintainer review; their ordinary CI still runs. The fork
+notice has no token permissions, checkout, or secrets. Keep this workflow on
+`pull_request`; do not use a privileged fork checkout to bypass authentication
+restrictions. This policy applies to automatic review, not the separate
+mention-triggered Claude workflow.


### PR DESCRIPTION
Fork pull requests currently fail before Claude can review because the workflow cannot obtain its required credentials/OIDC. Gate automatic Claude review on a same-repository PR head and give forks a separate, explicit skip summary requesting maintainer review.

The fork notice has no token permissions, checkout, secrets, or Claude action. The workflow keeps the pull_request trigger, and other CI remains unchanged. CLAUDE.md documents this automatic-review policy.

Closes #91

Validation: actionlint 1.7.7 passed; YAML structure and notice shell syntax checked; notice script smoke-tested. Air and Jarl passed. All 2,429 package assertions passed, with six dependency/credential skips and two existing invalid-path test warnings. An actual fork event was not created; GitHub will exercise that branch on the next fork PR.

R CMD check: zero errors and warnings, one NOTE for unavailable remote clock verification. The pkgdown documentation build passed.
