### PR TITLE
Validate tool registration and require explicit replacement

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -36,6 +36,7 @@ deputy/
 │   ├── tools-bundles.R     # Tool presets (minimal, standard, dev, data, full)
 │   ├── tools-interactive.R # tool_ask_user for human-in-the-loop
 │   ├── tools-mcp.R         # MCP discovery and sandboxed mcp-repl boundary
+│   ├── tool-registration.R # Batch validation and annotation defaults
 │   ├── errors.R            # Custom error hierarchy
 │   └── utils.R             # Internal utilities
 ├── tests/testthat/         # Unit tests (testthat edition 3)
@@ -293,6 +294,13 @@ other concurrent hosts.
 - `tools_preset("dev")` - + trusted run_r_code and run_bash
 - `tools_preset("data")` - read_file, list_files, read_csv, run_r_code
 - `tools_preset("full")` - all built-in tools
+
+Registration uses ellmer tool definitions for local functions, package exports,
+and service tools. Names must be unique; `register_tool(..., replace = TRUE)`
+and `register_tools(..., replace = TRUE)` explicitly replace existing names.
+The complete batch is validated before changing the Chat's tools, including
+constructor and `set_tools()` paths. Missing custom-tool annotations remain
+absent on the source but use conservative permission defaults (ADR-0007).
 
 ### Hook Events
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,12 @@
 # deputy (development version)
 
