### PR TITLE
Run stateless responder batches with governed fan-out

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -25,6 +25,8 @@ deputy/
 ├── R/                      # Source code (R6 classes and functions)
 │   ├── agent.R             # Agent class - main agentic workflow engine
 │   ├── agents-multi.R      # LeadAgent for multi-agent orchestration
+│   ├── parallel-delegate.R # Bounded stateless responder batches
+│   ├── agent-run-state.R   # Shared model-run and batch initialization
 │   ├── agent-definition-files.R # Portable YAML AgentDefinitions
 │   ├── agent-result.R      # AgentResult and AgentEvent objects
 │   ├── run-usage.R         # Run accounting and fail-closed limits
@@ -256,6 +258,17 @@ test_that("descriptive test name", {
 6. **HookRegistry** fires PreToolUse/PostToolUse events
 7. Tool executes and returns result
 8. Loop continues until LLM stops or limits reached
+
+Hosts may call `LeadAgent$parallel_delegate()` or its async counterpart with a
+named task vector selecting registered definitions. Tier-1 responders have no
+tools, skills, or MCP servers and make at most one request each. A batch uses
+the same lifecycle, accounting, and result assembly as ordinary runs, retains
+partial outcomes, and leaves the lead conversation intact. It owns the lead's
+active-run slot. See `dev/adr/0008-stateless-fanout.md` for wave allocations,
+observed-limit semantics, and the boundary with future background agents.
+
+Tests use httpuv (Suggests) in a separate local R process for a real ellmer
+streaming fixture; no external API or credentials are required.
 
 ### Permission Modes
 

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -21,6 +21,7 @@ Encoding: UTF-8
 Roxygen: list(markdown = TRUE)
 Suggests:
     httr2,
+    httpuv,
     jsonlite,
     jsonvalidate,
     knitr,

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,11 @@
 # deputy (development version)
 
+* `LeadAgent$parallel_delegate()` and `$parallel_delegate_async()` run fresh,
+  tool-free responders in bounded concurrent waves. Batches preserve named
+  partial results, record child runs, reserve request budgets, and support host
+  cancellation. Failed provider dispatches count toward request limits. Child
+  Chats isolate runtime callbacks as well as history and tools (#39).
+
 * `tool_metadata()` reports tool origin, supplied annotations, missing fields,
   and effective defaults through registration, cloning, and delegation. MCP
   loading preserves server annotations using a qualified mcptools 1.0.2 bridge,

--- a/R/agent-run-state.R
+++ b/R/agent-run-state.R
@@ -1,0 +1,128 @@
+# Shared initialization for model runs and host-driven delegation batches.
+initialize_agent_run <- function(
+  agent,
+  state,
+  messages,
+  limits,
+  run_context,
+  controller = NULL,
+  stream_mode = "content",
+  initial_usage = AgentUsage()
+) {
+  private <- agent$.__enclos_env__$private
+  private$run_active <- TRUE
+  private$current_run_id <-
+    private$new_run_id()
+  private$current_run_context <-
+    run_context
+  active_run_id <- private$current_run_id
+  state$active_run_id <- active_run_id
+  state$run_context <- run_context
+  state$limits <- limits
+
+  # Initialize lazily on first consumption. Merely constructing and
+  # abandoning a stream must not reserve this Agent forever.
+  private$tool_call_count <- 0L
+  private$tool_call_limit <-
+    limits$max_tool_calls
+  private$should_stop <- FALSE
+  private$stop_reason_from_hook <- NULL
+  private$current_usage_limits <- limits
+  private$current_usage_baseline <-
+    agent_usage_snapshot(private$.chat)
+  state$turns_before <- length(
+    private$.chat$get_turns()
+  )
+  private$current_tool_calls <- 0L
+  private$current_tool_results <- 0L
+  private$current_outer_requests <- 0L
+  private$current_external_usage <- initial_usage
+  private$current_stream_controller <-
+    controller %||%
+    tryCatch(
+      ellmer::stream_controller(),
+      error = function(e) NULL
+    )
+  private$current_stream_content <-
+    identical(stream_mode, "content")
+  private$current_run_state <- state
+  private$pending_events <- list()
+  private$tool_started_at <- list()
+  private$tool_event_overrides <- list()
+  private$tool_call_records <- list()
+  private$pending_delegations <- list()
+  private$original_tool_results <- list()
+  private$last_limit_status <- NULL
+  private$last_tool_cycle_signature <- NULL
+  private$consecutive_tool_cycles <- 0L
+  private$last_run_usage <- AgentUsage()
+  private$current_run_checkpoint_id <- NULL
+
+  if (!is.null(private$.file_checkpoints)) {
+    checkpoint_id <- private$.file_checkpoints$checkpoint(
+      paste0("run ", active_run_id),
+      metadata = list(
+        run_id = active_run_id,
+        message_count = length(messages)
+      )
+    )
+    private$current_run_checkpoint_id <-
+      checkpoint_id
+  }
+
+  task <- messages
+  if (length(messages) == 1L) {
+    task <- messages[[1L]]
+  }
+  private$record_run_event(
+    private$agent_event(
+      "start",
+      task = task,
+      usage_limits = limits,
+      checkpoint_id = private$current_run_checkpoint_id
+    )
+  )
+  if (
+    !is.null(
+      private$current_run_checkpoint_id
+    )
+  ) {
+    private$record_run_event(
+      private$agent_event(
+        "file_checkpoint",
+        checkpoint_id = private$current_run_checkpoint_id,
+        name = paste0("run ", active_run_id)
+      )
+    )
+  }
+
+  agent$hooks$fire(
+    "SessionStart",
+    context = private$hook_context(
+      permissions = agent$permissions,
+      provider = agent$provider(),
+      tools_count = length(private$.chat$get_tools()),
+      run_id = active_run_id
+    )
+  )
+  state$session_started <- TRUE
+  agent$hooks$fire(
+    "UserPromptSubmit",
+    prompt = if (length(messages) == 1L) messages[[1L]] else messages,
+    context = private$hook_context(
+      run_id = active_run_id
+    )
+  )
+
+  initial_limit_status <- usage_limit_status(
+    private$current_run_usage(),
+    private$current_usage_limits,
+    require_followup = TRUE
+  )
+  if (!is.null(initial_limit_status)) {
+    private$mark_usage_limit(initial_limit_status)
+    state$reason <- initial_limit_status$reason
+  }
+
+  invisible(state)
+}

--- a/R/agent.R
+++ b/R/agent.R
@@ -1861,16 +1861,7 @@ Agent <- R6::R6Class(
     },
 
     rewire_chat_runtime = function() {
-      chat_private <- tryCatch(
-        private$.chat$.__enclos_env__$private,
-        error = function(e) NULL
-      )
-      for (name in c("callback_on_tool_request", "callback_on_tool_result")) {
-        manager <- chat_private[[name]]
-        if (!is.null(manager) && is.function(manager$clear)) {
-          manager$clear()
-        }
-      }
+      clear_chat_tool_callbacks(private$.chat)
 
       tools <- private$.chat$get_tools()
       had_result_reader <- "deputy_read_tool_result" %in% names(tools)
@@ -2084,6 +2075,8 @@ Agent <- R6::R6Class(
       controller,
       structured = NULL
     ) {
+      # Count the dispatch even when a provider fails before recording a turn.
+      private$current_outer_requests <- private$current_outer_requests + 1L
       if (!is.null(structured)) {
         return(do.call(
           private$.chat$chat_structured_async,
@@ -2389,123 +2382,21 @@ Agent <- R6::R6Class(
           compaction_usage <- compaction$usage
         }
 
-        agent$.__enclos_env__$private$run_active <- TRUE
-        agent$.__enclos_env__$private$current_run_id <-
-          agent$.__enclos_env__$private$new_run_id()
-        agent$.__enclos_env__$private$current_run_context <-
-          effective_run_context
-        active_run_id <- agent$.__enclos_env__$private$current_run_id
-        stream_state$active_run_id <- active_run_id
-        stream_state$run_context <- effective_run_context
-        stream_state$limits <- run_limits
         on.exit(
           agent$.__enclos_env__$private$finish_callback_run(stream_state),
           add = TRUE
         )
-
-        # Initialize lazily on first consumption. Merely constructing and
-        # abandoning a stream must not reserve this Agent forever.
-        agent$.__enclos_env__$private$tool_call_count <- 0L
-        agent$.__enclos_env__$private$tool_call_limit <-
-          run_limits$max_tool_calls
-        agent$.__enclos_env__$private$should_stop <- FALSE
-        agent$.__enclos_env__$private$stop_reason_from_hook <- NULL
-        agent$.__enclos_env__$private$current_usage_limits <- run_limits
-        agent$.__enclos_env__$private$current_usage_baseline <-
-          agent_usage_snapshot(agent$.__enclos_env__$private$.chat)
-        stream_state$turns_before <- length(
-          agent$.__enclos_env__$private$.chat$get_turns()
+        initialize_agent_run(
+          agent,
+          stream_state,
+          messages,
+          run_limits,
+          effective_run_context,
+          controller,
+          stream_mode,
+          compaction_usage
         )
-        agent$.__enclos_env__$private$current_tool_calls <- 0L
-        agent$.__enclos_env__$private$current_tool_results <- 0L
-        agent$.__enclos_env__$private$current_outer_requests <- 0L
-        agent$.__enclos_env__$private$current_external_usage <- compaction_usage
-        agent$.__enclos_env__$private$current_stream_controller <-
-          controller %||%
-          tryCatch(
-            ellmer::stream_controller(),
-            error = function(e) NULL
-          )
-        agent$.__enclos_env__$private$current_stream_content <-
-          identical(stream_mode, "content")
-        agent$.__enclos_env__$private$current_run_state <- stream_state
-        agent$.__enclos_env__$private$pending_events <- list()
-        agent$.__enclos_env__$private$tool_started_at <- list()
-        agent$.__enclos_env__$private$tool_event_overrides <- list()
-        agent$.__enclos_env__$private$tool_call_records <- list()
-        agent$.__enclos_env__$private$pending_delegations <- list()
-        agent$.__enclos_env__$private$original_tool_results <- list()
-        agent$.__enclos_env__$private$last_limit_status <- NULL
-        agent$.__enclos_env__$private$last_tool_cycle_signature <- NULL
-        agent$.__enclos_env__$private$consecutive_tool_cycles <- 0L
-        agent$.__enclos_env__$private$last_run_usage <- AgentUsage()
-        agent$.__enclos_env__$private$current_run_checkpoint_id <- NULL
-
-        if (!is.null(agent$.__enclos_env__$private$.file_checkpoints)) {
-          checkpoint_id <- agent$.__enclos_env__$private$.file_checkpoints$checkpoint(
-            paste0("run ", active_run_id),
-            metadata = list(
-              run_id = active_run_id,
-              message_count = length(messages)
-            )
-          )
-          agent$.__enclos_env__$private$current_run_checkpoint_id <-
-            checkpoint_id
-        }
-
-        task <- messages
-        if (length(messages) == 1L) {
-          task <- messages[[1L]]
-        }
-        agent$.__enclos_env__$private$record_run_event(
-          agent$.__enclos_env__$private$agent_event(
-            "start",
-            task = task,
-            usage_limits = run_limits,
-            checkpoint_id = agent$.__enclos_env__$private$current_run_checkpoint_id
-          )
-        )
-        if (
-          !is.null(
-            agent$.__enclos_env__$private$current_run_checkpoint_id
-          )
-        ) {
-          agent$.__enclos_env__$private$record_run_event(
-            agent$.__enclos_env__$private$agent_event(
-              "file_checkpoint",
-              checkpoint_id = agent$.__enclos_env__$private$current_run_checkpoint_id,
-              name = paste0("run ", active_run_id)
-            )
-          )
-        }
-
-        agent$hooks$fire(
-          "SessionStart",
-          context = agent$.__enclos_env__$private$hook_context(
-            permissions = agent$permissions,
-            provider = agent$provider(),
-            tools_count = length(agent$.__enclos_env__$private$.chat$get_tools()),
-            run_id = active_run_id
-          )
-        )
-        stream_state$session_started <- TRUE
-        agent$hooks$fire(
-          "UserPromptSubmit",
-          prompt = if (length(messages) == 1L) messages[[1L]] else messages,
-          context = agent$.__enclos_env__$private$hook_context(
-            run_id = active_run_id
-          )
-        )
-
-        initial_limit_status <- usage_limit_status(
-          agent$.__enclos_env__$private$current_run_usage(),
-          agent$.__enclos_env__$private$current_usage_limits,
-          require_followup = TRUE
-        )
-        if (!is.null(initial_limit_status)) {
-          agent$.__enclos_env__$private$mark_usage_limit(initial_limit_status)
-          stream_state$reason <- initial_limit_status$reason
-        }
+        active_run_id <- stream_state$active_run_id
 
         if (agent$.__enclos_env__$private$should_stop) {
           stream <- coro::async_generator(function() {

--- a/R/agents-multi.R
+++ b/R/agents-multi.R
@@ -360,6 +360,75 @@ LeadAgent <- R6::R6Class(
     },
 
     #' @description
+    #' Run independent, stateless responders concurrently.
+    #'
+    #' Each selected AgentDefinition gets a fresh conversation and at most one
+    #' model request. Definitions with tools, skills, or MCP servers are
+    #' rejected. This is tier-1 fan-out, not background tool-using agents.
+    #' Results preserve input order, including failures and unstarted tasks.
+    #' @param tasks A named character vector of tasks. Names select unique
+    #'   registered AgentDefinitions.
+    #' @param max_active Maximum simultaneous responders.
+    #' @param mode Execution contract. Currently only `"stateless"` is supported.
+    #' @param usage_limits Optional batch-wide [UsageLimits]. Unset fields
+    #'   inherit the lead's defaults. Requests are reserved before dispatch;
+    #'   token and cost ceilings are divided across each concurrent wave and
+    #'   checked after responses, with possible overage by one response per
+    #'   active responder.
+    #' @param run_context Additional immutable context for the batch.
+    #' @return A list with `mode`, named `results` ([AgentResult] or `NULL`),
+    #'   named `errors`, named `status`, and an aggregate `run` ([AgentResult]).
+    #'   `$last_run()` retains the aggregate run. The lead's conversation is
+    #'   unchanged. Failed responders do not discard successful siblings.
+    parallel_delegate = function(
+      tasks,
+      max_active = 2L,
+      mode = "stateless",
+      usage_limits = NULL,
+      run_context = list()
+    ) {
+      promise <- self$parallel_delegate_async(
+        tasks,
+        max_active,
+        mode,
+        usage_limits,
+        run_context
+      )
+      tryCatch(
+        private$resolve_promise(promise),
+        interrupt = function(condition) {
+          self$interrupt()
+          try(private$resolve_promise(promise), silent = TRUE)
+          stop(condition)
+        }
+      )
+    },
+
+    #' @description
+    #' Run stateless fan-out without blocking the R event loop.
+    #' @param tasks,max_active,mode,usage_limits,run_context See
+    #'   `$parallel_delegate()`.
+    #' @return A promise resolving to the same batch result as
+    #'   `$parallel_delegate()`. `$interrupt()` cancels queued work and asks
+    #'   active responders to stop at their next supported provider boundary.
+    parallel_delegate_async = function(
+      tasks,
+      max_active = 2L,
+      mode = "stateless",
+      usage_limits = NULL,
+      run_context = list()
+    ) {
+      lead_parallel_delegate(
+        self,
+        tasks,
+        max_active,
+        mode,
+        usage_limits,
+        run_context
+      )
+    },
+
+    #' @description
     #' List delegated sub-agent runs, including failures.
     #'
     #' @return Data frame with one row per sub-agent run
@@ -751,7 +820,12 @@ LeadAgent <- R6::R6Class(
     },
 
     # Create a sub-agent from a definition
-    create_sub_agent = function(def, correlation = NULL, usage_limits = NULL) {
+    create_sub_agent = function(
+      def,
+      correlation = NULL,
+      usage_limits = NULL,
+      stateless = FALSE
+    ) {
       correlation <- correlation %||% private$claim_delegation()
 
       # Get the model to use
@@ -760,7 +834,11 @@ LeadAgent <- R6::R6Class(
         # then clear conversation history so the sub-agent starts fresh.
         sub_chat <- tryCatch(
           {
-            cloned <- private$.chat$clone()
+            cloned <- private$.chat$clone(deep = TRUE)
+            if (identical(cloned, private$.chat)) {
+              cli_abort("Chat cloning must return an independent instance")
+            }
+            clear_chat_tool_callbacks(cloned)
             cloned$set_turns(list())
             # The child definition chooses its tools. Inherited provider
             # configuration must not import the parent's executable registry.
@@ -817,7 +895,11 @@ LeadAgent <- R6::R6Class(
         permissions = sub_permissions,
         usage_limits = usage_limits %||%
           private$derive_subagent_usage_limits(def),
-        context_policy = self$context_policy,
+        context_policy = if (stateless) {
+          ContextPolicy(max_tokens = NULL, max_tool_result_bytes = NULL)
+        } else {
+          self$context_policy
+        },
         working_dir = self$working_dir,
         session_id = new_deputy_id("session_"),
         run_context = child_run_context,
@@ -832,7 +914,7 @@ LeadAgent <- R6::R6Class(
       # A checkpoint describes workspace state, not one agent's private
       # execution history. Delegated agents therefore write to the exact same
       # journal as the lead so a lead-level rewind includes child mutations.
-      if (!is.null(private$.file_checkpoints)) {
+      if (!stateless && !is.null(private$.file_checkpoints)) {
         sub_agent$.__enclos_env__$private$.file_checkpoints <-
           private$.file_checkpoints
       }

--- a/R/agents-multi.R
+++ b/R/agents-multi.R
@@ -834,11 +834,16 @@ LeadAgent <- R6::R6Class(
         # then clear conversation history so the sub-agent starts fresh.
         sub_chat <- tryCatch(
           {
-            cloned <- private$.chat$clone(deep = TRUE)
+            clone_args <- names(formals(private$.chat$clone))
+            cloned <- if (any(c("deep", "...") %in% clone_args)) {
+              private$.chat$clone(deep = TRUE)
+            } else {
+              private$.chat$clone()
+            }
             if (identical(cloned, private$.chat)) {
               cli_abort("Chat cloning must return an independent instance")
             }
-            clear_chat_tool_callbacks(cloned)
+            clear_chat_tool_callbacks(cloned, source = private$.chat)
             cloned$set_turns(list())
             # The child definition chooses its tools. Inherited provider
             # configuration must not import the parent's executable registry.

--- a/R/parallel-delegate.R
+++ b/R/parallel-delegate.R
@@ -104,6 +104,8 @@ parallel_responder <- function(
           task = task,
           context = private$hook_context(
             agent_definition = definition,
+            parent_agent_id = correlation$parent_agent_id,
+            parent_run_id = correlation$parent_run_id,
             child_agent_id = child$agent_id,
             child_agent_name = child$agent_name,
             child_run_context = child$run_context,
@@ -154,6 +156,8 @@ parallel_responder <- function(
         context = private$hook_context(
           status = status,
           error = if (!is.null(error)) conditionMessage(error),
+          parent_agent_id = correlation$parent_agent_id,
+          parent_run_id = correlation$parent_run_id,
           child_agent_id = child$agent_id,
           child_agent_name = child$agent_name,
           child_run_id = child_run_id,

--- a/R/parallel-delegate.R
+++ b/R/parallel-delegate.R
@@ -1,0 +1,353 @@
+# Tier-1 fan-out uses the same governed asynchronous runs as ordinary Agents.
+
+validate_parallel_tasks <- function(lead, tasks, max_active, mode) {
+  if (!identical(mode, "stateless")) {
+    cli_abort(
+      "Only {.code mode = 'stateless'} is supported for parallel delegation."
+    )
+  }
+  max_active <- context_policy_whole_number(max_active, "max_active")
+  if (is.null(max_active)) {
+    cli_abort("{.arg max_active} must be a positive whole number")
+  }
+  if (
+    !is.character(tasks) ||
+      length(tasks) == 0L ||
+      anyNA(tasks) ||
+      !all(nzchar(trimws(tasks))) ||
+      is.null(names(tasks))
+  ) {
+    cli_abort("{.arg tasks} must be a non-empty named character vector")
+  }
+  keys <- vapply(names(tasks), normalize_agent_definition_name, character(1))
+  if (anyDuplicated(keys)) {
+    cli_abort("{.arg tasks} must select each AgentDefinition at most once")
+  }
+  definitions <- lead$.__enclos_env__$private$.sub_agent_defs
+  unknown <- setdiff(keys, names(definitions))
+  if (length(unknown) > 0L) {
+    cli_abort("Unknown AgentDefinitions: {.val {unknown}}")
+  }
+  for (key in keys) {
+    definition <- definitions[[key]]
+    if (
+      length(definition$tools) > 0L ||
+        length(definition$skills) > 0L ||
+        length(definition$mcp_servers) > 0L
+    ) {
+      cli_abort(c(
+        "AgentDefinition {.val {key}} is not stateless.",
+        "i" = "Stateless fan-out requires no tools, skills, or MCP servers."
+      ))
+    }
+  }
+  list(
+    tasks = stats::setNames(unname(tasks), keys),
+    definitions = definitions[keys],
+    max_active = max_active
+  )
+}
+
+parallel_child_limits <- function(remaining, definition, count, index) {
+  allocation <- remaining
+  fields <- c(
+    "max_input_tokens",
+    "max_output_tokens",
+    "max_total_tokens",
+    "max_cost_usd"
+  )
+  for (field in fields) {
+    available <- remaining[[field]]
+    if (is.null(available)) {
+      next
+    }
+    allocation[[field]] <- if (identical(field, "max_cost_usd")) {
+      available / count
+    } else {
+      floor(available / count) + as.integer(index <= available %% count)
+    }
+  }
+  allocation$max_requests <- min(1L, definition$max_requests %||% 1L)
+  allocation$max_tool_calls <- 0L
+  allocation$on_exceed <- "stop"
+  allocation
+}
+
+parallel_responder <- function(
+  lead,
+  child,
+  definition,
+  task,
+  correlation,
+  limits,
+  state
+) {
+  private <- lead$.__enclos_env__$private
+  coro::async(function() {
+    on.exit(
+      {
+        private$release_delegation_usage(correlation$delegation_id)
+        state$active[[definition$name]] <- NULL
+      },
+      add = TRUE
+    )
+    error <- NULL
+    started_at <- Sys.time()
+    result <- tryCatch(
+      {
+        if (isTRUE(private$should_stop)) {
+          return(list(result = NULL, error = NULL, status = "not_started"))
+        }
+        lead$hooks$fire(
+          "SubagentStart",
+          agent_name = definition$name,
+          task = task,
+          context = private$hook_context(
+            agent_definition = definition,
+            child_agent_id = child$agent_id,
+            child_agent_name = child$agent_name,
+            child_run_context = child$run_context,
+            delegation_id = correlation$delegation_id
+          )
+        )
+        if (isTRUE(private$should_stop)) {
+          return(list(result = NULL, error = NULL, status = "not_started"))
+        }
+        task_to_run <- task
+        if (!is.null(definition$initial_prompt)) {
+          task_to_run <- paste(definition$initial_prompt, task, sep = "\n\n")
+        }
+        coro::await(child$run_async(task_to_run, usage_limits = limits))
+      },
+      error = function(condition) {
+        error <<- condition
+        NULL
+      }
+    )
+    usage <- result$usage %||%
+      child$.__enclos_env__$private$last_run_usage %||%
+      AgentUsage()
+    private$current_external_usage <- agent_usage_add(
+      private$current_external_usage,
+      usage
+    )
+    if (!is.null(error)) {
+      status <- "failed"
+    } else if (identical(result$stop_reason, "complete")) {
+      status <- "completed"
+    } else if (result$stop_reason %in% c("error", "provider_error")) {
+      status <- "failed"
+    } else {
+      status <- "stopped"
+    }
+    child_run_id <- result$run_id %||%
+      child$.__enclos_env__$private$current_run_id
+    tryCatch(
+      lead$hooks$fire(
+        "SubagentStop",
+        agent_name = definition$name,
+        task = task,
+        result = result$response,
+        context = private$hook_context(
+          status = status,
+          error = if (!is.null(error)) conditionMessage(error),
+          child_agent_id = child$agent_id,
+          child_agent_name = child$agent_name,
+          child_run_id = child_run_id,
+          child_run_context = child$run_context,
+          delegation_id = correlation$delegation_id
+        )
+      ),
+      error = function(condition) {
+        error <<- condition
+        status <<- "failed"
+      }
+    )
+    private$subagent_runs <- c(
+      private$subagent_runs,
+      list(list(
+        agent_name = definition$name,
+        agent_id = child$agent_id,
+        parent_agent_id = lead$agent_id,
+        task = task,
+        session_id = child$session_id(),
+        run_id = child_run_id,
+        parent_run_id = correlation$parent_run_id,
+        delegation_id = correlation$delegation_id,
+        tool_call_id = NULL,
+        run_context = child$run_context,
+        started_at = started_at,
+        completed_at = Sys.time(),
+        status = status,
+        result = result$response,
+        error = if (!is.null(error)) conditionMessage(error),
+        usage = usage,
+        agent_result = result,
+        turns = child$turns()
+      ))
+    )
+    limit <- usage_limit_status(private$current_run_usage(), state$limits)
+    if (!is.null(limit)) {
+      private$mark_usage_limit(limit)
+    }
+    list(result = result, error = error, status = status)
+  })()
+}
+
+lead_parallel_delegate <- function(
+  lead,
+  tasks,
+  max_active,
+  mode,
+  usage_limits,
+  run_context
+) {
+  selected <- validate_parallel_tasks(lead, tasks, max_active, mode)
+  private <- lead$.__enclos_env__$private
+  limits <- if (is.null(usage_limits)) {
+    lead$usage_limits
+  } else {
+    merge_usage_limits(usage_limits, lead$usage_limits)
+  }
+  context <- merge_run_context(lead$run_context, run_context)
+  coro::async(function() {
+    if (isTRUE(private$run_active)) {
+      cli::cli_abort(
+        "This agent already has an active run",
+        class = c("deputy_run_active", "deputy_error")
+      )
+    }
+    state <- private$new_callback_run_state()
+    state$active <- list()
+    controller <- list(cancel = function(reason = "interrupted") {
+      for (child in state$active) {
+        child$interrupt(reason)
+      }
+    })
+    completed <- FALSE
+    on.exit(
+      {
+        if (!completed) {
+          state$reason <- "error"
+        }
+        private$finish_callback_run(state)
+      },
+      add = TRUE
+    )
+    initialize_agent_run(
+      lead,
+      state,
+      as.list(selected$tasks),
+      limits,
+      context,
+      controller
+    )
+    count <- length(selected$tasks)
+    # Prepare the complete batch before any provider request. Fresh Chat
+    # objects are cheap; max_active bounds network activity.
+    prepared <- lapply(seq_len(count), function(index) {
+      definition <- selected$definitions[[index]]
+      correlation <- list(
+        parent_agent_id = lead$agent_id,
+        parent_run_id = state$active_run_id,
+        delegation_id = new_deputy_id("delegation_"),
+        run_context = context,
+        tool_call_id = NULL
+      )
+      child <- private$create_sub_agent(
+        definition,
+        correlation,
+        UsageLimits(
+          max_requests = min(1L, definition$max_requests %||% 1L),
+          max_tool_calls = 0L
+        ),
+        stateless = TRUE
+      )
+      list(
+        child = child,
+        definition = definition,
+        correlation = correlation,
+        task = selected$tasks[[index]]
+      )
+    })
+    outcomes <- rep(
+      list(list(
+        result = NULL,
+        error = NULL,
+        status = "not_started"
+      )),
+      count
+    )
+    names(outcomes) <- names(selected$tasks)
+    next_index <- 1L
+    while (next_index <= count && !isTRUE(private$should_stop)) {
+      limit <- usage_limit_status(
+        private$current_run_usage(),
+        limits,
+        require_followup = TRUE
+      )
+      if (!is.null(limit)) {
+        private$mark_usage_limit(limit)
+        break
+      }
+      remaining <- private$derive_subagent_usage_limits(
+        agent_definition("batch", "Batch allocation", "Respond once.")
+      )
+      wave_size <- min(
+        selected$max_active,
+        count - next_index + 1L,
+        remaining$max_requests %||% Inf
+      )
+      indices <- seq.int(next_index, length.out = wave_size)
+      wave <- lapply(seq_along(indices), function(position) {
+        index <- indices[[position]]
+        item <- prepared[[index]]
+        item$limits <- parallel_child_limits(
+          remaining,
+          item$definition,
+          wave_size,
+          position
+        )
+        item
+      })
+      promises <- lapply(wave, function(item) {
+        private$reserve_delegation_usage(
+          item$correlation$delegation_id,
+          item$limits
+        )
+        state$active[[item$definition$name]] <- item$child
+        parallel_responder(
+          lead,
+          item$child,
+          item$definition,
+          item$task,
+          item$correlation,
+          item$limits,
+          state
+        )
+      })
+      wave_outcomes <- coro::await(promises::promise_all(.list = promises))
+      outcomes[indices] <- wave_outcomes
+      next_index <- next_index + wave_size
+    }
+    statuses <- vapply(outcomes, `[[`, character(1), "status")
+    if (isTRUE(private$should_stop)) {
+      state$reason <- private$stop_reason_from_hook %||% "interrupted"
+    } else if (any(statuses == "failed")) {
+      state$reason <- "delegation_error"
+    } else if (any(statuses != "completed")) {
+      state$reason <- "delegation_stopped"
+    } else {
+      state$reason <- "complete"
+    }
+    completed <- TRUE
+    private$finish_callback_run(state)
+    list(
+      mode = "stateless",
+      results = lapply(outcomes, `[[`, "result"),
+      errors = lapply(outcomes, `[[`, "error"),
+      status = statuses,
+      run = state$result
+    )
+  })()
+}

--- a/R/parallel-delegate.R
+++ b/R/parallel-delegate.R
@@ -111,13 +111,14 @@ parallel_responder <- function(
           )
         )
         if (isTRUE(private$should_stop)) {
-          return(list(result = NULL, error = NULL, status = "not_started"))
+          NULL
+        } else {
+          task_to_run <- task
+          if (!is.null(definition$initial_prompt)) {
+            task_to_run <- paste(definition$initial_prompt, task, sep = "\n\n")
+          }
+          coro::await(child$run_async(task_to_run, usage_limits = limits))
         }
-        task_to_run <- task
-        if (!is.null(definition$initial_prompt)) {
-          task_to_run <- paste(definition$initial_prompt, task, sep = "\n\n")
-        }
-        coro::await(child$run_async(task_to_run, usage_limits = limits))
       },
       error = function(condition) {
         error <<- condition
@@ -133,6 +134,8 @@ parallel_responder <- function(
     )
     if (!is.null(error)) {
       status <- "failed"
+    } else if (is.null(result)) {
+      status <- "not_started"
     } else if (identical(result$stop_reason, "complete")) {
       status <- "completed"
     } else if (result$stop_reason %in% c("error", "provider_error")) {

--- a/R/tool-runtime.R
+++ b/R/tool-runtime.R
@@ -14,6 +14,15 @@ native_file_tool_names <- c(
 
 deputy_tool_result_reader_marker <- new.env(parent = emptyenv())
 
+clear_chat_tool_callbacks <- function(chat) {
+  private <- tryCatch(chat$.__enclos_env__$private, error = function(e) NULL)
+  for (name in c("callback_on_tool_request", "callback_on_tool_result")) {
+    manager <- private[[name]]
+    if (!is.null(manager) && is.function(manager$clear)) manager$clear()
+  }
+  invisible(chat)
+}
+
 runtime_wrap_tool <- function(
   tool,
   resolve_arguments,

--- a/R/tool-runtime.R
+++ b/R/tool-runtime.R
@@ -14,10 +14,17 @@ native_file_tool_names <- c(
 
 deputy_tool_result_reader_marker <- new.env(parent = emptyenv())
 
-clear_chat_tool_callbacks <- function(chat) {
+clear_chat_tool_callbacks <- function(chat, source = NULL) {
   private <- tryCatch(chat$.__enclos_env__$private, error = function(e) NULL)
+  source_private <- tryCatch(
+    source$.__enclos_env__$private,
+    error = function(e) NULL
+  )
   for (name in c("callback_on_tool_request", "callback_on_tool_result")) {
     manager <- private[[name]]
+    if (!is.null(manager) && identical(manager, source_private[[name]])) {
+      cli_abort("Chat cloning must isolate tool callback managers")
+    }
     if (!is.null(manager) && is.function(manager$clear)) manager$clear()
   }
   invisible(chat)

--- a/dev/adr/0008-stateless-fanout.md
+++ b/dev/adr/0008-stateless-fanout.md
@@ -1,0 +1,61 @@
+# Stateless fan-out uses governed asynchronous child runs
+
+Issue #39 separates one-request, tool-free responders from future tool-using
+background agents. The first tier is a host API on LeadAgent:
+`parallel_delegate(tasks, max_active = 2, mode = "stateless")`, plus an async
+method returning a promise. Tasks select unique registered AgentDefinitions.
+Definitions containing tools, skills, or MCP servers are rejected. Each child
+has fresh history, a fresh session, no automatic context compaction, and at
+most one model dispatch. Explicit definition memory and initial prompts remain
+part of its supplied context. Stateless describes execution, not absence of
+host-supplied context.
+
+## Backend decision
+
+The original issue proposed `ellmer::parallel_chat()` for tier 1. The released
+[bulk helper](https://ellmer.tidyverse.org/reference/parallel_chat.html) manages
+its own request loop around one Chat prototype. Inspection of ellmer 0.5.0
+shows that loop also invokes tools directly. Since Deputy now has a governed
+async kernel, routing through the bulk loop would require a second lifecycle
+and accounting adapter. Instead each responder uses `Agent$run_async()` and
+the batch joins its promises. This supports the released ellmer 0.4.2 minimum
+and 0.5.0 without adopting an unreleased concurrency API.
+
+Model runs and batches share run initialization and finalization. A batch
+owns the lead's active-run slot but does not alter its conversation. Child
+definitions retain the lead's permission ceiling. Inherited Chats are deep
+cloned; copied tool callback managers are cleared before the child Agent
+binds its own runtime callbacks. The definition supplies the complete child
+tool registry. All children are prepared before the first provider dispatch,
+so invalid configuration cannot lose already-paid sibling responses.
+
+## Scheduling and accounting
+
+The scheduler uses bounded waves. A wave reserves its request slots before
+dispatch, divides remaining token/cost ceilings, and waits for settlement
+before scheduling more work. Children receive at most one request and zero
+tool calls. Their limits use stop behavior so sibling results survive; the
+aggregate honors the caller's stop/error preference. Failed dispatches count
+toward requests even if no assistant turn was recorded. Missing cost data is
+unknown, and a configured cost ceiling fails closed.
+
+Token/cost caps are observed limits, not provider preflight estimates. A wave
+may overrun by one response per active child. Cancelling a batch stops queued
+work immediately and requests cooperative cancellation from active children;
+cleanup waits for them to settle. There is no process kill or provider request
+refund guarantee. Reservations are released on all worker exits.
+
+Each outcome retains its input key, status, result, and condition. Partial
+failures do not discard siblings. Child runs retain existing correlation,
+SubagentStart/Stop hooks, and inspection APIs. The aggregate has its own
+AgentResult and usage events. Synthesis is an explicit later run with an
+explicit separate budget.
+
+## Deferred boundary
+
+There is no `mode = "agentic"`, tool-using parallel worker tier, persistent
+inbox, wake scheduler, cross-run budget, or transitive agent tree in this
+change. Issue #42 tracks background-agent lifecycle and transitive limits.
+Issue #40 builds an opposing-perspective example on the completed tier-1
+contract. The wave scheduler is deliberately small; a continuously replenished
+queue or provider-specific rate limiter can follow measured need.

--- a/dev/adr/0008-stateless-fanout.md
+++ b/dev/adr/0008-stateless-fanout.md
@@ -28,6 +28,9 @@ cloned; copied tool callback managers are cleared before the child Agent
 binds its own runtime callbacks. The definition supplies the complete child
 tool registry. All children are prepared before the first provider dispatch,
 so invalid configuration cannot lose already-paid sibling responses.
+Custom Chats whose clone method lacks a `deep` argument may supply their own
+independent clone. Shared tool callback managers are rejected before clearing
+callbacks, so compatibility cannot erase the parent's governance callbacks.
 
 ## Scheduling and accounting
 

--- a/man/LeadAgent.Rd
+++ b/man/LeadAgent.Rd
@@ -24,6 +24,8 @@ sub-agents based on registered AgentDefinitions.
     \item \href{#method-LeadAgent-initialize}{\code{LeadAgent$new()}}
     \item \href{#method-LeadAgent-register_sub_agent}{\code{LeadAgent$register_sub_agent()}}
     \item \href{#method-LeadAgent-available_sub_agents}{\code{LeadAgent$available_sub_agents()}}
+    \item \href{#method-LeadAgent-parallel_delegate}{\code{LeadAgent$parallel_delegate()}}
+    \item \href{#method-LeadAgent-parallel_delegate_async}{\code{LeadAgent$parallel_delegate_async()}}
     \item \href{#method-LeadAgent-list_subagents}{\code{LeadAgent$list_subagents()}}
     \item \href{#method-LeadAgent-get_subagent_results}{\code{LeadAgent$get_subagent_results()}}
     \item \href{#method-LeadAgent-get_subagent_messages}{\code{LeadAgent$get_subagent_messages()}}
@@ -180,6 +182,82 @@ runs and delegated agents.}
   }
   \subsection{Returns}{
     Character vector of sub-agent names
+  }
+}
+
+\if{html}{\out{<hr>}}
+\if{html}{\out{<a id="method-LeadAgent-parallel_delegate"></a>}}
+\if{latex}{\out{\hypertarget{method-LeadAgent-parallel_delegate}{}}}
+\subsection{\code{LeadAgent$parallel_delegate()}}{
+  Run independent, stateless responders concurrently.
+
+Each selected AgentDefinition gets a fresh conversation and at most one
+model request. Definitions with tools, skills, or MCP servers are
+rejected. This is tier-1 fan-out, not background tool-using agents.
+Results preserve input order, including failures and unstarted tasks.
+  \subsection{Usage}{
+    \if{html}{\out{<div class="r">}}
+    \preformatted{LeadAgent$parallel_delegate(
+  tasks,
+  max_active = 2L,
+  mode = "stateless",
+  usage_limits = NULL,
+  run_context = list()
+)}
+    \if{html}{\out{</div>}}
+  }
+  \subsection{Arguments}{
+    \if{html}{\out{<div class="arguments">}}
+    \describe{
+      \item{\code{tasks}}{A named character vector of tasks. Names select unique
+registered AgentDefinitions.}
+      \item{\code{max_active}}{Maximum simultaneous responders.}
+      \item{\code{mode}}{Execution contract. Currently only \code{"stateless"} is supported.}
+      \item{\code{usage_limits}}{Optional batch-wide \link{UsageLimits}. Unset fields
+inherit the lead's defaults. Requests are reserved before dispatch;
+token and cost ceilings are divided across each concurrent wave and
+checked after responses, with possible overage by one response per
+active responder.}
+      \item{\code{run_context}}{Additional immutable context for the batch.}
+    }
+    \if{html}{\out{</div>}}
+  }
+  \subsection{Returns}{
+    A list with \code{mode}, named \code{results} (\link{AgentResult} or \code{NULL}),
+named \code{errors}, named \code{status}, and an aggregate \code{run} (\link{AgentResult}).
+\verb{$last_run()} retains the aggregate run. The lead's conversation is
+unchanged. Failed responders do not discard successful siblings.
+  }
+}
+
+\if{html}{\out{<hr>}}
+\if{html}{\out{<a id="method-LeadAgent-parallel_delegate_async"></a>}}
+\if{latex}{\out{\hypertarget{method-LeadAgent-parallel_delegate_async}{}}}
+\subsection{\code{LeadAgent$parallel_delegate_async()}}{
+  Run stateless fan-out without blocking the R event loop.
+  \subsection{Usage}{
+    \if{html}{\out{<div class="r">}}
+    \preformatted{LeadAgent$parallel_delegate_async(
+  tasks,
+  max_active = 2L,
+  mode = "stateless",
+  usage_limits = NULL,
+  run_context = list()
+)}
+    \if{html}{\out{</div>}}
+  }
+  \subsection{Arguments}{
+    \if{html}{\out{<div class="arguments">}}
+    \describe{
+      \item{\code{tasks, max_active, mode, usage_limits, run_context}}{See
+\verb{$parallel_delegate()}.}
+    }
+    \if{html}{\out{</div>}}
+  }
+  \subsection{Returns}{
+    A promise resolving to the same batch result as
+\verb{$parallel_delegate()}. \verb{$interrupt()} cancels queued work and asks
+active responders to stop at their next supported provider boundary.
   }
 }
 

--- a/tests/testthat/helper-parallel-http.R
+++ b/tests/testthat/helper-parallel-http.R
@@ -1,0 +1,62 @@
+# A separate process is required: curl opens the streaming connection before
+# yielding to the caller's event loop. No external service or key is used.
+local_parallel_server <- function(.local_envir = parent.frame()) {
+  skip_if_not_installed("httpuv")
+  skip_if_not_installed("jsonlite")
+  directory <- withr::local_tempdir(.local_envir = .local_envir)
+  process <- callr::r_bg(
+    function(directory) {
+      port <- httpuv::randomPort()
+      count <- 0L
+      server <- httpuv::startServer(
+        "127.0.0.1",
+        port,
+        list(call = function(req) {
+          count <<- count + 1L
+          request <- jsonlite::fromJSON(
+            rawToChar(req$rook.input$read()),
+            simplifyVector = FALSE
+          )
+          saveRDS(request, file.path(directory, paste0(count, ".rds")))
+          list(
+            status = 200L,
+            headers = list("Content-Type" = "text/event-stream"),
+            body = paste0(
+              'data: {"id":"fixture","model":"gpt-4o-mini","choices":[{"index":0,"delta":{"role":"assistant","content":"fixture reply"},"finish_reason":null}]}\n\n',
+              'data: {"id":"fixture","model":"gpt-4o-mini","choices":[{"index":0,"delta":{},"finish_reason":"stop"}],"usage":{"prompt_tokens":10,"completion_tokens":5,"total_tokens":15}}\n\n',
+              'data: [DONE]\n\n'
+            )
+          )
+        })
+      )
+      on.exit(server$stop(), add = TRUE)
+      saveRDS(port, file.path(directory, "port.rds"))
+      file.create(file.path(directory, "ready"))
+      repeat {
+        httpuv::service(50)
+      }
+    },
+    args = list(directory = directory)
+  )
+  withr::defer(process$kill(), envir = .local_envir)
+  deadline <- Sys.time() + 10
+  while (!file.exists(file.path(directory, "ready"))) {
+    if (!process$is_alive() || Sys.time() > deadline) {
+      cli::cli_abort("Local streaming fixture failed to start")
+    }
+    Sys.sleep(0.05)
+  }
+  list(
+    url = paste0(
+      "http://127.0.0.1:",
+      readRDS(file.path(directory, "port.rds")),
+      "/v1"
+    ),
+    requests = function() {
+      lapply(
+        list.files(directory, pattern = "^[0-9]+[.]rds$", full.names = TRUE),
+        readRDS
+      )
+    }
+  )
+}

--- a/tests/testthat/helper-parallel.R
+++ b/tests/testthat/helper-parallel.R
@@ -1,0 +1,97 @@
+create_parallel_chat <- function(state = new.env(parent = emptyenv())) {
+  if (is.null(state$started)) {
+    state$started <- character()
+    state$completed <- character()
+    state$active <- 0L
+    state$peak <- 0L
+    state$inputs <- list()
+    state$fail <- character()
+  }
+  chat <- create_mock_chat()
+  chat$get_tokens <- function() {
+    count <- sum(vapply(
+      chat$get_turns(),
+      inherits,
+      logical(1),
+      what = "ellmer::AssistantTurn"
+    ))
+    data.frame(
+      input = rep(10, count),
+      output = rep(5, count),
+      cached_input = rep(0, count),
+      cost = rep(0.001, count)
+    )
+  }
+  chat$last_turn <- function(role = "assistant") {
+    turns <- chat$get_turns()
+    if (length(turns) == 0L) {
+      return(NULL)
+    }
+    tail(turns, 1L)[[1L]]
+  }
+  chat$clone <- function(deep = FALSE) {
+    cloned <- create_parallel_chat(state)
+    cloned$set_turns(chat$get_turns())
+    cloned$set_system_prompt(chat$get_system_prompt())
+    cloned$set_tools(chat$get_tools())
+    cloned
+  }
+  chat$stream_async <- function(prompt, stream = "content", controller = NULL) {
+    coro::async_generator(function() {
+      key <- chat$get_system_prompt()
+      state$started <- c(state$started, key)
+      state$active <- state$active + 1L
+      state$peak <- max(state$peak, state$active)
+      state$inputs[[key]] <- list(
+        prompt = prompt,
+        turns = chat$get_turns(),
+        tools = chat$get_tools()
+      )
+      released <- FALSE
+      on.exit(
+        {
+          if (!released) state$active <- state$active - 1L
+        },
+        add = TRUE
+      )
+      coro::await(promises::promise(function(resolve, reject) {
+        if (isTRUE(state$hold_a_until_b) && key == "a") {
+          state$release_a <- resolve
+        } else {
+          later::later(function() resolve(NULL))
+        }
+      }))
+      state$active <- state$active - 1L
+      released <- TRUE
+      if (key == "b" && is.function(state$release_a)) {
+        state$release_a(NULL)
+        state$release_a <- NULL
+      }
+      if (key %in% state$fail) {
+        stop("deterministic responder failure")
+      }
+      text <- paste(key, prompt)
+      chat$set_turns(list(
+        ellmer::UserTurn(list(ellmer::ContentText(prompt))),
+        ellmer::AssistantTurn(
+          list(ellmer::ContentText(text)),
+          tokens = c(10, 5, 0),
+          cost = 0.001
+        )
+      ))
+      state$completed <- c(state$completed, key)
+      coro::yield(ellmer::ContentText(text))
+    })()
+  }
+  chat
+}
+
+parallel_test_lead <- function(state, ...) {
+  LeadAgent$new(
+    create_parallel_chat(state),
+    sub_agents = lapply(c("a", "b", "c"), function(name) {
+      agent_definition(name, paste("Responder", name), name)
+    }),
+    ...
+  )
+}

--- a/tests/testthat/helper-runtime.R
+++ b/tests/testthat/helper-runtime.R
@@ -141,7 +141,7 @@ create_content_stream_chat <- function(
       },
       on_tool_request = function(callback) state$on_tool_request <- callback,
       on_tool_result = function(callback) state$on_tool_result <- callback,
-      clone = function() {
+      clone = function(deep = FALSE) {
         create_content_stream_chat(
           tool_name = tool_name,
           tool_result = tool_result,

--- a/tests/testthat/test-agent-events.R
+++ b/tests/testthat/test-agent-events.R
@@ -85,17 +85,42 @@ test_that("interrupt cooperatively stops an active run", {
   expect_false(agent$interrupt())
 })
 
-test_that("interrupt before a provider call reports zero requests", {
-  agent <- Agent$new(chat = create_mock_chat("unused"))
+test_that("interrupt counts an already-dispatched request without an assistant turn", {
+  chat <- create_mock_chat("unused")
+  stream_async <- chat$stream_async
+  dispatched <- 0L
+  chat$stream_async <- function(...) {
+    dispatched <<- dispatched + 1L
+    stream_async(...)
+  }
+  agent <- Agent$new(chat = chat)
   generator <- agent$run("cancel")
   expect_identical(generator()$type, "start")
+  expect_identical(dispatched, 1L)
   agent$.__enclos_env__$private$current_stream_controller <- NULL
   expect_true(agent$interrupt("cancelled"))
 
   events <- collect_agent_events(generator)
   stop <- Filter(function(event) event$type == "stop", events)[[1L]]
   expect_identical(stop$reason, "cancelled")
-  expect_identical(stop$usage$requests, 0L)
+  expect_identical(stop$usage$requests, 1L)
+})
+
+test_that("cancellation during run initialization makes no provider request", {
+  chat <- create_mock_chat("unused")
+  chat$stream_async <- function(...) cli::cli_abort("unexpected dispatch")
+  agent <- Agent$new(chat = chat)
+  agent$add_hook(HookMatcher$new(
+    event = "SessionStart",
+    timeout = 0,
+    callback = function(...) {
+      agent$interrupt("cancelled")
+      NULL
+    }
+  ))
+  result <- agent$run_sync("cancel")
+  expect_identical(result$stop_reason, "cancelled")
+  expect_identical(result$usage$requests, 0L)
 })
 
 test_that("interrupt stops native streams that ignore their controller", {

--- a/tests/testthat/test-agents-multi.R
+++ b/tests/testthat/test-agents-multi.R
@@ -1243,7 +1243,7 @@ test_that("SubagentStop hook fires after successful delegation", {
   mock_chat <- create_mock_chat()
 
   # Add clone method to mock_chat for model inheritance
-  mock_chat$clone <- function() {
+  mock_chat$clone <- function(deep = FALSE) {
     sub_mock <- create_mock_chat(responses = list("Sub-agent result"))
     # Override stream to return strings
     sub_mock$stream <- function(prompt = NULL) {
@@ -1312,7 +1312,7 @@ test_that("delegation executes sub-agent and returns result", {
   mock_chat <- create_mock_chat()
 
   # Add clone method for model inheritance
-  mock_chat$clone <- function() {
+  mock_chat$clone <- function(deep = FALSE) {
     sub_mock <- create_mock_chat(
       responses = list("Task completed successfully")
     )
@@ -1364,7 +1364,7 @@ test_that("delegation passes permissions to sub-agent", {
   # Track what permissions were used
   sub_agent_created_with_perms <- NULL
 
-  mock_chat$clone <- function() {
+  mock_chat$clone <- function(deep = FALSE) {
     sub_mock <- create_mock_chat(responses = list("Done"))
     sub_mock$stream <- function(prompt = NULL) {
       yielded <- FALSE
@@ -1415,7 +1415,7 @@ test_that("delegation handles sub-agent execution failure", {
   mock_chat <- create_mock_chat()
 
   # Clone that produces a chat which will fail on both stream AND chat
-  mock_chat$clone <- function() {
+  mock_chat$clone <- function(deep = FALSE) {
     sub_mock <- create_mock_chat()
     sub_mock$stream <- function(prompt = NULL) {
       stop("Simulated stream failure")
@@ -1456,7 +1456,7 @@ test_that("delegation handles sub-agent execution failure", {
 test_that("SubagentStop hook receives working_dir in context", {
   mock_chat <- create_mock_chat()
 
-  mock_chat$clone <- function() {
+  mock_chat$clone <- function(deep = FALSE) {
     sub_mock <- create_mock_chat(responses = list("Result"))
     sub_mock$stream <- function(prompt = NULL) {
       yielded <- FALSE

--- a/tests/testthat/test-delegation-correlation.R
+++ b/tests/testthat/test-delegation-correlation.R
@@ -87,7 +87,7 @@ create_delegation_child_chat <- function() {
       },
       on_tool_request = function(callback) state$on_tool_request <- callback,
       on_tool_result = function(callback) state$on_tool_result <- callback,
-      clone = function() chat
+      clone = function(deep = FALSE) chat
     ),
     class = "Chat"
   )
@@ -217,7 +217,7 @@ create_delegation_parent_chat <- function(child_chat) {
       },
       on_tool_request = function(callback) state$on_tool_request <- callback,
       on_tool_result = function(callback) state$on_tool_result <- callback,
-      clone = function() child_chat
+      clone = function(deep = FALSE) child_chat
     ),
     class = "Chat"
   )

--- a/tests/testthat/test-parallel-delegate.R
+++ b/tests/testthat/test-parallel-delegate.R
@@ -55,6 +55,13 @@ test_that("stateless responders overlap with isolated conversations and ordered 
     unique(vapply(hooks, `[[`, character(1), "run_id")),
     batch$run$run_id
   )
+  for (context in hooks) {
+    expect_identical(context$parent_agent_id, lead$agent_id)
+    expect_identical(context$parent_run_id, batch$run$run_id)
+    child <- runs[runs$delegation_id == context$delegation_id, ]
+    expect_identical(context$child_agent_id, child$agent_id)
+    expect_identical(context$parent_run_id, child$parent_run_id)
+  }
   expect_length(lead$.__enclos_env__$private$delegation_usage_reservations, 0L)
 })
 

--- a/tests/testthat/test-parallel-delegate.R
+++ b/tests/testthat/test-parallel-delegate.R
@@ -1,0 +1,280 @@
+test_that("stateless responders overlap with isolated conversations and ordered results", {
+  state <- new.env(parent = emptyenv())
+  state$hold_a_until_b <- TRUE
+  lead <- parallel_test_lead(state, tools = list(tool_read_file))
+  lead$set_turns(list(create_mock_user_turn("private parent history")))
+  before <- lead$turns()
+  hooks <- list()
+  for (event in c("SubagentStart", "SubagentStop")) {
+    lead$add_hook(HookMatcher$new(
+      event = event,
+      timeout = 0,
+      callback = function(agent_name, context, ...) {
+        hooks[[length(hooks) + 1L]] <<- context
+        NULL
+      }
+    ))
+  }
+  batch <- resolve_async_value(lead$parallel_delegate_async(
+    c(a = "first", b = "second", c = "third")
+  ))
+  expect_identical(state$peak, 2L)
+  expect_identical(state$completed, c("b", "a", "c"))
+  expect_identical(batch$mode, "stateless")
+  expect_identical(
+    batch$status,
+    c(a = "completed", b = "completed", c = "completed")
+  )
+  expect_identical(
+    vapply(batch$results, function(result) result$response, character(1)),
+    c(a = "a first", b = "b second", c = "c third")
+  )
+  expect_identical(lead$turns(), before)
+  for (input in state$inputs) {
+    expect_length(input$turns, 0L)
+    expect_length(input$tools, 0L)
+  }
+  expect_equal(
+    batch$run$usage,
+    AgentUsage(
+      requests = 3L,
+      input_tokens = 30,
+      output_tokens = 15,
+      cost_usd = 0.003
+    )
+  )
+  expect_identical(lead$last_run(), batch$run)
+  expect_identical(batch$run$stop_reason, "complete")
+  runs <- lead$list_subagents()
+  expect_equal(nrow(runs), 3L)
+  expect_identical(unique(runs$parent_run_id), batch$run$run_id)
+  expect_length(unique(runs$agent_id), 3L)
+  expect_length(unique(runs$session_id), 3L)
+  expect_length(hooks, 6L)
+  expect_identical(
+    unique(vapply(hooks, `[[`, character(1), "run_id")),
+    batch$run$run_id
+  )
+  expect_length(lead$.__enclos_env__$private$delegation_usage_reservations, 0L)
+})
+
+test_that("fan-out rejects nonstateless definitions and invalid batches before dispatch", {
+  state <- new.env(parent = emptyenv())
+  lead <- parallel_test_lead(state)
+  lead$register_sub_agent(agent_definition(
+    "tool",
+    "Tool",
+    "Tool",
+    tools = list(tool_read_file)
+  ))
+  lead$register_sub_agent(agent_definition(
+    "mcp",
+    "MCP",
+    "MCP",
+    mcp_servers = "service"
+  ))
+  lead$register_sub_agent(agent_definition(
+    "skill",
+    "Skill",
+    "Skill",
+    skills = list("skill")
+  ))
+  for (name in c("tool", "mcp", "skill")) {
+    expect_error(
+      lead$parallel_delegate(stats::setNames("task", name)),
+      "not stateless"
+    )
+  }
+  expect_error(lead$parallel_delegate(c(a = "one", A = "two")), "at most once")
+  expect_error(
+    lead$parallel_delegate(c(missing = "task")),
+    "Unknown AgentDefinitions"
+  )
+  expect_error(lead$parallel_delegate("task"), "named character vector")
+  expect_error(
+    lead$parallel_delegate(c(a = "task"), max_active = 0),
+    "positive whole number"
+  )
+  expect_error(
+    lead$parallel_delegate(c(a = "task"), mode = "agentic"),
+    "stateless"
+  )
+  expect_length(state$started, 0L)
+})
+
+test_that("failed responders retain successful siblings and count dispatch attempts", {
+  state <- new.env(parent = emptyenv())
+  lead <- parallel_test_lead(state)
+  state$fail <- "b"
+  batch <- lead$parallel_delegate(c(a = "first", b = "second", c = "third"))
+  expect_identical(
+    batch$status,
+    c(a = "completed", b = "failed", c = "completed")
+  )
+  expect_match(
+    conditionMessage(batch$errors$b),
+    "deterministic responder failure"
+  )
+  expect_null(batch$results$b)
+  expect_identical(batch$run$usage$requests, 3L)
+  expect_identical(batch$run$usage$cost_usd, NA_real_)
+  expect_identical(batch$run$stop_reason, "delegation_error")
+  runs <- lead$list_subagents()
+  expect_identical(
+    runs$status[match(c("a", "b", "c"), runs$agent_name)],
+    c("completed", "failed", "completed")
+  )
+  expect_length(lead$.__enclos_env__$private$delegation_usage_reservations, 0L)
+  state$fail <- character()
+  next_batch <- lead$parallel_delegate(c(a = "again"))
+  expect_identical(next_batch$status, c(a = "completed"))
+  expect_identical(next_batch$run$usage$requests, 1L)
+})
+
+test_that("zero budgets and preparation failures leave the lead reusable", {
+  state <- new.env(parent = emptyenv())
+  lead <- parallel_test_lead(state)
+  batch <- lead$parallel_delegate(
+    c(a = "task"),
+    usage_limits = UsageLimits(max_requests = 0)
+  )
+  expect_identical(batch$status, c(a = "not_started"))
+  expect_identical(batch$run$usage$requests, 0L)
+  expect_error(
+    lead$parallel_delegate(
+      c(a = "task"),
+      usage_limits = UsageLimits(max_requests = 0, on_exceed = "error")
+    ),
+    class = "deputy_request_limit"
+  )
+  expect_length(state$started, 0L)
+  private <- lead$.__enclos_env__$private
+  clone <- private$.chat$clone
+  private$.chat$clone <- function(deep = FALSE) {
+    cli::cli_abort("fixture clone failure")
+  }
+  expect_error(lead$parallel_delegate(c(a = "task")), "fixture clone failure")
+  expect_false(private$run_active)
+  expect_identical(lead$last_run()$stop_reason, "error")
+  private$.chat$clone <- clone
+  expect_identical(
+    lead$parallel_delegate(c(a = "again"))$status,
+    c(a = "completed")
+  )
+})
+
+test_that("batch request limits reserve slots before concurrent dispatch", {
+  state <- new.env(parent = emptyenv())
+  lead <- parallel_test_lead(
+    state,
+    usage_limits = UsageLimits(max_requests = 2)
+  )
+  batch <- lead$parallel_delegate(
+    c(a = "first", b = "second", c = "third"),
+    max_active = 3
+  )
+  expect_identical(state$started, c("a", "b"))
+  expect_identical(batch$status[["c"]], "not_started")
+  expect_null(batch$results$c)
+  expect_identical(batch$run$usage$requests, 2L)
+  expect_identical(batch$run$stop_reason, "request_limit")
+  exact <- lead$parallel_delegate(c(a = "first", b = "second"))
+  expect_identical(exact$run$stop_reason, "complete")
+})
+
+test_that("unavailable costs and observed token overages stop queued responders", {
+  state <- new.env(parent = emptyenv())
+  lead <- parallel_test_lead(state)
+  state$fail <- "b"
+  batch <- lead$parallel_delegate(
+    c(a = "first", b = "second", c = "third"),
+    max_active = 1,
+    usage_limits = UsageLimits(max_cost_usd = 0.5)
+  )
+  expect_identical(batch$run$stop_reason, "cost_unavailable")
+  expect_identical(batch$status[["c"]], "not_started")
+  expect_identical(batch$run$usage$requests, 2L)
+  state$started <- character()
+  state$fail <- character()
+  batch <- lead$parallel_delegate(
+    c(a = "first", b = "second", c = "third"),
+    usage_limits = UsageLimits(max_total_tokens = 10)
+  )
+  expect_identical(batch$run$stop_reason, "total_token_limit")
+  expect_identical(batch$status[["c"]], "not_started")
+  expect_equal(batch$run$usage$total_tokens, 30)
+  expect_length(state$started, 2L)
+})
+
+test_that("interrupting a batch drains active responders and releases the lead", {
+  state <- new.env(parent = emptyenv())
+  lead <- parallel_test_lead(state)
+  promise <- lead$parallel_delegate_async(c(
+    a = "first",
+    b = "second",
+    c = "third"
+  ))
+  expect_error(
+    resolve_async_value(lead$run_async("overlap")),
+    class = "deputy_run_active"
+  )
+  expect_true(lead$interrupt("cancelled_by_host"))
+  batch <- resolve_async_value(promise)
+  expect_identical(batch$run$stop_reason, "cancelled_by_host")
+  expect_identical(batch$status[["c"]], "not_started")
+  expect_identical(state$active, 0L)
+  expect_false(lead$.__enclos_env__$private$run_active)
+  expect_length(lead$.__enclos_env__$private$delegation_usage_reservations, 0L)
+  again <- lead$parallel_delegate(c(a = "again"))
+  expect_identical(again$status, c(a = "completed"))
+})
+
+test_that("released ellmer Chats preserve transport and isolate runtime callbacks", {
+  server <- local_parallel_server()
+  chat <- ellmer::chat_openai_compatible(
+    base_url = server$url,
+    model = "gpt-4o-mini",
+    credentials = function() "fixture",
+    echo = "none"
+  )
+  lead <- LeadAgent$new(
+    chat,
+    tools = list(tool_read_file),
+    sub_agents = list(
+      agent_definition("a", "A", "A"),
+      agent_definition("b", "B", "B")
+    )
+  )
+  history <- list(
+    ellmer::UserTurn(list(ellmer::ContentText("private history"))),
+    ellmer::AssistantTurn(list(ellmer::ContentText("private answer")))
+  )
+  lead$set_turns(history)
+  parent_manager <- chat$.__enclos_env__$private$callback_on_tool_request
+  child <- lead$.__enclos_env__$private$create_sub_agent(lead$sub_agent_defs[[
+    1L
+  ]])
+  child_manager <- child$.__enclos_env__$private$.chat$.__enclos_env__$private$callback_on_tool_request
+  expect_false(identical(parent_manager, child_manager))
+  expect_identical(child_manager$count(), parent_manager$count())
+  batch <- lead$parallel_delegate(c(a = "first", b = "second"))
+  expect_identical(batch$status, c(a = "completed", b = "completed"))
+  expect_identical(trimws(batch$results$a$response), "fixture reply")
+  expect_identical(batch$run$usage$requests, 2L)
+  expect_equal(batch$run$usage$total_tokens, 30)
+  expect_equal(lead$turns(), history)
+  requests <- server$requests()
+  expect_length(requests, 2L)
+  for (request in requests) {
+    expect_identical(request$model, "gpt-4o-mini")
+    expect_null(request$tools)
+    expect_length(request$messages, 2L)
+    expect_true(request$messages[[1L]]$content %in% c("A", "B"))
+    content <- request$messages[[2L]]$content
+    if (is.list(content)) {
+      expect_length(content, 1L)
+      content <- content[[1L]]$text
+    }
+    expect_true(content %in% c("first", "second"))
+  }
+})

--- a/tests/testthat/test-parallel-delegate.R
+++ b/tests/testthat/test-parallel-delegate.R
@@ -229,6 +229,66 @@ test_that("interrupting a batch drains active responders and releases the lead",
   expect_identical(again$status, c(a = "completed"))
 })
 
+test_that("no-argument custom clones work when their callbacks are isolated", {
+  state <- new.env(parent = emptyenv())
+  lead <- parallel_test_lead(state)
+  chat <- lead$.__enclos_env__$private$.chat
+  clone <- chat$clone
+  chat$clone <- function() clone()
+  lead$.__enclos_env__$private$.chat <- chat
+  batch <- lead$parallel_delegate(c(a = "first", b = "second"))
+  expect_identical(batch$status, c(a = "completed", b = "completed"))
+
+  manager <- new.env(parent = emptyenv())
+  cleared <- FALSE
+  manager$clear <- function() cleared <<- TRUE
+  chat$.__enclos_env__ <- list(
+    private = list(callback_on_tool_request = manager)
+  )
+  chat$clone <- function() {
+    child <- clone()
+    child$.__enclos_env__ <- chat$.__enclos_env__
+    child
+  }
+  lead$.__enclos_env__$private$.chat <- chat
+  expect_error(
+    lead$parallel_delegate(c(a = "again")),
+    "must isolate tool callback managers"
+  )
+  expect_false(cleared)
+  expect_length(state$started, 2L)
+})
+
+test_that("cancellation from SubagentStart balances hooks without dispatching", {
+  state <- new.env(parent = emptyenv())
+  lead <- parallel_test_lead(state)
+  stopped <- list()
+  lead$add_hook(HookMatcher$new(
+    event = "SubagentStart",
+    timeout = 0,
+    callback = function(...) {
+      lead$interrupt("cancelled_before_dispatch")
+      NULL
+    }
+  ))
+  lead$add_hook(HookMatcher$new(
+    event = "SubagentStop",
+    timeout = 0,
+    callback = function(agent_name, context, ...) {
+      stopped[[agent_name]] <<- context$status
+      NULL
+    }
+  ))
+  batch <- lead$parallel_delegate(c(a = "first", b = "second"))
+  expect_identical(batch$status, c(a = "not_started", b = "not_started"))
+  expect_identical(stopped, list(a = "not_started"))
+  expect_length(state$started, 0L)
+  expect_identical(batch$run$usage$requests, 0L)
+  expect_identical(batch$run$stop_reason, "cancelled_before_dispatch")
+  expect_identical(lead$list_subagents()$status, "not_started")
+  expect_length(lead$.__enclos_env__$private$delegation_usage_reservations, 0L)
+})
+
 test_that("released ellmer Chats preserve transport and isolate runtime callbacks", {
   server <- local_parallel_server()
   chat <- ellmer::chat_openai_compatible(

--- a/vignettes/multi-agent.Rmd
+++ b/vignettes/multi-agent.Rmd
@@ -155,11 +155,81 @@ result <- lead$run_sync(
 cat(result$response)
 ```
 
-Direct synchronous delegation participates in the lead run's usage limits. Each
+Direct delegation participates in the lead run's usage limits. Each
 child inherits the lead's remaining `UsageLimits`, and its usage is aggregated
-into `result$usage` and enforced by the lead after delegation. This accounting
-does not yet cover parallel or background children, transitive child trees, or
-cross-run global limits.
+into `result$usage` and enforced by the lead after delegation. Concurrent direct
+children reserve allocations before launch. Background children, transitive
+child trees, and cross-run global limits remain outside this contract.
+
+## Stateless fan-out
+
+For independent perspectives on supplied text, the host can select responders
+directly. Each definition gets a fresh conversation with its own prompt and
+at most one model request. The lead makes no model request for orchestration.
+Definitions with tools, skills, or MCP servers are rejected before dispatch.
+
+```{r, eval = FALSE}
+lead <- LeadAgent$new(
+  ellmer::chat_openai(),
+  sub_agents = list(
+    agent_definition("benefits", "Find benefits", "Explain the strongest benefits."),
+    agent_definition("risks", "Find risks", "Explain the strongest risks.")
+  )
+)
+batch <- lead$parallel_delegate(
+  c(benefits = "Review a four-day working week.",
+    risks = "Review a four-day working week."),
+  max_active = 2,
+  usage_limits = UsageLimits(max_requests = 2),
+  run_context = list(workflow = "decision-review")
+)
+batch$status
+batch$results$benefits$response
+batch$run$usage
+lead$list_subagents()
+```
+
+Names are normalized and must select each registered definition at most once.
+The result preserves input order and has five fields:
+
+| Field | Meaning |
+| --- | --- |
+| `mode` | `"stateless"`; other modes are currently rejected |
+| `results` | Named list of child `AgentResult` objects, or `NULL` |
+| `errors` | Named list of captured conditions, or `NULL` |
+| `status` | Named vector: `completed`, `failed`, `stopped`, or `not_started` |
+| `run` | Aggregate `AgentResult` with usage, events, and batch stop reason |
+
+A failed responder does not discard successful siblings. Check `status` before
+synthesis; a stopped child may have partial text. Child records include unique
+agent, session, run, and delegation identifiers linked to the batch run, and
+fire the usual `SubagentStart` and `SubagentStop` hooks. `$last_run()` retains
+the aggregate on normal return. The lead's conversation is unchanged; the
+host explicitly supplies selected responses to any later synthesis run.
+
+### Limits and cancellation
+
+`max_active` bounds simultaneous responders. Work runs in waves: the next wave
+starts after all current responders settle. Each wave reserves request slots
+before dispatch and divides the remaining token and cost ceilings among its
+responders. A definition can narrow its request allowance to zero. Failed
+dispatch attempts count as requests; missing cost information stops queued
+work when a cost ceiling is configured.
+
+Request limits prevent excess dispatches. Token and cost ceilings use observed
+usage, so a wave can exceed them by up to one response per active responder.
+Unused allocations are released after settlement. All observed child usage is
+included in the aggregate, including failed or interrupted runs. The default
+`on_exceed = "stop"` returns partial outcomes. `on_exceed = "error"` raises the
+usual typed limit condition after cleanup; completed child records remain
+inspectable through `$list_subagents()` and `$get_subagent_results()`.
+
+For Shiny or another asynchronous host, use `$parallel_delegate_async()` and
+consume its promise. `$interrupt()` prevents queued work from starting and
+asks active responders to stop at the next supported provider boundary. The
+batch settles after its active responders drain. The lead rejects overlapping
+runs until cleanup finishes. Tool-using background workers and persistent
+agent scheduling are separate future work.
 
 ## Monitoring with SubagentStop Hooks
 


### PR DESCRIPTION
Closes #39.

Hosts can call `LeadAgent$parallel_delegate()` or `$parallel_delegate_async()` with named tasks to run fresh, tool-free responders in bounded concurrent waves. Outcomes preserve input order, successful siblings survive individual failures, and child records retain run/delegation correlation. The batch owns the lead's active-run slot and leaves its conversation intact.

Request slots are reserved before dispatch. Remaining token and cost ceilings are divided across each wave and checked against observed usage; a wave can overrun by one response per active child. Cancellation stops queued work and drains active responders. Failed dispatches count toward request limits, including when no assistant turn was recorded.

The implementation reuses Deputy's governed async kernel rather than adding another lifecycle around `ellmer::parallel_chat()`. Inherited Chats deep-clone and rebind runtime callbacks. ADR-0008 documents that decision and the explicit tier-1 boundary: definitions with tools, skills, or MCP servers are rejected, and agentic/background execution remains in #42.

Validation: full suite with released ellmer 0.5.0; R CMD check with minimum ellmer 0.4.2 (0 errors, 0 warnings, 0 notes); pkgdown build; Air; Jarl; `git diff --check`. Regression coverage includes deterministic overlap and out-of-order completion, real ellmer streaming against a localhost fixture, partial failure, budget exhaustion, cancellation, preparation failure, and reuse after cleanup.
