### PR TITLE
Default to GPT-5.6 Luna and refresh OpenAI examples

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -46,7 +46,7 @@ deputy/
 ├── tests/testthat/         # Unit tests (testthat edition 3)
 ├── inst/skills/            # Built-in skills with YAML metadata
 ├── inst/examples/          # Runnable recipes, standalone scripts, and Shiny app
-├── exec/deputy.R           # Terminal CLI using Rapp
+├── exec/deputy.R           # Terminal CLI using Rapp (OpenAI / gpt-5.6-luna default)
 ├── vignettes/              # User documentation (R Markdown)
 ├── man/                    # Auto-generated roxygen2 docs
 ├── dev/agents/             # Agent skill configuration (issue tracker, labels, domain)

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,10 @@
 # deputy (development version)
 
+* The CLI now defaults to OpenAI with `gpt-5.6-luna`. OpenAI examples also
+  select Luna explicitly, with documented Terra and Sol overrides. Explicit
+  model choices, other providers' defaults, and caller-supplied Chats are
+  preserved (#106).
+
 * The standalone `09-debate.R` example runs opposing stateless responders,
   formats their arguments side by side, and synthesizes completed results
   using a reusable, tool-free `debate` skill. Failed perspectives remain

--- a/R/agent.R
+++ b/R/agent.R
@@ -93,7 +93,7 @@ clone_compaction_chat <- function(chat) {
 #' \dontrun{
 #' # Create an agent with file tools
 #' agent <- Agent$new(
-#'   chat = ellmer::chat("openai/gpt-4o"),
+#'   chat = ellmer::chat("openai/gpt-5.6-luna"),
 #'   tools = tools_file()
 #' )
 #'

--- a/R/agents-multi.R
+++ b/R/agents-multi.R
@@ -129,7 +129,7 @@ normalize_agent_definitions <- function(definitions, arg = "sub_agents") {
 #'
 #' # Use with a lead agent
 #' lead <- LeadAgent$new(
-#'   chat = ellmer::chat("openai/gpt-4o"),
+#'   chat = ellmer::chat("openai/gpt-5.6-luna"),
 #'   sub_agents = list(code_reviewer)
 #' )
 #' }

--- a/R/cli.R
+++ b/R/cli.R
@@ -147,11 +147,7 @@ cli_create_chat <- function(provider, model) {
     } else {
       ellmer::chat_anthropic(model = model)
     },
-    openai = if (is.null(model)) {
-      ellmer::chat_openai()
-    } else {
-      ellmer::chat_openai(model = model)
-    },
+    openai = ellmer::chat_openai(model = model %||% "gpt-5.6-luna"),
     google = if (is.null(model)) {
       ellmer::chat_google_gemini()
     } else {
@@ -616,7 +612,7 @@ deputy_cli_main <- function(config) {
     }
   )
   if (debug_enabled) {
-    model <- config$model %||% "<default>"
+    model <- chat$get_model()
     debug_log(
       "Chat initialized for provider=",
       config$provider,

--- a/R/deputy-package.R
+++ b/R/deputy-package.R
@@ -35,7 +35,7 @@ NULL
 #'
 #' # Create an agent with file tools
 #' agent <- Agent$new(
-#'   chat = ellmer::chat("openai/gpt-4o"),
+#'   chat = ellmer::chat("openai/gpt-5.6-luna"),
 #'   tools = tools_preset("standard")
 #' )
 #'

--- a/R/tools-builtin.R
+++ b/R/tools-builtin.R
@@ -270,7 +270,7 @@ glob_relative_paths <- function(path = ".", pattern = "*", recursive = TRUE) {
 #' @examples
 #' \dontrun{
 #' agent <- Agent$new(
-#'   chat = ellmer::chat("openai/gpt-4o"),
+#'   chat = ellmer::chat("openai/gpt-5.6-luna"),
 #'   tools = list(tool_read_file)
 #' )
 #' }
@@ -414,7 +414,7 @@ tool_read_markdown <- ellmer::tool(
 #' @examples
 #' \dontrun{
 #' agent <- Agent$new(
-#'   chat = ellmer::chat("openai/gpt-4o"),
+#'   chat = ellmer::chat("openai/gpt-5.6-luna"),
 #'   tools = list(tool_write_file)
 #' )
 #' }
@@ -626,7 +626,7 @@ tool_multi_edit <- ellmer::tool(
 #' @examples
 #' \dontrun{
 #' agent <- Agent$new(
-#'   chat = ellmer::chat("openai/gpt-4o"),
+#'   chat = ellmer::chat("openai/gpt-5.6-luna"),
 #'   tools = list(tool_list_files)
 #' )
 #' }
@@ -998,7 +998,7 @@ run_r_code_impl <- function(code, timeout = 30, working_dir = getwd()) {
 #' @examples
 #' \dontrun{
 #' agent <- Agent$new(
-#'   chat = ellmer::chat("openai/gpt-4o"),
+#'   chat = ellmer::chat("openai/gpt-5.6-luna"),
 #'   tools = list(tool_run_r_code)
 #' )
 #' }
@@ -1097,7 +1097,7 @@ run_bash_impl <- function(command, timeout = 30, working_dir = getwd()) {
 #' @examples
 #' \dontrun{
 #' agent <- Agent$new(
-#'   chat = ellmer::chat("openai/gpt-4o"),
+#'   chat = ellmer::chat("openai/gpt-5.6-luna"),
 #'   tools = list(tool_run_bash),
 #'   permissions = permissions_full()  # Required for bash
 #' )
@@ -1142,7 +1142,7 @@ attr(tool_run_bash, "deputy_workspace_runner") <-
 #' @examples
 #' \dontrun{
 #' agent <- Agent$new(
-#'   chat = ellmer::chat("openai/gpt-4o"),
+#'   chat = ellmer::chat("openai/gpt-5.6-luna"),
 #'   tools = list(tool_read_csv)
 #' )
 #' }

--- a/R/tools-bundles.R
+++ b/R/tools-bundles.R
@@ -14,7 +14,7 @@
 #' @examples
 #' \dontrun{
 #' agent <- Agent$new(
-#'   chat = ellmer::chat("openai/gpt-4o"),
+#'   chat = ellmer::chat("openai/gpt-5.6-luna"),
 #'   tools = tools_file()
 #' )
 #' }
@@ -46,7 +46,7 @@ tools_file <- function() {
 #' @examples
 #' \dontrun{
 #' agent <- Agent$new(
-#'   chat = ellmer::chat("openai/gpt-4o"),
+#'   chat = ellmer::chat("openai/gpt-5.6-luna"),
 #'   tools = tools_code()
 #' )
 #' }
@@ -72,7 +72,7 @@ tools_code <- function() {
 #' @examples
 #' \dontrun{
 #' agent <- Agent$new(
-#'   chat = ellmer::chat("openai/gpt-4o"),
+#'   chat = ellmer::chat("openai/gpt-5.6-luna"),
 #'   tools = tools_data()
 #' )
 #' }
@@ -220,7 +220,7 @@ get_provider_name <- function(chat) {
 #' \dontrun{
 #' # Allow all tools with full permissions
 #' agent <- Agent$new(
-#'   chat = ellmer::chat("openai/gpt-4o"),
+#'   chat = ellmer::chat("openai/gpt-5.6-luna"),
 #'   tools = tools_all(),
 #'   permissions = permissions_full()
 #' )
@@ -271,20 +271,20 @@ ToolPresets <- c("minimal", "standard", "dev", "data", "full")
 #' \dontrun{
 #' # Minimal preset for read-only operations
 #' agent <- Agent$new(
-#'   chat = ellmer::chat("openai/gpt-4o"),
+#'   chat = ellmer::chat("openai/gpt-5.6-luna"),
 #'   tools = tools_preset("minimal"),
 #'   permissions = permissions_readonly()
 #' )
 #'
 #' # Standard preset for typical development
 #' agent <- Agent$new(
-#'   chat = ellmer::chat("openai/gpt-4o"),
+#'   chat = ellmer::chat("openai/gpt-5.6-luna"),
 #'   tools = tools_preset("standard")
 #' )
 #'
 #' # Data analysis preset
 #' agent <- Agent$new(
-#'   chat = ellmer::chat("openai/gpt-4o"),
+#'   chat = ellmer::chat("openai/gpt-5.6-luna"),
 #'   tools = tools_preset("data")
 #' )
 #' }

--- a/R/tools-interactive.R
+++ b/R/tools-interactive.R
@@ -391,7 +391,7 @@ validate_questions <- function(questions) {
 #' \dontrun{
 #' # Add to agent's tools
 #' agent <- Agent$new(
-#'   chat = ellmer::chat("openai/gpt-4o"),
+#'   chat = ellmer::chat("openai/gpt-5.6-luna"),
 #'   tools = c(tools_file(), tool_ask_user)
 #' )
 #'
@@ -438,7 +438,7 @@ tool_ask_user <- new_ask_user_tool()
 #' agent_id <- "agent-review"
 #' session_id <- "session-review"
 #' agent <- Agent$new(
-#'   chat = ellmer::chat("openai/gpt-4o"),
+#'   chat = ellmer::chat("openai/gpt-5.6-luna"),
 #'   tools = c(
 #'     tools_file(),
 #'     tools_interactive(

--- a/R/tools-mcp.R
+++ b/R/tools-mcp.R
@@ -133,7 +133,7 @@ validate_mcp_repl_sandbox_server <- function(server, sandbox) {
 #'   sandbox = "workspace-write"
 #' )
 #' agent <- Agent$new(
-#'   chat = ellmer::chat("openai"),
+#'   chat = ellmer::chat("openai/gpt-5.6-luna"),
 #'   tools = repl_tools,
 #'   permissions = Permissions$new(web = FALSE)
 #' )

--- a/R/tools-web.R
+++ b/R/tools-web.R
@@ -26,7 +26,7 @@
 #' @examples
 #' \dontrun{
 #' agent <- Agent$new(
-#'   chat = ellmer::chat("openai/gpt-4o"),
+#'   chat = ellmer::chat("openai/gpt-5.6-luna"),
 #'   tools = list(tool_web_fetch),
 #'   permissions = Permissions$new(web = TRUE)
 #' )
@@ -119,7 +119,7 @@ tool_web_fetch <- ellmer::tool(
 #' @examples
 #' \dontrun{
 #' agent <- Agent$new(
-#'   chat = ellmer::chat("openai/gpt-4o"),
+#'   chat = ellmer::chat("openai/gpt-5.6-luna"),
 #'   tools = list(tool_web_search),
 #'   permissions = Permissions$new(web = TRUE)
 #' )

--- a/README.Rmd
+++ b/README.Rmd
@@ -100,11 +100,12 @@ stopifnot(
 )
 ```
 
-Then choose any provider supported by ellmer and run a task. The model call is
+The examples use `gpt-5.6-luna`, the inexpensive GPT-5.6 model. Choose any
+provider supported by ellmer when creating your own Chat. The model call is
 not executed while building the documentation:
 
 ```{r first-agent, eval = FALSE}
-chat <- ellmer::chat("openai")
+chat <- ellmer::chat("openai/gpt-5.6-luna")
 
 agent <- Agent$new(
   chat = chat,
@@ -119,6 +120,13 @@ result <- agent$run_sync(
   "Explain what this R package does. Support the answer with file paths."
 )
 ```
+
+Set `OPENAI_API_KEY` for these examples. To use a larger GPT-5.6 model, replace
+`gpt-5.6-luna` with `gpt-5.6-terra` (balanced) or `gpt-5.6-sol` (flagship).
+Use the explicit tier name: `gpt-5.6` is an alias for Sol. See OpenAI's
+[model guide](https://developers.openai.com/api/docs/guides/latest-model?model=gpt-5.6)
+for the tier tradeoffs. Deputy preserves the model and parameters of the Chat
+you supply, including when it creates inherited child Chats.
 
 `run_sync()` returns an `AgentResult`, not just text:
 
@@ -180,8 +188,13 @@ rx --from github::JamesHWade/deputy deputy \
   --provider openai "Summarize the R files in this project"
 
 ir tool install github::JamesHWade/deputy
-deputy --provider openai --tools minimal
+deputy --tools minimal
+deputy --model gpt-5.6-terra --tools minimal
 ```
+
+The CLI defaults to OpenAI with `gpt-5.6-luna`. Use `--model` to select another
+model or `--provider` to select another provider, such as `--provider anthropic`.
+Other providers retain their own model defaults when `--model` is omitted.
 
 ## Status
 

--- a/README.md
+++ b/README.md
@@ -94,11 +94,12 @@ stopifnot(
 )
 ```
 
-Then choose any provider supported by ellmer and run a task. The model
+The examples use `gpt-5.6-luna`, the inexpensive GPT-5.6 model. Choose
+any provider supported by ellmer when creating your own Chat. The model
 call is not executed while building the documentation:
 
 ``` r
-chat <- ellmer::chat("openai")
+chat <- ellmer::chat("openai/gpt-5.6-luna")
 
 agent <- Agent$new(
   chat = chat,
@@ -113,6 +114,14 @@ result <- agent$run_sync(
   "Explain what this R package does. Support the answer with file paths."
 )
 ```
+
+Set `OPENAI_API_KEY` for these examples. To use a larger GPT-5.6 model,
+replace `gpt-5.6-luna` with `gpt-5.6-terra` (balanced) or `gpt-5.6-sol`
+(flagship). Use the explicit tier name: `gpt-5.6` is an alias for Sol.
+See OpenAI’s [model
+guide](https://developers.openai.com/api/docs/guides/latest-model?model=gpt-5.6)
+for the tier tradeoffs. Deputy preserves the model and parameters of the
+Chat you supply, including when it creates inherited child Chats.
 
 `run_sync()` returns an `AgentResult`, not just text:
 
@@ -180,8 +189,14 @@ rx --from github::JamesHWade/deputy deputy \
   --provider openai "Summarize the R files in this project"
 
 ir tool install github::JamesHWade/deputy
-deputy --provider openai --tools minimal
+deputy --tools minimal
+deputy --model gpt-5.6-terra --tools minimal
 ```
+
+The CLI defaults to OpenAI with `gpt-5.6-luna`. Use `--model` to select
+another model or `--provider` to select another provider, such as
+`--provider anthropic`. Other providers retain their own model defaults
+when `--model` is omitted.
 
 ## Status
 

--- a/exec/deputy.R
+++ b/exec/deputy.R
@@ -5,9 +5,9 @@
 
 #| description: "LLM provider to use (anthropic, openai, google, ollama)"
 #| short: 'p'
-provider <- "anthropic"
+provider <- "openai"
 
-#| description: "Model to use (provider-specific)"
+#| description: "Model to use (OpenAI default: gpt-5.6-luna; otherwise provider-specific)"
 #| short: 'm'
 model <- NA_character_
 

--- a/inst/examples/shiny-chat/app.R
+++ b/inst/examples/shiny-chat/app.R
@@ -8,7 +8,7 @@ ui <- bslib::page_fluid(
 
 server <- function(input, output, session) {
   chat <- ellmer::chat_openai(
-    model = "gpt-4o-mini",
+    model = "gpt-5.6-luna",
     system_prompt = "You are a helpful assistant that can read and analyse
       files. Be concise."
   )

--- a/inst/examples/standalone/01-basic.R
+++ b/inst/examples/standalone/01-basic.R
@@ -1,7 +1,7 @@
 # Run with Rscript after installing deputy and setting OPENAI_API_KEY.
 library(deputy)
 chat <- ellmer::chat_openai(
-  model = Sys.getenv("DEPUTY_EXAMPLE_MODEL", "gpt-4o-mini")
+  model = Sys.getenv("DEPUTY_EXAMPLE_MODEL", "gpt-5.6-luna")
 )
 
 agent <- Agent$new(

--- a/inst/examples/standalone/02-tools.R
+++ b/inst/examples/standalone/02-tools.R
@@ -1,7 +1,7 @@
 # Run with Rscript after installing deputy and setting OPENAI_API_KEY.
 library(deputy)
 chat <- ellmer::chat_openai(
-  model = Sys.getenv("DEPUTY_EXAMPLE_MODEL", "gpt-4o-mini")
+  model = Sys.getenv("DEPUTY_EXAMPLE_MODEL", "gpt-5.6-luna")
 )
 
 workspace <- tempfile("deputy-tools-")

--- a/inst/examples/standalone/03-permissions.R
+++ b/inst/examples/standalone/03-permissions.R
@@ -1,7 +1,7 @@
 # Run with Rscript after installing deputy and setting OPENAI_API_KEY.
 library(deputy)
 chat <- ellmer::chat_openai(
-  model = Sys.getenv("DEPUTY_EXAMPLE_MODEL", "gpt-4o-mini")
+  model = Sys.getenv("DEPUTY_EXAMPLE_MODEL", "gpt-5.6-luna")
 )
 
 workspace <- tempfile("deputy-permissions-")

--- a/inst/examples/standalone/04-hooks.R
+++ b/inst/examples/standalone/04-hooks.R
@@ -1,7 +1,7 @@
 # Run with Rscript after installing deputy and setting OPENAI_API_KEY.
 library(deputy)
 chat <- ellmer::chat_openai(
-  model = Sys.getenv("DEPUTY_EXAMPLE_MODEL", "gpt-4o-mini")
+  model = Sys.getenv("DEPUTY_EXAMPLE_MODEL", "gpt-5.6-luna")
 )
 
 workspace <- tempfile("deputy-hooks-")

--- a/inst/examples/standalone/05-delegation.R
+++ b/inst/examples/standalone/05-delegation.R
@@ -1,7 +1,7 @@
 # Run with Rscript after installing deputy and setting OPENAI_API_KEY.
 library(deputy)
 chat <- ellmer::chat_openai(
-  model = Sys.getenv("DEPUTY_EXAMPLE_MODEL", "gpt-4o-mini")
+  model = Sys.getenv("DEPUTY_EXAMPLE_MODEL", "gpt-5.6-luna")
 )
 
 reviewer <- agent_definition(

--- a/inst/examples/standalone/06-structured-output.R
+++ b/inst/examples/standalone/06-structured-output.R
@@ -2,7 +2,7 @@
 library(deputy)
 rlang::check_installed("jsonlite", reason = "to run this example")
 chat <- ellmer::chat_openai(
-  model = Sys.getenv("DEPUTY_EXAMPLE_MODEL", "gpt-4o-mini")
+  model = Sys.getenv("DEPUTY_EXAMPLE_MODEL", "gpt-5.6-luna")
 )
 
 agent <- Agent$new(

--- a/inst/examples/standalone/07-session-resume.R
+++ b/inst/examples/standalone/07-session-resume.R
@@ -1,7 +1,7 @@
 # Run with Rscript after installing deputy and setting OPENAI_API_KEY.
 library(deputy)
 chat <- ellmer::chat_openai(
-  model = Sys.getenv("DEPUTY_EXAMPLE_MODEL", "gpt-4o-mini")
+  model = Sys.getenv("DEPUTY_EXAMPLE_MODEL", "gpt-5.6-luna")
 )
 
 agent <- Agent$new(
@@ -16,7 +16,7 @@ agent$save_session(session_file)
 # A new Agent provides the backend and permission ceiling for the resumed chat.
 resumed <- Agent$new(
   chat = ellmer::chat_openai(
-    model = Sys.getenv("DEPUTY_EXAMPLE_MODEL", "gpt-4o-mini")
+    model = Sys.getenv("DEPUTY_EXAMPLE_MODEL", "gpt-5.6-luna")
   ),
   tools = list(),
   usage_limits = UsageLimits(max_requests = 3)

--- a/inst/examples/standalone/08-skills.R
+++ b/inst/examples/standalone/08-skills.R
@@ -2,7 +2,7 @@
 library(deputy)
 rlang::check_installed("yaml", reason = "to run this example")
 chat <- ellmer::chat_openai(
-  model = Sys.getenv("DEPUTY_EXAMPLE_MODEL", "gpt-4o-mini")
+  model = Sys.getenv("DEPUTY_EXAMPLE_MODEL", "gpt-5.6-luna")
 )
 
 skill_dir <- tempfile("deputy-skill-")

--- a/inst/examples/standalone/09-debate.R
+++ b/inst/examples/standalone/09-debate.R
@@ -2,7 +2,7 @@
 # Two independent one-request perspectives, then one synthesis request.
 library(deputy)
 rlang::check_installed("yaml", reason = "to load the debate skill")
-model <- Sys.getenv("DEPUTY_EXAMPLE_MODEL", "gpt-4o-mini")
+model <- Sys.getenv("DEPUTY_EXAMPLE_MODEL", "gpt-5.6-luna")
 question <- Sys.getenv(
   "DEPUTY_DEBATE_TOPIC",
   "Should a small R package adopt a mandatory code review for every change?"

--- a/inst/examples/standalone/README.md
+++ b/inst/examples/standalone/README.md
@@ -5,8 +5,13 @@ Install deputy and its released ellmer dependency, set
 optional packages `jsonlite` (structured output) and `yaml` (skills), for example
 with `install.packages(c("jsonlite", "yaml"))`. Those scripts check these
 dependencies before creating a chat. Live runs
-make billable model requests. Set `DEPUTY_EXAMPLE_MODEL` to choose another
-OpenAI model supported by your account.
+make billable model requests using `gpt-5.6-luna` by default. Set
+`DEPUTY_EXAMPLE_MODEL` to choose another OpenAI model supported by your account,
+such as `gpt-5.6-terra` or `gpt-5.6-sol`. The `gpt-5.6` alias selects Sol.
+
+```bash
+DEPUTY_EXAMPLE_MODEL=gpt-5.6-terra Rscript inst/examples/standalone/01-basic.R
+```
 
 ```r
 example <- system.file("examples", "standalone", "01-basic.R", package = "deputy")

--- a/man/Agent.Rd
+++ b/man/Agent.Rd
@@ -58,7 +58,7 @@ invalidate later file history. Conversation history is not changed.}
 \dontrun{
 # Create an agent with file tools
 agent <- Agent$new(
-  chat = ellmer::chat("openai/gpt-4o"),
+  chat = ellmer::chat("openai/gpt-5.6-luna"),
   tools = tools_file()
 )
 

--- a/man/agent_definition.Rd
+++ b/man/agent_definition.Rd
@@ -68,7 +68,7 @@ code_reviewer <- agent_definition(
 
 # Use with a lead agent
 lead <- LeadAgent$new(
-  chat = ellmer::chat("openai/gpt-4o"),
+  chat = ellmer::chat("openai/gpt-5.6-luna"),
   sub_agents = list(code_reviewer)
 )
 }

--- a/man/deputy-package.Rd
+++ b/man/deputy-package.Rd
@@ -35,7 +35,7 @@ delegation.
 
 # Create an agent with file tools
 agent <- Agent$new(
-  chat = ellmer::chat("openai/gpt-4o"),
+  chat = ellmer::chat("openai/gpt-5.6-luna"),
   tools = tools_preset("standard")
 )
 

--- a/man/tool_ask_user.Rd
+++ b/man/tool_ask_user.Rd
@@ -57,7 +57,7 @@ tool with \code{\link[=tools_interactive]{tools_interactive()}}.
 \dontrun{
 # Add to agent's tools
 agent <- Agent$new(
-  chat = ellmer::chat("openai/gpt-4o"),
+  chat = ellmer::chat("openai/gpt-5.6-luna"),
   tools = c(tools_file(), tool_ask_user)
 )
 

--- a/man/tool_list_files.Rd
+++ b/man/tool_list_files.Rd
@@ -33,7 +33,7 @@ A tool that lists files and directories within a specified path.
 \examples{
 \dontrun{
 agent <- Agent$new(
-  chat = ellmer::chat("openai/gpt-4o"),
+  chat = ellmer::chat("openai/gpt-5.6-luna"),
   tools = list(tool_list_files)
 )
 }

--- a/man/tool_read_csv.Rd
+++ b/man/tool_read_csv.Rd
@@ -27,7 +27,7 @@ along with the first few rows.
 \examples{
 \dontrun{
 agent <- Agent$new(
-  chat = ellmer::chat("openai/gpt-4o"),
+  chat = ellmer::chat("openai/gpt-5.6-luna"),
   tools = list(tool_read_csv)
 )
 }

--- a/man/tool_read_file.Rd
+++ b/man/tool_read_file.Rd
@@ -25,7 +25,7 @@ A tool that reads the contents of a file and returns it as a string.
 \examples{
 \dontrun{
 agent <- Agent$new(
-  chat = ellmer::chat("openai/gpt-4o"),
+  chat = ellmer::chat("openai/gpt-5.6-luna"),
   tools = list(tool_read_file)
 )
 }

--- a/man/tool_run_bash.Rd
+++ b/man/tool_run_bash.Rd
@@ -23,7 +23,7 @@ A tool that executes bash/shell commands and returns the output.
 \examples{
 \dontrun{
 agent <- Agent$new(
-  chat = ellmer::chat("openai/gpt-4o"),
+  chat = ellmer::chat("openai/gpt-5.6-luna"),
   tools = list(tool_run_bash),
   permissions = permissions_full()  # Required for bash
 )

--- a/man/tool_run_r_code.Rd
+++ b/man/tool_run_r_code.Rd
@@ -35,7 +35,7 @@ The execution boundary is explicit:
 \examples{
 \dontrun{
 agent <- Agent$new(
-  chat = ellmer::chat("openai/gpt-4o"),
+  chat = ellmer::chat("openai/gpt-5.6-luna"),
   tools = list(tool_run_r_code)
 )
 }

--- a/man/tool_web_fetch.Rd
+++ b/man/tool_web_fetch.Rd
@@ -34,7 +34,7 @@ The tool respects a 30-second timeout and follows redirects.
 \examples{
 \dontrun{
 agent <- Agent$new(
-  chat = ellmer::chat("openai/gpt-4o"),
+  chat = ellmer::chat("openai/gpt-5.6-luna"),
   tools = list(tool_web_fetch),
   permissions = Permissions$new(web = TRUE)
 )

--- a/man/tool_web_search.Rd
+++ b/man/tool_web_search.Rd
@@ -30,7 +30,7 @@ consider using a dedicated search API.
 \examples{
 \dontrun{
 agent <- Agent$new(
-  chat = ellmer::chat("openai/gpt-4o"),
+  chat = ellmer::chat("openai/gpt-5.6-luna"),
   tools = list(tool_web_search),
   permissions = Permissions$new(web = TRUE)
 )

--- a/man/tool_write_file.Rd
+++ b/man/tool_write_file.Rd
@@ -26,7 +26,7 @@ A tool that writes content to a file, creating it if it doesn't exist.
 \examples{
 \dontrun{
 agent <- Agent$new(
-  chat = ellmer::chat("openai/gpt-4o"),
+  chat = ellmer::chat("openai/gpt-5.6-luna"),
   tools = list(tool_write_file)
 )
 }

--- a/man/tools_all.Rd
+++ b/man/tools_all.Rd
@@ -17,7 +17,7 @@ to allow all operations.
 \dontrun{
 # Allow all tools with full permissions
 agent <- Agent$new(
-  chat = ellmer::chat("openai/gpt-4o"),
+  chat = ellmer::chat("openai/gpt-5.6-luna"),
   tools = tools_all(),
   permissions = permissions_full()
 )

--- a/man/tools_code.Rd
+++ b/man/tools_code.Rd
@@ -23,7 +23,7 @@ both tools.
 \examples{
 \dontrun{
 agent <- Agent$new(
-  chat = ellmer::chat("openai/gpt-4o"),
+  chat = ellmer::chat("openai/gpt-5.6-luna"),
   tools = tools_code()
 )
 }

--- a/man/tools_data.Rd
+++ b/man/tools_data.Rd
@@ -19,7 +19,7 @@ Returns a list of tools for reading data files:
 \examples{
 \dontrun{
 agent <- Agent$new(
-  chat = ellmer::chat("openai/gpt-4o"),
+  chat = ellmer::chat("openai/gpt-5.6-luna"),
   tools = tools_data()
 )
 }

--- a/man/tools_file.Rd
+++ b/man/tools_file.Rd
@@ -20,7 +20,7 @@ Returns a list of tools for file operations:
 \examples{
 \dontrun{
 agent <- Agent$new(
-  chat = ellmer::chat("openai/gpt-4o"),
+  chat = ellmer::chat("openai/gpt-5.6-luna"),
   tools = tools_file()
 )
 }

--- a/man/tools_interactive.Rd
+++ b/man/tools_interactive.Rd
@@ -30,7 +30,7 @@ hosts so each Agent receives its own handler.
 agent_id <- "agent-review"
 session_id <- "session-review"
 agent <- Agent$new(
-  chat = ellmer::chat("openai/gpt-4o"),
+  chat = ellmer::chat("openai/gpt-5.6-luna"),
   tools = c(
     tools_file(),
     tools_interactive(

--- a/man/tools_mcp_repl.Rd
+++ b/man/tools_mcp_repl.Rd
@@ -42,7 +42,7 @@ repl_tools <- tools_mcp_repl(
   sandbox = "workspace-write"
 )
 agent <- Agent$new(
-  chat = ellmer::chat("openai"),
+  chat = ellmer::chat("openai/gpt-5.6-luna"),
   tools = repl_tools,
   permissions = Permissions$new(web = FALSE)
 )

--- a/man/tools_preset.Rd
+++ b/man/tools_preset.Rd
@@ -31,20 +31,20 @@ Presets simplify agent setup by providing curated toolsets.
 \dontrun{
 # Minimal preset for read-only operations
 agent <- Agent$new(
-  chat = ellmer::chat("openai/gpt-4o"),
+  chat = ellmer::chat("openai/gpt-5.6-luna"),
   tools = tools_preset("minimal"),
   permissions = permissions_readonly()
 )
 
 # Standard preset for typical development
 agent <- Agent$new(
-  chat = ellmer::chat("openai/gpt-4o"),
+  chat = ellmer::chat("openai/gpt-5.6-luna"),
   tools = tools_preset("standard")
 )
 
 # Data analysis preset
 agent <- Agent$new(
-  chat = ellmer::chat("openai/gpt-4o"),
+  chat = ellmer::chat("openai/gpt-5.6-luna"),
   tools = tools_preset("data")
 )
 }

--- a/tests/testthat/test-cli.R
+++ b/tests/testthat/test-cli.R
@@ -121,6 +121,32 @@ test_that("Rapp parses CLI options before entering the package runtime", {
   expect_equal(captured$task, "one complete task")
 })
 
+test_that("CLI model defaults and overrides reach the real ellmer Chat", {
+  withr::local_envvar(OPENAI_API_KEY = "example")
+  chat <- NULL
+  local_mocked_bindings(
+    deputy_cli_main = function(config) {
+      config <- cli_normalize_config(config)
+      chat <<- cli_create_chat(config$provider, config$model)
+      invisible(NULL)
+    },
+    .package = "deputy"
+  )
+
+  Rapp::run(cli_test_app(), "inspect files")
+  expect_identical(chat$get_model(), "gpt-5.6-luna")
+
+  Rapp::run(cli_test_app(), c("--provider", "openai", "inspect files"))
+  expect_identical(chat$get_model(), "gpt-5.6-luna")
+
+  for (model in c("gpt-5.6-terra", "gpt-5.6-sol", "gpt-4o-mini")) {
+    Rapp::run(cli_test_app(), c("--model", model, "inspect files"))
+    expect_identical(chat$get_model(), model)
+    agent <- Agent$new(chat, tools = list())
+    expect_identical(agent$get_model(), model)
+  }
+})
+
 test_that("Rapp discovers and installs the package executable", {
   destination <- withr::local_tempdir()
 
@@ -160,6 +186,25 @@ test_that("Google uses the current ellmer constructor and its default model", {
     list(provider = "google")
   )
   expect_equal(seen_model, "gemini-test")
+})
+
+test_that("Anthropic retains its provider default and explicit model override", {
+  seen_model <- NULL
+  local_mocked_bindings(
+    chat_anthropic = function(model) {
+      seen_model <<- if (missing(model)) "<provider-default>" else model
+      list(provider = "anthropic")
+    },
+    .package = "ellmer"
+  )
+
+  expect_equal(cli_create_chat("anthropic", NULL), list(provider = "anthropic"))
+  expect_equal(seen_model, "<provider-default>")
+  expect_equal(
+    cli_create_chat("anthropic", "claude-test"),
+    list(provider = "anthropic")
+  )
+  expect_equal(seen_model, "claude-test")
 })
 
 test_that("CLI builds permissions and usage limits separately", {

--- a/tests/testthat/test-standalone-examples.R
+++ b/tests/testthat/test-standalone-examples.R
@@ -3,23 +3,30 @@ run_standalone_example <- function(
   chat,
   env = new.env(parent = as.environment("package:deputy"))
 ) {
+  models <- character()
   local_mocked_bindings(
-    chat_openai = function(...) if (is.function(chat)) chat() else chat,
+    chat_openai = function(model, ...) {
+      models <<- c(models, model)
+      if (is.function(chat)) chat() else chat
+    },
     .package = "ellmer"
   )
   path <- system.file("examples", "standalone", name, package = "deputy")
   sys.source(path, envir = env)
+  attr(env, "models") <- models
   env
 }
 
 test_that("basic, structured, session and skill scripts execute independently", {
   skip_if_not_installed("jsonlite")
   skip_if_not_installed("yaml")
+  withr::local_envvar(DEPUTY_EXAMPLE_MODEL = NA_character_)
   basic <- run_standalone_example(
     "01-basic.R",
     create_mock_chat("An R vector.")
   )
   expect_identical(basic$result$response, "An R vector.")
+  expect_identical(attr(basic, "models"), "gpt-5.6-luna")
   structured <- run_standalone_example(
     "06-structured-output.R",
     create_mock_chat('{"status":"ok"}')
@@ -54,6 +61,7 @@ test_that("basic, structured, session and skill scripts execute independently", 
   })
   expect_equal(receiver_chat$get_turns(), source_chat$get_turns())
   expect_identical(index, 2L)
+  expect_identical(attr(session, "models"), rep("gpt-5.6-luna", 2L))
   expect_identical(session$resumed$run_context$project, "session-example")
   expect_identical(session$result$response, "Cedar")
   expect_false(file.exists(session$session_file))
@@ -131,7 +139,10 @@ test_that("delegation example runs its registered reviewer during the lead run",
 
 test_that("debate example compares independent heads and synthesizes both arguments", {
   skip_if_not_installed("yaml")
-  withr::local_envvar(DEPUTY_DEBATE_TOPIC = "Should reviews be mandatory?")
+  withr::local_envvar(
+    DEPUTY_DEBATE_TOPIC = "Should reviews be mandatory?",
+    DEPUTY_EXAMPLE_MODEL = "gpt-5.6-terra"
+  )
   state <- new.env(parent = emptyenv())
   state$responder <- function(system_prompt, task) {
     if (grepl("AGAINST", system_prompt, fixed = TRUE)) {
@@ -153,6 +164,7 @@ test_that("debate example compares independent heads and synthesizes both argume
     if (index == 1L) create_parallel_chat(state) else moderator_chat
   })
   expect_identical(index, 2L)
+  expect_identical(attr(example, "models"), rep("gpt-5.6-terra", 2L))
   expect_identical(state$peak, 2L)
   expect_identical(
     example$batch$status,

--- a/vignettes/example-code-review.Rmd
+++ b/vignettes/example-code-review.Rmd
@@ -100,7 +100,7 @@ The `LeadAgent` coordinates the reviewers. It has a `delegate_to_agent`
 tool that lets it assign tasks to any registered sub-agent:
 
 ```{r create-lead}
-chat <- ellmer::chat_openai()
+chat <- ellmer::chat_openai(model = "gpt-5.6-luna")
 
 lead <- LeadAgent$new(
   chat = chat,
@@ -198,7 +198,7 @@ review_schema <- list(
   required = c("summary", "total_findings", "findings")
 )
 
-chat <- ellmer::chat_openai()
+chat <- ellmer::chat_openai(model = "gpt-5.6-luna")
 
 lead <- LeadAgent$new(
   chat = chat,

--- a/vignettes/example-shiny-chat.Rmd
+++ b/vignettes/example-shiny-chat.Rmd
@@ -44,7 +44,7 @@ ui <- bslib::page_fluid(
 
 server <- function(input, output, session) {
   chat <- ellmer::chat_openai(
-    model = "gpt-4o-mini",
+    model = "gpt-5.6-luna",
     system_prompt = "You are a concise data assistant."
   )
 

--- a/vignettes/getting-started.Rmd
+++ b/vignettes/getting-started.Rmd
@@ -36,7 +36,9 @@ install.packages("deputy")
 
 You also need credentials for one
 [ellmer provider](https://ellmer.tidyverse.org/reference/index.html). The
-examples use OpenAI, but the Deputy API is provider-independent.
+examples use OpenAI's `gpt-5.6-luna` with `OPENAI_API_KEY`, but the Deputy API is
+provider-independent. To use a larger GPT-5.6 model, select `gpt-5.6-terra` or
+`gpt-5.6-sol` explicitly when creating the Chat. The `gpt-5.6` alias selects Sol.
 
 ## 1. Define the workspace and limits
 
@@ -77,7 +79,7 @@ This chunk makes a provider request, so it is displayed but not run while the
 vignette is built.
 
 ```{r first-agent, eval = FALSE}
-chat <- ellmer::chat("openai")
+chat <- ellmer::chat("openai/gpt-5.6-luna")
 
 agent <- Agent$new(
   chat = chat,

--- a/vignettes/hooks.Rmd
+++ b/vignettes/hooks.Rmd
@@ -91,7 +91,7 @@ deputy includes several ready-made hooks:
 ```{r hooks-log-demo}
 library(deputy)
 
-chat <- ellmer::chat_openai(model = "gpt-4o-mini")
+chat <- ellmer::chat_openai(model = "gpt-5.6-luna")
 agent <- Agent$new(
   chat = chat,
   tools = tools_file(),
@@ -174,7 +174,7 @@ hook_audit <- HookMatcher$new(
   }
 )
 
-chat <- ellmer::chat_openai(model = "gpt-4o-mini")
+chat <- ellmer::chat_openai(model = "gpt-5.6-luna")
 agent <- Agent$new(
   chat = chat,
   tools = tools_file(),

--- a/vignettes/multi-agent.Rmd
+++ b/vignettes/multi-agent.Rmd
@@ -170,7 +170,7 @@ Definitions with tools, skills, or MCP servers are rejected before dispatch.
 
 ```{r, eval = FALSE}
 lead <- LeadAgent$new(
-  ellmer::chat_openai(),
+  ellmer::chat_openai(model = "gpt-5.6-luna"),
   sub_agents = list(
     agent_definition("benefits", "Find benefits", "Explain the strongest benefits."),
     agent_definition("risks", "Find risks", "Explain the strongest risks.")
@@ -349,7 +349,7 @@ invalid files stop discovery rather than silently dropping a definition.
 
 ```{r, eval = FALSE}
 lead <- LeadAgent$new(
-  chat = ellmer::chat_openai(),
+  chat = ellmer::chat_openai(model = "gpt-5.6-luna"),
   sub_agents = definitions,
   permissions = Permissions$new(mode = "standard", file_write = FALSE),
   usage_limits = UsageLimits(max_requests = 6)

--- a/vignettes/permissions.Rmd
+++ b/vignettes/permissions.Rmd
@@ -221,7 +221,7 @@ with `UsageLimits()` on the agent or an individual run:
 
 ```{r, eval = FALSE}
 agent <- Agent$new(
-  chat = ellmer::chat("openai"),
+  chat = ellmer::chat("openai/gpt-5.6-luna"),
   tools = tools_file(),
   permissions = permissions_standard(),
   usage_limits = UsageLimits(

--- a/vignettes/structured-output.Rmd
+++ b/vignettes/structured-output.Rmd
@@ -26,7 +26,7 @@ The simplest form asks the LLM to return a JSON object:
 ```{r structured-json-object}
 library(deputy)
 
-chat <- ellmer::chat_openai(model = "gpt-4o-mini")
+chat <- ellmer::chat_openai(model = "gpt-5.6-luna")
 agent <- Agent$new(chat = chat)
 
 result <- agent$run_sync(
@@ -68,7 +68,7 @@ schema <- list(
   required = c("packages")
 )
 
-chat <- ellmer::chat_openai(model = "gpt-4o-mini")
+chat <- ellmer::chat_openai(model = "gpt-5.6-luna")
 agent <- Agent$new(chat = chat)
 
 result <- agent$run_sync(
@@ -133,7 +133,7 @@ schema <- list(
   required = c("language", "purpose", "first_release_year")
 )
 
-chat <- ellmer::chat_openai(model = "gpt-4o-mini")
+chat <- ellmer::chat_openai(model = "gpt-5.6-luna")
 agent <- Agent$new(chat = chat)
 
 result <- agent$run_sync(

--- a/vignettes/tools.Rmd
+++ b/vignettes/tools.Rmd
@@ -62,7 +62,7 @@ uppercase <- ellmer::tool(
   )
 )
 # Constructing this Chat does not make a model request.
-chat <- ellmer::chat_openai(credentials = function() "example", model = "gpt-4o-mini")
+chat <- ellmer::chat_openai(credentials = function() "example", model = "gpt-5.6-luna")
 agent <- Agent$new(chat = chat, tools = list(uppercase))
 agent$get_tools()$uppercase("hello")
 agent$register_tool(uppercase, replace = TRUE)
@@ -136,7 +136,7 @@ Combine bundles by concatenating:
 
 ```{r, eval = FALSE}
 tools <- c(tools_file(), tools_code())
-agent <- Agent$new(chat = ellmer::chat_openai(), tools = tools)
+agent <- Agent$new(chat = ellmer::chat_openai(model = "gpt-5.6-luna"), tools = tools)
 ```
 
 ## Tool Presets
@@ -210,7 +210,7 @@ tool_dice <- ellmer::tool(
   )
 )
 
-chat <- ellmer::chat_openai(model = "gpt-4o-mini")
+chat <- ellmer::chat_openai(model = "gpt-5.6-luna")
 agent <- Agent$new(chat = chat, tools = list(tool_dice))
 result <- agent$run_sync("Roll 2d20 for me")
 cat(result$response)
@@ -279,7 +279,7 @@ repl_tools <- tools_mcp_repl(
 )
 
 agent <- Agent$new(
-  chat = ellmer::chat("openai"),
+  chat = ellmer::chat("openai/gpt-5.6-luna"),
   tools = repl_tools,
   permissions = Permissions$new(web = FALSE)
 )
@@ -302,7 +302,7 @@ agent_id <- "agent-analysis"
 session_id <- "session-analysis"
 
 agent <- Agent$new(
-  chat = ellmer::chat_openai(),
+  chat = ellmer::chat_openai(model = "gpt-5.6-luna"),
   tools = c(
     tools_file(),
     tools_interactive(


### PR DESCRIPTION
The CLI previously selected Anthropic by default, while OpenAI examples selected GPT-4o models or inherited ellmer's changing default. Deputy now starts the CLI with OpenAI's `gpt-5.6-luna` and selects Luna explicitly throughout current OpenAI examples, including the standalone scripts and Shiny app.

`--model`, `--provider`, and `DEPUTY_EXAMPLE_MODEL` continue to override those defaults. The README and getting-started guide show Terra/Sol choices and explain that the `gpt-5.6` alias selects Sol. Caller-supplied Chats and inherited model/provider settings are preserved; provider-specific examples and historical test fixtures retain their choices. CLI debug logs now report the resolved model.

Closes #106.

Validation:
- Air formatting, Jarl lint, and `git diff --check`.
- Full suite with minimum supported ellmer 0.4.2: 2,846 passing assertions; six environment-dependent skips and two existing deliberate write-error warnings.
- CLI, standalone, and delegation tests with released ellmer 0.5.0: 430 passing assertions.
- R CMD check: 0 errors, 0 warnings, 0 notes; pkgdown site and generated reference/README documentation built successfully.
- Bounded live Luna checks on both ellmer versions: a readonly Agent called `read_file` and returned the expected phrase, completing in two requests and one tool call each. This verifies API/tool-loop compatibility, not broad model-quality equivalence.

Model guidance: https://developers.openai.com/api/docs/guides/latest-model?model=gpt-5.6