+* Tool registration validates complete batches before changing the registry.
+  Duplicate names now fail unless the host explicitly uses `replace = TRUE`;
+  duplicate names within a batch always fail. Constructor tools, skills,
+  and `set_tools()` share validation. Missing custom-tool annotations remain
+  visible and use conservative permission defaults, including possible
+  external access (#49).
+
 * `agent_definition_read()`, `agent_definition_write()`, and
   `agent_definitions()` add portable YAML definitions, explicit tool/skill
   registries, and discovery from `.deputy/agents/` (#41).

--- a/R/agent.R
+++ b/R/agent.R
@@ -232,13 +232,13 @@ Agent <- R6::R6Class(
       # Rebind all tools to this Agent's runtime authority, including tools
       # configured on the supplied Chat before Agent construction.
       backend_tools <- private$.chat$get_tools()
-      if (length(backend_tools) > 0) {
-        private$.chat$set_tools(list())
-        self$register_tools(backend_tools)
-      }
-      if (length(tools) > 0) {
-        self$register_tools(tools)
-      }
+      backend_tools <- validate_tool_batch(
+        backend_tools,
+        preserve_reader = TRUE
+      )
+      tools <- validate_tool_batch(tools, existing = backend_tools)
+      wrapped <- lapply(c(backend_tools, tools), private$adapt_tool)
+      private$.chat$set_tools(wrapped)
 
       # Wire up ellmer's callbacks for permission/hook enforcement
       private$.chat$on_tool_request(private$handle_tool_request)
@@ -645,13 +645,13 @@ Agent <- R6::R6Class(
     #' @return Invisible self.
     set_tools = function(tools) {
       had_result_reader <- isTRUE(private$.tool_result_reader_registered)
-      tools[["deputy_read_tool_result"]] <- NULL
-      private$.chat$set_tools(list())
-      private$.tool_result_reader_registered <- FALSE
-      self$register_tools(tools)
+      tools <- validate_tool_batch(tools, preserve_reader = TRUE)
+      wrapped <- lapply(tools, private$adapt_tool)
       if (had_result_reader) {
-        private$ensure_tool_result_reader()
+        wrapped[["deputy_read_tool_result"]] <-
+          private$.chat$get_tools()[["deputy_read_tool_result"]]
       }
+      private$.chat$set_tools(wrapped)
       invisible(self)
     },
 
@@ -717,12 +717,16 @@ Agent <- R6::R6Class(
     #' because their execution occurs inside the provider rather than R. Native
     #' tools therefore require static permissions and cannot be registered with
     #' a custom `can_use_tool` callback.
+    #' Existing names require explicit replacement. Every tool in a batch is
+    #' validated and adapted before the registry changes. List element names
+    #' do not rename tools; each tool's own name is authoritative.
     #' @param tool A tool created with `ellmer::tool()` or a supported
     #'   provider-native web tool.
+    #' @param replace Replace tools already registered under the same name?
+    #'   Defaults to FALSE. Duplicate names within a batch always fail.
     #' @return Invisible self for chaining
-    register_tool = function(tool) {
-      private$.chat$register_tool(private$adapt_tool(tool))
-      invisible(self)
+    register_tool = function(tool, replace = FALSE) {
+      self$register_tools(list(tool), replace = replace)
     },
 
     #' @description
@@ -730,10 +734,15 @@ Agent <- R6::R6Class(
     #'
     #' @param tools A list of function tools or supported provider-native web
     #'   tools.
+    #' @param replace Replace tools already registered under the same name?
+    #'   Defaults to FALSE. Duplicate names within a batch always fail.
     #' @return Invisible self for chaining
-    register_tools = function(tools) {
+    register_tools = function(tools, replace = FALSE) {
+      existing <- private$.chat$get_tools()
+      tools <- validate_tool_batch(tools, existing, replace = replace)
       wrapped <- lapply(tools, private$adapt_tool)
-      private$.chat$register_tools(wrapped)
+      existing[names(wrapped)] <- wrapped
+      private$.chat$set_tools(existing)
       invisible(self)
     },
 
@@ -1441,7 +1450,7 @@ Agent <- R6::R6Class(
           }
         }
 
-        self$register_tools(skill$tools)
+        self$register_tools(skill$tools, replace = allow_conflicts)
       }
 
       # Append prompt to system prompt
@@ -1808,12 +1817,8 @@ Agent <- R6::R6Class(
       tools <- private$.chat$get_tools()
       had_result_reader <- "deputy_read_tool_result" %in% names(tools)
       tools[["deputy_read_tool_result"]] <- NULL
-      private$.chat$set_tools(list())
-      if (length(tools) > 0L) {
-        private$.chat$register_tools(
-          lapply(tools, private$prepare_cloned_tool)
-        )
-      }
+      tools <- validate_tool_batch(tools)
+      private$.chat$set_tools(lapply(tools, private$prepare_cloned_tool))
       private$.tool_result_reader_registered <- FALSE
       if (isTRUE(had_result_reader)) {
         private$ensure_tool_result_reader()
@@ -3794,11 +3799,13 @@ Agent <- R6::R6Class(
         object = request
       )
 
-      # Tool annotations
+      # Resolve annotations from the registered executable. Providers may omit
+      # the tool object or attach a stale copy to the request.
+      registered_tool <- private$.chat$get_tools()[[tool_name]]
       tool_annotations <- tryCatch(
         {
-          if (!is.null(request@tool)) {
-            request@tool@annotations
+          if (!is.null(registered_tool)) {
+            registered_tool@annotations
           } else {
             NULL
           }
@@ -3810,10 +3817,10 @@ Agent <- R6::R6Class(
       )
       internal_tool <- tryCatch(
         {
-          if (is.null(request@tool)) {
+          if (is.null(registered_tool)) {
             NULL
           } else {
-            attr(request@tool, "deputy_internal_tool", exact = TRUE)
+            attr(registered_tool, "deputy_internal_tool", exact = TRUE)
           }
         },
         error = function(e) NULL

--- a/R/agents-multi.R
+++ b/R/agents-multi.R
@@ -762,6 +762,9 @@ LeadAgent <- R6::R6Class(
           {
             cloned <- private$.chat$clone()
             cloned$set_turns(list())
+            # The child definition chooses its tools. Inherited provider
+            # configuration must not import the parent's executable registry.
+            cloned$set_tools(list())
             cloned
           },
           error = function(e) {

--- a/R/agents-multi.R
+++ b/R/agents-multi.R
@@ -743,7 +743,9 @@ LeadAgent <- R6::R6Class(
         ),
         annotations = ellmer::tool_annotations(
           read_only_hint = FALSE,
-          destructive_hint = FALSE
+          destructive_hint = FALSE,
+          open_world_hint = FALSE,
+          idempotent_hint = FALSE
         )
       )
     },

--- a/R/permissions.R
+++ b/R/permissions.R
@@ -29,7 +29,7 @@
 #' Tools with `destructive_hint = TRUE` require explicit permission.
 #' Examples: `tool_write_file`, `tool_delete_file`, `tool_run_bash`
 #'
-#' **open_world_hint** (logical, default: FALSE)
+#' **open_world_hint** (logical, default: TRUE)
 #'
 #' Indicates the tool may interact with external systems.
 #' Used for network calls, package installation, etc.
@@ -38,7 +38,15 @@
 #' **idempotent_hint** (logical, default: FALSE)
 #'
 #' Indicates repeated calls produce the same result.
-#' Safe to retry on failure.
+#' This annotation alone does not authorize automatic retries.
+#'
+#' Missing annotations remain absent on the tool. For custom tools, permission
+#' checks assume modification, possible destruction, external access, and no
+#' idempotence unless stated otherwise. If `read_only_hint = TRUE`, an omitted
+#' destructive annotation is ignored; an explicit TRUE still denies read-only
+#' use. Native tools continue to require their named capabilities. A custom
+#' permission callback can explicitly authorize a tool in standard mode;
+#' full mode bypasses annotation checks but still honors tool gating.
 #'
 #' @section Creating Tools with Annotations:
 #'
@@ -51,7 +59,8 @@
 #'   arguments = list(pattern = ellmer::type_string("Search pattern")),
 #'   annotations = ellmer::tool_annotations(
 #'     read_only_hint = TRUE,
-#'     destructive_hint = FALSE
+#'     destructive_hint = FALSE,
+#'     open_world_hint = FALSE
 #'   )
 #' )
 #'
@@ -508,6 +517,13 @@ Permissions <- R6::R6Class(
 
       # Extract tool annotations from context if available
       annotations <- context$tool_annotations
+      if (
+        !normalize_native_tool_id(tool_name) %in%
+          permission_native_capability_tool_ids &&
+          !isTRUE(allowlist_exempt)
+      ) {
+        annotations <- effective_tool_annotations(annotations)
+      }
 
       if (self$mode == "readonly") {
         tool_id <- normalize_native_tool_id(tool_name)
@@ -1091,8 +1107,8 @@ Permissions <- R6::R6Class(
         return(PermissionResultAllow())
       }
 
-      # For unknown tools, use annotations if available
-      annotations <- context$tool_annotations
+      # Unknown tools use conservative defaults for every missing annotation.
+      annotations <- effective_tool_annotations(context$tool_annotations)
       if (!is.null(annotations)) {
         # Destructive tools need explicit permission
         if (isTRUE(annotations$destructive_hint)) {
@@ -1116,7 +1132,7 @@ Permissions <- R6::R6Class(
         }
       }
 
-      # Default: allow unknown tools without destructive annotations
+      # The tool passed the effective annotation capability checks.
       PermissionResultAllow()
     },
 
@@ -1142,7 +1158,7 @@ Permissions <- R6::R6Class(
       }
 
       # Plan mode is intentionally conservative: no annotation means deny.
-      if (is.null(annotations)) {
+      if (length(annotations) == 0L) {
         return(PermissionResultDeny(
           reason = paste0(
             "Plan mode only allows annotated read-only tools. ",
@@ -1150,6 +1166,10 @@ Permissions <- R6::R6Class(
             " has no annotations."
           )
         ))
+      }
+
+      if (!is_permission_native_capability_tool(tool_name)) {
+        annotations <- effective_tool_annotations(annotations)
       }
 
       if (isTRUE(annotations$destructive_hint)) {

--- a/R/tool-registration.R
+++ b/R/tool-registration.R
@@ -1,0 +1,132 @@
+# Tool registration -------------------------------------------------------
+
+tool_annotation_defaults <- list(
+  read_only_hint = FALSE,
+  destructive_hint = TRUE,
+  idempotent_hint = FALSE,
+  open_world_hint = TRUE
+)
+
+effective_tool_annotations <- function(annotations) {
+  effective <- tool_annotation_defaults
+  supplied <- annotations[!vapply(annotations, is.null, logical(1))]
+  effective[names(supplied)] <- supplied
+  # MCP defines destructive/idempotent annotations only for modifying tools.
+  # Retain an explicit destructive claim so contradictory metadata cannot
+  # weaken a permission check.
+  if (
+    isTRUE(effective$read_only_hint) && is.null(annotations$destructive_hint)
+  ) {
+    effective$destructive_hint <- FALSE
+  }
+  effective
+}
+
+tool_registration_error <- function(message, ..., .envir = parent.frame()) {
+  abort_deputy(
+    message,
+    class = c("tool_registration", "tool"),
+    ...,
+    .envir = .envir
+  )
+}
+
+validate_tool_annotations <- function(annotations, tool_name) {
+  if (is.null(annotations) || identical(annotations, list())) {
+    return(invisible(NULL))
+  }
+  if (
+    !is.list(annotations) ||
+      is.null(names(annotations)) ||
+      anyNA(names(annotations)) ||
+      anyDuplicated(names(annotations)) ||
+      !all(nzchar(names(annotations)))
+  ) {
+    tool_registration_error(
+      "Annotations for tool {.val {tool_name}} must be a uniquely named list."
+    )
+  }
+  for (field in c(
+    "read_only_hint",
+    "destructive_hint",
+    "idempotent_hint",
+    "open_world_hint"
+  )) {
+    value <- annotations[[field]]
+    if (!is.null(value) && !rlang::is_bool(value)) {
+      tool_registration_error(
+        "Annotation {.val {field}} for tool {.val {tool_name}} must be TRUE or FALSE."
+      )
+    }
+  }
+  title <- annotations$title
+  if (!is.null(title) && !is_nonempty_string(title)) {
+    tool_registration_error(
+      "Annotation {.val title} for tool {.val {tool_name}} must be one non-empty string."
+    )
+  }
+  invisible(NULL)
+}
+
+validate_tool_batch <- function(
+  tools,
+  existing = list(),
+  replace = FALSE,
+  preserve_reader = FALSE
+) {
+  if (!rlang::is_bool(replace)) {
+    tool_registration_error("{.arg replace} must be TRUE or FALSE.")
+  }
+  if (!is.list(tools)) {
+    tool_registration_error(
+      "{.arg tools} must be a list of ellmer tool definitions."
+    )
+  }
+  result <- list()
+  for (index in seq_along(tools)) {
+    tool <- tools[[index]]
+    if (!inherits(tool, c("ellmer::ToolDef", "ellmer::ToolBuiltIn"))) {
+      tool_registration_error(
+        "Tool at position {index} must be an ellmer tool definition."
+      )
+    }
+    # Re-register the executable source, not an old Agent's runtime wrapper.
+    tool <- attr(tool, "deputy_runtime_source_tool", exact = TRUE) %||% tool
+    name <- tool@name
+    if (!is_nonempty_string(name)) {
+      tool_registration_error(
+        "Tool at position {index} must have a non-empty name."
+      )
+    }
+    if (identical(name, "deputy_read_tool_result")) {
+      if (
+        isTRUE(preserve_reader) &&
+          identical(
+            attr(tool, "deputy_internal_tool", exact = TRUE),
+            deputy_tool_result_reader_marker
+          )
+      ) {
+        next
+      }
+      tool_registration_error("Tool name {.val {name}} is reserved by Deputy.")
+    }
+    if (name %in% names(result)) {
+      tool_registration_error(
+        "Duplicate tool name {.val {name}} in the registration batch.",
+        tool_name = name
+      )
+    }
+    if (!replace && name %in% names(existing)) {
+      tool_registration_error(
+        c(
+          "Tool {.val {name}} is already registered.",
+          "i" = "Use {.code replace = TRUE} to replace an existing tool."
+        ),
+        tool_name = name
+      )
+    }
+    validate_tool_annotations(tool@annotations, name)
+    result[[name]] <- tool
+  }
+  result
+}

--- a/dev/adr/0007-tool-registration-and-annotations.md
+++ b/dev/adr/0007-tool-registration-and-annotations.md
@@ -1,0 +1,27 @@
+# Tool registration validates a complete batch before publication
+
+Issues #49 and #50 share one tool boundary. Hosts use `ellmer::tool()` to
+describe a local function, a package export, or a service call; Deputy does
+not infer schemas, import packages, or connect services during registration.
+Existing tool bundles and MCP loaders supply the same ellmer objects.
+
+`Agent$register_tool()` and `$register_tools()` reject existing names unless
+the host explicitly supplies `replace = TRUE`. Duplicate names within a
+batch always fail. List element names do not rename tools. Constructor tools,
+tools already on a supplied Chat, skills, and `set_tools()` share validation.
+Validation and runtime adaptation finish before a single `Chat$set_tools()`
+call publishes the registry. This guarantees that validation failures leave
+the previous registry intact; arbitrary backend failures are not a database
+transaction. Deputy reserves its internal result reader's name.
+
+Supplied annotations retain their original values. Known boolean annotations
+must be scalar, non-missing logical values. Missing values remain absent on
+the tool, while permission checks for custom tools assume read-only FALSE,
+destructive TRUE, idempotent FALSE, and open-world TRUE. These are the
+[MCP annotation defaults](https://modelcontextprotocol.io/specification/2025-06-18/schema#toolannotations).
+Destructive defaults are irrelevant when read-only is explicitly TRUE; an
+explicit contradictory destructive TRUE remains restrictive. Annotations
+describe behavior and do not establish trust or grant authority. Native
+capability checks, deny/allow lists, callbacks, and parent permission ceilings
+still apply. Full mode and explicit standard-mode callbacks remain host
+authorization mechanisms.

--- a/man/Agent.Rd
+++ b/man/Agent.Rd
@@ -836,9 +836,12 @@ provider-native web tools are authorized once, before registration,
 because their execution occurs inside the provider rather than R. Native
 tools therefore require static permissions and cannot be registered with
 a custom \code{can_use_tool} callback.
+Existing names require explicit replacement. Every tool in a batch is
+validated and adapted before the registry changes. List element names
+do not rename tools; each tool's own name is authoritative.
   \subsection{Usage}{
     \if{html}{\out{<div class="r">}}
-    \preformatted{Agent$register_tool(tool)}
+    \preformatted{Agent$register_tool(tool, replace = FALSE)}
     \if{html}{\out{</div>}}
   }
   \subsection{Arguments}{
@@ -846,6 +849,8 @@ a custom \code{can_use_tool} callback.
     \describe{
       \item{\code{tool}}{A tool created with \code{ellmer::tool()} or a supported
 provider-native web tool.}
+      \item{\code{replace}}{Replace tools already registered under the same name?
+Defaults to FALSE. Duplicate names within a batch always fail.}
     }
     \if{html}{\out{</div>}}
   }
@@ -861,7 +866,7 @@ provider-native web tool.}
   Register multiple tools with the agent.
   \subsection{Usage}{
     \if{html}{\out{<div class="r">}}
-    \preformatted{Agent$register_tools(tools)}
+    \preformatted{Agent$register_tools(tools, replace = FALSE)}
     \if{html}{\out{</div>}}
   }
   \subsection{Arguments}{
@@ -869,6 +874,8 @@ provider-native web tool.}
     \describe{
       \item{\code{tools}}{A list of function tools or supported provider-native web
 tools.}
+      \item{\code{replace}}{Replace tools already registered under the same name?
+Defaults to FALSE. Duplicate names within a batch always fail.}
     }
     \if{html}{\out{</div>}}
   }

--- a/man/PermissionMode.Rd
+++ b/man/PermissionMode.Rd
@@ -36,7 +36,7 @@ Indicates the tool may cause destructive/irreversible changes.
 Tools with \code{destructive_hint = TRUE} require explicit permission.
 Examples: \code{tool_write_file}, \code{tool_delete_file}, \code{tool_run_bash}
 
-\strong{open_world_hint} (logical, default: FALSE)
+\strong{open_world_hint} (logical, default: TRUE)
 
 Indicates the tool may interact with external systems.
 Used for network calls, package installation, etc.
@@ -45,7 +45,15 @@ Examples: \code{tool_web_search}, \code{tool_install_package}
 \strong{idempotent_hint} (logical, default: FALSE)
 
 Indicates repeated calls produce the same result.
-Safe to retry on failure.
+This annotation alone does not authorize automatic retries.
+
+Missing annotations remain absent on the tool. For custom tools, permission
+checks assume modification, possible destruction, external access, and no
+idempotence unless stated otherwise. If \code{read_only_hint = TRUE}, an omitted
+destructive annotation is ignored; an explicit TRUE still denies read-only
+use. Native tools continue to require their named capabilities. A custom
+permission callback can explicitly authorize a tool in standard mode;
+full mode bypasses annotation checks but still honors tool gating.
 }
 
 \section{Creating Tools with Annotations}{
@@ -59,7 +67,8 @@ tool_search <- ellmer::tool(
   arguments = list(pattern = ellmer::type_string("Search pattern")),
   annotations = ellmer::tool_annotations(
     read_only_hint = TRUE,
-    destructive_hint = FALSE
+    destructive_hint = FALSE,
+    open_world_hint = FALSE
   )
 )
 

--- a/tests/testthat/_snaps/tool-registration.md
+++ b/tests/testthat/_snaps/tool-registration.md
@@ -1,0 +1,8 @@
+# registration requires explicit replacement and uses tool names
+
+    Code
+      agent$register_tool(replacement)
+    Condition
+      Error in `validate_tool_batch()`:
+      ! Tool "lookup" is already registered.
+      i Use `replace = TRUE` to replace an existing tool.

--- a/tests/testthat/helper-runtime.R
+++ b/tests/testthat/helper-runtime.R
@@ -116,6 +116,7 @@ create_content_stream_chat <- function(
       get_system_prompt = function() state$system_prompt,
       set_system_prompt = function(prompt) state$system_prompt <- prompt,
       get_tools = function() state$tools,
+      set_tools = function(tools) state$tools <- tools,
       register_tool = function(tool) state$tools[[tool@name]] <- tool,
       register_tools = function(tools) {
         for (registered_tool in tools) {

--- a/tests/testthat/test-agent-permissions.R
+++ b/tests/testthat/test-agent-permissions.R
@@ -388,7 +388,7 @@ test_that("Agent respects bash permission", {
 
   # Bash allowed
   agent_bash <- Agent$new(
-    chat = mock_chat,
+    chat = create_mock_chat(),
     tools = list(tool_run_bash),
     permissions = Permissions$new(bash = TRUE)
   )
@@ -418,7 +418,7 @@ test_that("Agent respects r_code permission", {
 
   # R code allowed
   agent_r <- Agent$new(
-    chat = mock_chat,
+    chat = create_mock_chat(),
     tools = list(tool_run_r_code),
     permissions = Permissions$new(r_code = TRUE)
   )

--- a/tests/testthat/test-context-policy.R
+++ b/tests/testthat/test-context-policy.R
@@ -154,6 +154,7 @@ test_that("the run kernel rechecks context between provider tool turns", {
   }
   agent <- Agent$new(
     chat = chat,
+    permissions = permissions_full(),
     context_policy = ContextPolicy(
       max_tokens = 50,
       compact_to = 0.5,
@@ -227,7 +228,11 @@ test_that("large tool results become durable integrity-checked references", {
     fun = function() value,
     name = "large_result",
     description = "Return a large test value.",
-    arguments = list()
+    arguments = list(),
+    annotations = ellmer::tool_annotations(
+      read_only_hint = TRUE,
+      open_world_hint = FALSE
+    )
   )
   agent <- Agent$new(
     chat = create_mock_chat(),
@@ -333,7 +338,11 @@ test_that("post-tool hooks inspect original offloaded results", {
     fun = function() value,
     name = "large_result",
     description = "Return a large test value.",
-    arguments = list()
+    arguments = list(),
+    annotations = ellmer::tool_annotations(
+      read_only_hint = TRUE,
+      open_world_hint = FALSE
+    )
   )
   captured <- NULL
   agent <- Agent$new(
@@ -413,7 +422,11 @@ test_that("the internal result reader remains available behind an allowlist", {
     fun = function() value,
     name = "large_result",
     description = "Return a large test value.",
-    arguments = list()
+    arguments = list(),
+    annotations = ellmer::tool_annotations(
+      read_only_hint = TRUE,
+      open_world_hint = FALSE
+    )
   )
   other_tool <- ellmer::tool(
     fun = function() "other",

--- a/tests/testthat/test-delegation-correlation.R
+++ b/tests/testthat/test-delegation-correlation.R
@@ -65,6 +65,7 @@ create_delegation_child_chat <- function() {
       get_system_prompt = function() state$system_prompt,
       set_system_prompt = function(prompt) state$system_prompt <- prompt,
       get_tools = function() state$tools,
+      set_tools = function(tools) state$tools <- tools,
       register_tool = function(tool) state$tools[[tool@name]] <- tool,
       register_tools = function(tools) {
         for (tool in tools) {
@@ -194,6 +195,7 @@ create_delegation_parent_chat <- function(child_chat) {
       get_system_prompt = function() state$system_prompt,
       set_system_prompt = function(prompt) state$system_prompt <- prompt,
       get_tools = function() state$tools,
+      set_tools = function(tools) state$tools <- tools,
       register_tool = function(tool) state$tools[[tool@name]] <- tool,
       register_tools = function(tools) {
         for (tool in tools) {
@@ -289,7 +291,10 @@ test_that("delegated runs retain end-to-end correlation", {
     name = "inspect_evidence",
     description = "Inspect one deterministic evidence fixture.",
     arguments = list(claim = ellmer::type_string("Claim identifier")),
-    annotations = ellmer::tool_annotations(read_only_hint = TRUE)
+    annotations = ellmer::tool_annotations(
+      read_only_hint = TRUE,
+      open_world_hint = FALSE
+    )
   )
   definition <- agent_definition(
     name = "evidence_reviewer",

--- a/tests/testthat/test-permissions.R
+++ b/tests/testthat/test-permissions.R
@@ -248,7 +248,7 @@ test_that("readonly fails closed for unknown unannotated tools", {
   )
 
   expect_s3_class(result, "PermissionResultDeny")
-  expect_match(result$reason, "explicit tool allowlist")
+  expect_match(result$reason, "destructive")
 })
 
 test_that("readonly still enforces capability fields before annotations", {
@@ -357,7 +357,9 @@ test_that("readonly annotations do not grant authority to unknown tools", {
 
   read_only_context <- c(
     context,
-    list(tool_annotations = list(read_only_hint = TRUE))
+    list(
+      tool_annotations = list(read_only_hint = TRUE, open_world_hint = FALSE)
+    )
   )
   result <- perms$check("unknown_tool", list(), read_only_context)
   expect_s3_class(result, "PermissionResultDeny")
@@ -394,7 +396,9 @@ test_that("standard mode uses annotations for unknown tools", {
   # Unknown read-only tool should be allowed
   read_only_context <- c(
     context,
-    list(tool_annotations = list(read_only_hint = TRUE))
+    list(
+      tool_annotations = list(read_only_hint = TRUE, open_world_hint = FALSE)
+    )
   )
   result <- perms$check("custom_read_tool", list(), read_only_context)
   expect_s3_class(result, "PermissionResultAllow")

--- a/tests/testthat/test-tool-registration.R
+++ b/tests/testthat/test-tool-registration.R
@@ -1,0 +1,210 @@
+registration_chat <- function() {
+  ellmer::chat_openai(
+    credentials = function() "test",
+    model = "gpt-4o-mini",
+    echo = "none"
+  )
+}
+
+registration_tool <- function(name = "lookup", value = "original") {
+  ellmer::tool(
+    fun = function() value,
+    name = name,
+    description = "Return a local value.",
+    annotations = ellmer::tool_annotations(
+      read_only_hint = TRUE,
+      destructive_hint = FALSE,
+      idempotent_hint = TRUE,
+      open_world_hint = FALSE
+    )
+  )
+}
+
+test_that("registration requires explicit replacement and uses tool names", {
+  agent <- Agent$new(chat = registration_chat())
+  original <- registration_tool()
+  expect_identical(agent$register_tool(original), agent)
+  before <- agent$get_tools()
+  replacement <- registration_tool(value = "replacement")
+  expect_snapshot(error = TRUE, agent$register_tool(replacement))
+  expect_identical(agent$get_tools(), before)
+  expect_identical(agent$register_tool(replacement, replace = TRUE), agent)
+  expect_identical(agent$get_tools()$lookup(), "replacement")
+  agent$register_tools(list(ignored_alias = registration_tool("second")))
+  expect_named(agent$get_tools(), c("lookup", "second"))
+})
+
+test_that("whole batches are checked before changing a real Chat registry", {
+  agent <- Agent$new(
+    chat = registration_chat(),
+    tools = list(registration_tool())
+  )
+  before <- agent$get_tools()
+  for (replace in c(FALSE, TRUE)) {
+    expect_error(
+      agent$register_tools(
+        list(registration_tool("new"), 42),
+        replace = replace
+      ),
+      class = "deputy_tool_registration"
+    )
+    expect_error(
+      agent$register_tools(
+        list(registration_tool("new"), registration_tool("new")),
+        replace = replace
+      ),
+      "Duplicate tool name"
+    )
+    expect_identical(agent$get_tools(), before)
+  }
+  expect_error(agent$register_tools(list(), replace = NA), "replace")
+  expect_error(agent$register_tools(registration_tool()), "list")
+  expect_error(
+    agent$set_tools(list(registration_tool("new"), 42)),
+    "position 2"
+  )
+  expect_identical(agent$get_tools(), before)
+  agent$set_tools(list(registration_tool("new")))
+  expect_named(agent$get_tools(), "new")
+  agent$set_tools(list())
+  expect_length(agent$get_tools(), 0)
+})
+
+test_that("invalid annotations and native adaptation preserve all tools", {
+  agent <- Agent$new(
+    chat = registration_chat(),
+    tools = list(registration_tool())
+  )
+  before <- agent$get_tools()
+  for (value in list(NA, "true", c(TRUE, FALSE), 1)) {
+    invalid <- registration_tool("invalid")
+    invalid@annotations <- list(read_only_hint = value)
+    expect_error(
+      agent$register_tools(list(registration_tool("new"), invalid)),
+      class = "deputy_tool_registration"
+    )
+    expect_identical(agent$get_tools(), before)
+  }
+  expect_error(
+    agent$set_tools(list(
+      registration_tool("new"),
+      ellmer::openai_tool_web_search()
+    )),
+    "not authorized"
+  )
+  expect_identical(agent$get_tools(), before)
+})
+
+test_that("constructor failures preserve tools on the supplied Chat", {
+  chat <- registration_chat()
+  chat$register_tool(registration_tool())
+  before <- chat$get_tools()
+  expect_error(
+    Agent$new(chat = chat, tools = list(registration_tool())),
+    "already registered"
+  )
+  expect_identical(chat$get_tools(), before)
+  expect_error(Agent$new(chat = chat, tools = list(42)), "position 1")
+  expect_identical(chat$get_tools(), before)
+  agent <- Agent$new(chat = chat, tools = list(registration_tool("second")))
+  expect_named(agent$get_tools(), c("lookup", "second"))
+  expect_true(all(vapply(
+    agent$get_tools(),
+    function(tool) {
+      isTRUE(attr(tool, "deputy_runtime_tool"))
+    },
+    logical(1)
+  )))
+})
+
+test_that("the internal result reader cannot be replaced by a public tool", {
+  agent <- Agent$new(chat = registration_chat())
+  spoof <- registration_tool("deputy_read_tool_result")
+  expect_error(agent$register_tool(spoof, replace = TRUE), "reserved")
+  expect_error(agent$set_tools(list(spoof)), "reserved")
+  expect_error(
+    Agent$new(chat = registration_chat(), tools = list(spoof)),
+    "reserved"
+  )
+})
+
+test_that("function and package tools share registration and survive cloning", {
+  packaged <- ellmer::tool(
+    fun = base::toupper,
+    name = "uppercase",
+    description = "Uppercase text.",
+    arguments = list(x = ellmer::type_string()),
+    annotations = ellmer::tool_annotations(
+      read_only_hint = TRUE,
+      open_world_hint = FALSE
+    )
+  )
+  agent <- Agent$new(
+    chat = registration_chat(),
+    tools = list(packaged, registration_tool())
+  )
+  clone <- agent$clone()
+  clone$set_tools(clone$get_tools())
+  expect_identical(clone$get_tools()$uppercase("hello"), "HELLO")
+  clone$register_tool(registration_tool(value = "cloned"), replace = TRUE)
+  expect_identical(clone$get_tools()$lookup(), "cloned")
+  expect_identical(agent$get_tools()$lookup(), "original")
+})
+
+test_that("missing annotations stay absent and use conservative permissions", {
+  tool <- ellmer::tool(
+    function() "unknown",
+    name = "unknown",
+    description = "Unknown effects."
+  )
+  agent <- Agent$new(chat = registration_chat(), tools = list(tool))
+  expect_identical(agent$get_tools()$unknown@annotations, list())
+  for (annotations in list(NULL, list(), list(open_world_hint = NULL))) {
+    context <- list(tool_annotations = annotations)
+    for (mode in c("standard", "readonly", "plan")) {
+      policy <- Permissions$new(mode = mode, web = FALSE, file_write = FALSE)
+      expect_s3_class(
+        policy$check("unknown", list(), context),
+        "PermissionResultDeny"
+      )
+    }
+    expect_s3_class(
+      permissions_full()$check("unknown", list(), context),
+      "PermissionResultAllow"
+    )
+  }
+  seen <- NULL
+  policy <- Permissions$new(can_use_tool = function(
+    tool_name,
+    tool_input,
+    context
+  ) {
+    seen <<- context$tool_annotations
+    PermissionResultAllow()
+  })
+  expect_s3_class(
+    policy$check("unknown", list(), list(tool_annotations = list())),
+    "PermissionResultAllow"
+  )
+  expect_identical(seen, list())
+  expect_identical(effective_tool_annotations(list()), tool_annotation_defaults)
+})
+
+test_that("permission annotations come from the registered executable", {
+  agent <- Agent$new(
+    chat = registration_chat(),
+    tools = list(registration_tool()),
+    permissions = Permissions$new(mode = "readonly", tool_allowlist = "lookup")
+  )
+  misleading <- registration_tool()
+  misleading@annotations <- list(destructive_hint = TRUE)
+  for (attached in list(NULL, misleading)) {
+    request <- ellmer::ContentToolRequest(
+      id = "lookup-1",
+      name = "lookup",
+      arguments = list(),
+      tool = attached
+    )
+    expect_no_error(agent$.__enclos_env__$private$handle_tool_request(request))
+  }
+})

--- a/tests/testthat/test-tool-registration.R
+++ b/tests/testthat/test-tool-registration.R
@@ -208,3 +208,24 @@ test_that("permission annotations come from the registered executable", {
     expect_no_error(agent$.__enclos_env__$private$handle_tool_request(request))
   }
 })
+
+test_that("child definitions can share parent tools without inheriting the registry", {
+  shared <- registration_tool("shared")
+  definition <- agent_definition(
+    "reviewer",
+    "Reviews values",
+    "Inspect a value.",
+    tools = list(shared)
+  )
+  lead <- LeadAgent$new(
+    chat = registration_chat(),
+    sub_agents = list(definition),
+    tools = list(shared, registration_tool("parent_only"))
+  )
+  child <- lead$.__enclos_env__$private$create_sub_agent(definition)
+  expect_named(child$get_tools(), "shared")
+  expect_identical(child$get_tools()$shared(), "original")
+  expect_true(all(
+    c("shared", "parent_only", "delegate_to_agent") %in% names(lead$get_tools())
+  ))
+})

--- a/tests/testthat/test-tools-web.R
+++ b/tests/testthat/test-tools-web.R
@@ -199,7 +199,7 @@ test_that("web permission is checked correctly", {
 
   # Web allowed
   agent_web <- Agent$new(
-    chat = mock_chat,
+    chat = create_mock_chat(),
     tools = list(tool_web_fetch),
     permissions = Permissions$new(web = TRUE)
   )
@@ -231,7 +231,7 @@ test_that("web_search permission is checked correctly", {
 
   # Web allowed
   agent_web <- Agent$new(
-    chat = mock_chat,
+    chat = create_mock_chat(),
     tools = list(tool_web_search),
     permissions = Permissions$new(web = TRUE)
   )

--- a/vignettes/tools.Rmd
+++ b/vignettes/tools.Rmd
@@ -45,6 +45,45 @@ details.
 
 ## Tool Bundles
 
+Use `ellmer::tool()` for local functions, package exports, and service call
+wrappers, then register those objects through the same Agent API. Registration
+does not load packages or infer a function's effects. Describe them explicitly:
+
+```{r registration-contract, eval=TRUE}
+library(deputy)
+uppercase <- ellmer::tool(
+  base::toupper,
+  name = "uppercase",
+  description = "Uppercase local text.",
+  arguments = list(x = ellmer::type_string()),
+  annotations = ellmer::tool_annotations(
+    read_only_hint = TRUE, destructive_hint = FALSE,
+    open_world_hint = FALSE, idempotent_hint = TRUE
+  )
+)
+# Constructing this Chat does not make a model request.
+chat <- ellmer::chat_openai(credentials = function() "example", model = "gpt-4o-mini")
+agent <- Agent$new(chat = chat, tools = list(uppercase))
+agent$get_tools()$uppercase("hello")
+agent$register_tool(uppercase, replace = TRUE)
+```
+
+Existing names are errors unless `replace = TRUE` is explicit. Repeated names
+inside one batch always fail, including with replacement enabled. List names
+do not rename a tool. `set_tools()` replaces the whole user registry. Both
+methods and construction validate and adapt the complete batch before changing
+the backend registry; a malformed later tool leaves earlier tools untouched.
+Skills use `load_skill(..., allow_conflicts = TRUE)` for explicit replacement.
+
+Missing annotations stay absent on the source object. For custom tools,
+permissions assume possible modification, destruction, and external access,
+and no idempotence. An explicit read-only annotation makes an omitted
+destructive annotation irrelevant. A local read tool therefore needs at least
+`read_only_hint = TRUE` and `open_world_hint = FALSE` under standard permissions.
+Readonly mode additionally requires an explicit allowlist entry for custom
+tools. Annotations do not grant authority or verify a service's trustworthiness.
+See `PermissionMode` for callback and mode behavior.
+
 Bundles group related tools together:
 
 ```{r, eval = FALSE}


### PR DESCRIPTION
Closes #49

Registering a tool with an existing name now errors unless the host explicitly passes `replace = TRUE`. Duplicate names within a batch always fail. Constructor tools, existing Chat tools, skills, and `set_tools()` share validation and runtime adaptation before the registry changes; malformed later entries cannot erase or partially replace existing tools. Child Agents inherit provider configuration with a fresh registry before applying their definition, so shared parent/child tool names do not collide.

Ellmer continues to own function and schema construction for local functions, package exports, and service tools. Deputy validates supplied annotations, retains missing fields, and applies conservative custom-tool permission defaults. Permission callbacks read annotations from the registered executable instead of an optional or stale request copy. The internal result reader cannot be replaced through public registration.

```r
agent$register_tool(tool)                 # Errors if the name already exists
agent$register_tool(tool, replace = TRUE) # Explicit replacement
```

Validation: real ellmer Chat registry tests; full suite on ellmer 0.4.2; focused compatibility tests on CRAN ellmer 0.5.0; Air and Jarl; full pkgdown build with an executable registration example; R CMD check with zero errors, warnings, or notes. The metadata and MCP follow-through is the next PR in this native GitHub stack.
