### PR TITLE
Govern automatic compaction and preserve recovery state

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -29,6 +29,7 @@ deputy/
 │   ├── agents-multi.R      # LeadAgent for multi-agent orchestration
 │   ├── parallel-delegate.R # Bounded stateless responder batches
 │   ├── agent-run-state.R   # Shared model-run and batch initialization
+│   ├── compaction-run.R    # Governed asynchronous summary attempts and recovery
 │   ├── agent-definition-files.R # Portable YAML AgentDefinitions
 │   ├── agent-result.R      # AgentResult and AgentEvent objects
 │   ├── run-usage.R         # Run accounting and fail-closed limits
@@ -276,6 +277,14 @@ observed-limit semantics, and the boundary with future background agents.
 
 Tests use httpuv (Suggests) in a separate local R process for a real ellmer
 streaming fixture; no external API or credentials are required.
+
+Automatic compaction runs after SessionStart/UserPromptSubmit and between tool
+rounds at ellmer's request-start boundary. Its isolated summary streams share
+the run's budget and cancellation controller. ContextPolicy's explicit summary
+fallback Chats never select the task provider or inherit executable tools and
+callbacks. Installing a compacted window preserves prior usage and completed
+tool effects. Manual `compact()` remains synchronous. Evaluation cases and the
+future history-retrieval comparison are described in `dev/compaction-evaluation.md`.
 
 ### Permission Modes
 

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -69,6 +69,7 @@ Collate:
     'agent.R'
     'agents-multi.R'
     'cli.R'
+    'compaction-run.R'
     'context-policy.R'
     'deputy-package.R'
     'errors.R'

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -70,6 +70,7 @@ Collate:
     'agents-multi.R'
     'cli.R'
     'compaction-run.R'
+    'context-estimation.R'
     'context-policy.R'
     'deputy-package.R'
     'errors.R'

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,13 @@
 # deputy (development version)
 
+* `ContextPolicy()` governs automatic compaction under the active run's identity,
+  shared usage limits, and cancellation controller. Explicit
+  `summary_fallback_chats` recover transient summary failures independently of
+  task fallback. Summary attempts remain inspectable, accepted summaries survive
+  task fallback, and interrupted or failed compaction preserves the active
+  context. Between-round compaction preserves completed tool effects and usage
+  (#111).
+
 * Split runtime, permission, checkpoint, and built-in tool support into cohesive
   modules, with tests grouped by behavior. Public class interfaces and session
   formats are unchanged by the mechanical extraction.

--- a/R/agent-context.R
+++ b/R/agent-context.R
@@ -168,6 +168,9 @@ deputy_agent_context_methods <- function(self = NULL, private = NULL) {
         ),
         error = function(e) NULL
       )
+      if (is.null(count)) {
+        count <- context_count_after_unpaired_result(chat, messages)
+      }
       if (!is.numeric(count) || length(count) == 0L || anyNA(count)) {
         return(NULL)
       }
@@ -322,6 +325,9 @@ deputy_agent_context_methods <- function(self = NULL, private = NULL) {
       }
 
       list(
+        chat = private$.chat,
+        system_prompt = private$.chat$get_system_prompt(),
+        previous_summary = private$.compaction_summary,
         turns = turns,
         turns_to_compact = turns_to_compact,
         turns_to_keep = turns_to_keep,
@@ -339,6 +345,18 @@ deputy_agent_context_methods <- function(self = NULL, private = NULL) {
       summary_usage,
       attempts = list()
     ) {
+      if (
+        isTRUE(plan$automatic) &&
+          (!identical(private$.chat, plan$chat) ||
+            !identical(private$.chat$get_turns(), plan$turns) ||
+            !identical(private$.chat$get_system_prompt(), plan$system_prompt) ||
+            !identical(private$.compaction_summary, plan$previous_summary))
+      ) {
+        abort_deputy(
+          "Conversation changed while compaction was preparing its replacement.",
+          class = c("compaction_conflict", "compaction_error")
+        )
+      }
       summary <- paste(as.character(summary), collapse = "\n")
       current_system <- private$system_prompt_without_compaction()
       new_system <- paste0(

--- a/R/agent-context.R
+++ b/R/agent-context.R
@@ -7,11 +7,19 @@ clone_compaction_chat <- function(chat) {
 
   callback_names <- c(
     "callback_on_tool_request",
-    "callback_on_tool_result"
+    "callback_on_tool_result",
+    "callback_on_request_start",
+    "callback_on_request_end"
   )
   live_private <- chat$.__enclos_env__$private
   summary_private <- summary_chat$.__enclos_env__$private
 
+  callback_names <- Filter(
+    function(name) {
+      !is.null(summary_private[[name]]) || startsWith(name, "callback_on_tool")
+    },
+    callback_names
+  )
   for (callback_name in callback_names) {
     live_manager <- live_private[[callback_name]]
     summary_manager <- summary_private[[callback_name]]
@@ -236,64 +244,175 @@ deputy_agent_context_methods <- function(self = NULL, private = NULL) {
       as.integer(max(minimum_keep, length(turns) - recent + 1L))
     },
 
-    maybe_auto_compact = function(messages, limits = NULL, usage = NULL) {
-      policy <- private$.context_policy
-      if (is.null(policy$max_tokens)) {
-        return(NULL)
-      }
+    maybe_auto_compact = function(messages) {
+      governed_compaction(self, messages)
+    },
+
+    prepare_compaction = function(
+      keep_last,
+      summary,
+      fallback,
+      automatic,
+      estimated_tokens
+    ) {
       turns <- private$.chat$get_turns()
-      if (length(turns) == 0L) {
-        return(NULL)
+      fallback <- match.arg(fallback, c("error", "text"))
+
+      if (is.null(keep_last)) {
+        max_tokens <- self$context_policy$max_tokens
+        keep_last <- if (is.null(max_tokens)) {
+          min(4L, length(turns))
+        } else {
+          private$compaction_keep_last(
+            messages = list(),
+            target_tokens = floor(
+              max_tokens * self$context_policy$compact_to
+            )
+          )
+        }
+      }
+      keep_last <- validate_usage_limit(keep_last, "keep_last", integer = TRUE)
+      if (is.null(keep_last)) {
+        keep_last <- 0L
       }
 
-      if (is.null(limits) && isTRUE(private$run_active)) {
-        limits <- private$current_usage_limits
-      }
-      if (!is.null(limits)) {
-        if (is.null(usage)) {
-          usage <- if (isTRUE(private$run_active)) {
-            private$current_run_usage()
-          } else {
-            AgentUsage()
-          }
-        }
-        limit_status <- usage_limit_status(
-          usage,
-          limits,
-          require_followup = TRUE
+      if (length(turns) <= keep_last) {
+        result <- new_compaction_result(
+          method = "none",
+          automatic = automatic,
+          turns_compacted = 0L,
+          turns_kept = length(turns),
+          estimated_tokens = estimated_tokens
         )
-        if (!is.null(limit_status)) {
-          if (isTRUE(private$run_active)) {
-            private$mark_usage_limit(limit_status)
-          }
-          return(NULL)
+        private$.last_compaction <- result
+        return(list(result = result))
+      }
+
+      # Determine which turns to compact
+      compact_count <- length(turns) - keep_last
+      turns_to_compact <- turns[1:compact_count]
+      turns_to_keep <- if (keep_last == 0L) {
+        list()
+      } else {
+        tail(turns, keep_last)
+      }
+
+      # Fire PreCompact hook
+      hook_result <- private$fire_hook(
+        "PreCompact",
+        turns_to_compact = turns_to_compact,
+        turns_to_keep = turns_to_keep,
+        context = private$hook_context(
+          total_turns = length(turns),
+          compact_count = compact_count
+        )
+      )
+
+      # Check if hook wants to cancel compaction
+      if (!is.null(hook_result) && isFALSE(hook_result$continue)) {
+        result <- new_compaction_result(
+          method = "cancelled",
+          automatic = automatic,
+          turns_compacted = 0L,
+          turns_kept = length(turns),
+          estimated_tokens = estimated_tokens
+        )
+        private$.last_compaction <- result
+        return(list(result = result))
+      }
+
+      list(
+        turns = turns,
+        turns_to_compact = turns_to_compact,
+        turns_to_keep = turns_to_keep,
+        summary = summary %||% hook_result$summary,
+        method = if (!is.null(summary)) "custom" else "hook",
+        automatic = automatic,
+        estimated_tokens = estimated_tokens
+      )
+    },
+
+    install_compaction = function(
+      plan,
+      summary,
+      method,
+      summary_usage,
+      attempts = list()
+    ) {
+      summary <- paste(as.character(summary), collapse = "\n")
+      current_system <- private$system_prompt_without_compaction()
+      new_system <- paste0(
+        current_system,
+        private$compaction_prompt_block(summary)
+      )
+
+      usage <- if (isTRUE(private$run_active)) private$current_run_usage()
+      old_prompt <- private$.chat$get_system_prompt()
+      tryCatch(
+        {
+          private$.chat$set_system_prompt(new_system)
+          private$.chat$set_turns(plan$turns_to_keep)
+        },
+        error = function(error) {
+          private$.chat$set_system_prompt(old_prompt)
+          private$.chat$set_turns(plan$turns)
+          rlang::cnd_signal(error)
+        }
+      )
+      private$.compaction_summary <- summary
+      if (!is.null(usage)) {
+        # Preserve run usage when old provider turns leave the active window.
+        # Tool counts remain in their existing authoritative runtime fields.
+        usage$tool_calls <- usage$tool_calls - private$current_tool_calls
+        private$current_external_usage <- usage
+        private$current_outer_requests <- 0L
+        private$current_usage_baseline <- agent_usage_snapshot(private$.chat)
+        state <- private$current_run_state
+        state$turns_before <- max(
+          0L,
+          state$turns_before - length(plan$turns_to_compact)
+        )
+        if (!isTRUE(state$response_seen) && private$current_tool_calls == 0L) {
+          state$dispatch_turns <- private$.chat$get_turns()
+          state$request_turns_before <- length(state$dispatch_turns)
         }
       }
 
-      estimated <- private$context_token_count(messages)
-      if (is.null(estimated) || estimated <= policy$max_tokens) {
-        return(NULL)
-      }
-
-      keep_last <- private$compaction_keep_last(
-        messages = messages,
-        target_tokens = floor(policy$max_tokens * policy$compact_to)
+      result <- new_compaction_result(
+        method = method,
+        automatic = plan$automatic,
+        turns_compacted = length(plan$turns_to_compact),
+        turns_kept = length(plan$turns_to_keep),
+        estimated_tokens = plan$estimated_tokens,
+        usage = summary_usage,
+        attempts = attempts,
+        run_id = private$current_run_id,
+        summary = summary
       )
-      result <- self$compact(
-        keep_last = keep_last,
-        fallback = policy$fallback,
-        automatic = TRUE,
-        estimated_tokens = estimated
+      private$.last_compaction <- result
+      private$record_run_event(private$agent_event(
+        "compaction",
+        method = method,
+        automatic = plan$automatic,
+        turns_compacted = length(plan$turns_to_compact),
+        turns_kept = length(plan$turns_to_keep),
+        usage = summary_usage,
+        attempts = attempts
+      ))
+      private$fire_hook(
+        "PostCompact",
+        result = result,
+        context = private$hook_context(
+          total_turns = length(plan$turns),
+          compact_count = length(plan$turns_to_compact),
+          automatic = isTRUE(plan$automatic)
+        )
       )
-      if (isTRUE(private$run_active)) {
-        private$add_external_usage(result$usage)
-      }
       result
     },
 
     # Generate a summary of turns using the LLM
-    generate_compaction_summary = function(turns, fallback = "error") {
-      fallback <- match.arg(fallback, c("error", "text"))
+    compaction_summary_prompt = function(turns) {
       # Format turns for compaction
       turn_texts <- vapply(
         turns,
@@ -352,7 +471,7 @@ deputy_agent_context_methods <- function(self = NULL, private = NULL) {
       }
 
       # Create the compaction prompt
-      compaction_prompt <- paste0(
+      paste0(
         "Summarize the following conversation excerpt concisely. ",
         "Focus on:\n",
         "1. Key decisions made\n",
@@ -368,7 +487,11 @@ deputy_agent_context_methods <- function(self = NULL, private = NULL) {
         "\n---\n\n",
         "Summary:"
       )
+    },
 
+    generate_compaction_summary = function(turns, fallback = "error") {
+      fallback <- match.arg(fallback, c("error", "text"))
+      compaction_prompt <- private$compaction_summary_prompt(turns)
       temp_chat <- tryCatch(
         clone_compaction_chat(private$.chat),
         error = function(e) e

--- a/R/agent-context.R
+++ b/R/agent-context.R
@@ -285,6 +285,7 @@ deputy_agent_context_methods <- function(self = NULL, private = NULL) {
           automatic = automatic,
           turns_compacted = 0L,
           turns_kept = length(turns),
+          run_id = private$active_run_id(),
           estimated_tokens = estimated_tokens
         )
         private$.last_compaction <- result
@@ -318,6 +319,7 @@ deputy_agent_context_methods <- function(self = NULL, private = NULL) {
           automatic = automatic,
           turns_compacted = 0L,
           turns_kept = length(turns),
+          run_id = private$active_run_id(),
           estimated_tokens = estimated_tokens
         )
         private$.last_compaction <- result
@@ -399,7 +401,7 @@ deputy_agent_context_methods <- function(self = NULL, private = NULL) {
         estimated_tokens = plan$estimated_tokens,
         usage = summary_usage,
         attempts = attempts,
-        run_id = private$current_run_id,
+        run_id = private$active_run_id(),
         summary = summary
       )
       private$.last_compaction <- result

--- a/R/agent-context.R
+++ b/R/agent-context.R
@@ -379,12 +379,7 @@ deputy_agent_context_methods <- function(self = NULL, private = NULL) {
       )
       private$.compaction_summary <- summary
       if (!is.null(usage)) {
-        # Preserve run usage when old provider turns leave the active window.
-        # Tool counts remain in their existing authoritative runtime fields.
-        usage$tool_calls <- usage$tool_calls - private$current_tool_calls
-        private$current_external_usage <- usage
-        private$current_outer_requests <- 0L
-        private$current_usage_baseline <- agent_usage_snapshot(private$.chat)
+        preserve_run_usage(self, usage)
         state <- private$current_run_state
         state$turns_before <- max(
           0L,

--- a/R/agent-requests.R
+++ b/R/agent-requests.R
@@ -1,8 +1,12 @@
 # Model dispatch governance. ellmer owns provider IO and transport retries.
 
-normalize_fallback_chats <- function(chats, primary) {
+normalize_fallback_chats <- function(
+  chats,
+  primary,
+  argument = "fallback_chats"
+) {
   if (!is.list(chats)) {
-    abort_deputy("{.arg fallback_chats} must be a list of Chats")
+    abort_deputy("{.arg {argument}} must be a list of Chats")
   }
   for (chat in chats) {
     validate_chat(chat)
@@ -29,7 +33,16 @@ install_request_callbacks <- function(agent) {
     return(invisible(NULL))
   }
   callbacks <- list(
-    on_request_start = function(turns) begin_model_request(agent),
+    on_request_start = function(turns) {
+      coro::async(function() {
+        # All tool results have settled; ellmer has not dispatched this round.
+        if (private$current_run_state$task_requests > 0L) {
+          pending <- utils::tail(turns, 1L)[[1L]]
+          coro::await(private$maybe_auto_compact(messages = pending@contents))
+        }
+        begin_model_request(agent)
+      })()
+    },
     on_request_end = function(turn) end_model_request(agent, turn)
   )
   attr(chat, "deputy_request_callbacks") <- lapply(
@@ -105,6 +118,7 @@ begin_model_request <- function(agent) {
   }
   private$current_outer_requests <- private$current_outer_requests + 1L
   state$request_number <- state$request_number + 1L
+  state$task_requests <- state$task_requests + 1L
   state$request_turns_before <- length(private$.chat$get_turns())
   state$model_failure <- NULL
   private$record_run_event(private$agent_event(

--- a/R/agent-requests.R
+++ b/R/agent-requests.R
@@ -85,7 +85,7 @@ retain_pending_tool_results <- function(agent, request_turns) {
   }
   chat <- agent$.__enclos_env__$private$.chat
   current <- chat$get_turns()
-  previous <- head(request_turns, -1L)
+  previous <- utils::head(request_turns, -1L)
   # Compaction preserves the pending round. If a host deliberately replaced
   # that conversation while we awaited, do not append orphaned tool results.
   if (

--- a/R/agent-requests.R
+++ b/R/agent-requests.R
@@ -35,12 +35,23 @@ install_request_callbacks <- function(agent) {
   callbacks <- list(
     on_request_start = function(turns) {
       coro::async(function() {
-        # All tool results have settled; ellmer has not dispatched this round.
-        if (private$current_run_state$task_requests > 0L) {
-          pending <- utils::tail(turns, 1L)[[1L]]
-          coro::await(private$maybe_auto_compact(messages = pending@contents))
-        }
-        begin_model_request(agent)
+        tryCatch(
+          {
+            # All tool results have settled; ellmer has not stored or dispatched
+            # the pending user turn yet. Count its contents without appending it.
+            if (private$current_run_state$task_requests > 0L) {
+              pending <- utils::tail(turns, 1L)[[1L]]
+              coro::await(private$maybe_auto_compact(
+                messages = pending@contents
+              ))
+            }
+            begin_model_request(agent)
+          },
+          error = function(error) {
+            retain_pending_tool_results(agent, turns)
+            rlang::cnd_signal(error)
+          }
+        )
       })()
     },
     on_request_end = function(turn) end_model_request(agent, turn)
@@ -56,6 +67,34 @@ install_request_callbacks <- function(agent) {
     }
   )
   chat$conversation_id <- private$.session_id
+  invisible(NULL)
+}
+
+retain_pending_tool_results <- function(agent, request_turns) {
+  pending <- utils::tail(request_turns, 1L)[[1L]]
+  if (
+    !inherits(pending, "ellmer::UserTurn") ||
+      !any(vapply(
+        pending@contents,
+        inherits,
+        logical(1),
+        what = "ellmer::ContentToolResult"
+      ))
+  ) {
+    return(invisible(NULL))
+  }
+  chat <- agent$.__enclos_env__$private$.chat
+  current <- chat$get_turns()
+  previous <- head(request_turns, -1L)
+  # Compaction preserves the pending round. If a host deliberately replaced
+  # that conversation while we awaited, do not append orphaned tool results.
+  if (
+    length(current) &&
+      length(previous) &&
+      identical(tail(current, 1L), tail(previous, 1L))
+  ) {
+    chat$set_turns(c(current, list(pending)))
+  }
   invisible(NULL)
 }
 

--- a/R/agent-run-state.R
+++ b/R/agent-run-state.R
@@ -58,6 +58,8 @@ initialize_agent_run <- function(
   state$response_seen <- FALSE
   state$fallback_index <- private$.fallback_position
   state$request_number <- 0L
+  state$task_requests <- 0L
+  state$failure_phase <- NULL
   state$request_turns_before <- state$turns_before
   state$model_failure <- NULL
   state$dispatch_turns <- private$.chat$get_turns()

--- a/R/agent-stream.R
+++ b/R/agent-stream.R
@@ -306,16 +306,6 @@ deputy_agent_stream_methods <- function(self = NULL, private = NULL) {
           )
         }
 
-        compaction <- agent$.__enclos_env__$private$maybe_auto_compact(
-          messages,
-          limits = run_limits,
-          usage = AgentUsage()
-        )
-        compaction_usage <- AgentUsage()
-        if (!is.null(compaction)) {
-          compaction_usage <- compaction$usage
-        }
-
         on.exit(
           agent$.__enclos_env__$private$finish_callback_run(stream_state),
           add = TRUE
@@ -328,13 +318,24 @@ deputy_agent_stream_methods <- function(self = NULL, private = NULL) {
             run_limits,
             effective_run_context,
             controller,
-            stream_mode,
-            compaction_usage
+            stream_mode
           ),
           error = function(error) {
             stream_state$reason <- "error"
             record_run_failure(agent, "initialization", error)
             rlang::cnd_signal(error)
+          }
+        )
+        tryCatch(
+          coro::await(agent$.__enclos_env__$private$maybe_auto_compact(
+            messages
+          )),
+          error = function(error) {
+            if (!agent$.__enclos_env__$private$should_stop) {
+              stream_state$reason <- "error"
+              record_run_failure(agent, "compaction", error)
+              rlang::cnd_signal(error)
+            }
           }
         )
         active_run_id <- stream_state$active_run_id
@@ -402,10 +403,13 @@ deputy_agent_stream_methods <- function(self = NULL, private = NULL) {
             stream_state$reason <- "error"
             # Structured requests record dispatch errors before applying
             # validation; a rejected value is a separate run outcome.
-            if (is.null(structured)) {
+            if (is.null(structured) && is.null(stream_state$failure_phase)) {
               record_model_failure(agent, stream_error)
             }
-            if (try_chat_fallback(agent, stream_error)) {
+            if (
+              is.null(stream_state$failure_phase) &&
+                try_chat_fallback(agent, stream_error)
+            ) {
               stream <- tryCatch(
                 agent$.__enclos_env__$private$start_async_stream(
                   messages,
@@ -428,7 +432,8 @@ deputy_agent_stream_methods <- function(self = NULL, private = NULL) {
             stream_state$reason <- "error"
             record_run_failure(
               agent,
-              if (is.null(structured)) "stream" else "structured_output",
+              stream_state$failure_phase %||%
+                if (is.null(structured)) "stream" else "structured_output",
               stream_error
             )
             rlang::cnd_signal(stream_error)

--- a/R/agent-tool-callbacks.R
+++ b/R/agent-tool-callbacks.R
@@ -318,12 +318,6 @@ deputy_agent_tool_callbacks_methods <- function(self = NULL, private = NULL) {
         }
       }
 
-      # ellmer may make another provider request after this tool result. Check
-      # the complete context again while the run is between provider turns.
-      if (!isTRUE(private$should_stop)) {
-        private$maybe_auto_compact(messages = list())
-      }
-
       invisible(NULL)
     },
 

--- a/R/agent.R
+++ b/R/agent.R
@@ -1188,127 +1188,27 @@ Agent <- R6::R6Class(
           class = c("deputy_run_active", "deputy_error")
         )
       }
-      turns <- private$.chat$get_turns()
-      fallback <- match.arg(fallback, c("error", "text"))
-
-      if (is.null(keep_last)) {
-        max_tokens <- self$context_policy$max_tokens
-        keep_last <- if (is.null(max_tokens)) {
-          min(4L, length(turns))
-        } else {
-          private$compaction_keep_last(
-            messages = list(),
-            target_tokens = floor(
-              max_tokens * self$context_policy$compact_to
-            )
-          )
-        }
+      plan <- private$prepare_compaction(
+        keep_last,
+        summary,
+        fallback,
+        automatic,
+        estimated_tokens
+      )
+      if (!is.null(plan$result)) {
+        return(plan$result)
       }
-      keep_last <- validate_usage_limit(keep_last, "keep_last", integer = TRUE)
-      if (is.null(keep_last)) {
-        keep_last <- 0L
-      }
-
-      if (length(turns) <= keep_last) {
-        result <- new_compaction_result(
-          method = "none",
-          automatic = automatic,
-          turns_compacted = 0L,
-          turns_kept = length(turns),
-          estimated_tokens = estimated_tokens
-        )
-        private$.last_compaction <- result
-        return(result)
-      }
-
-      # Determine which turns to compact
-      compact_count <- length(turns) - keep_last
-      turns_to_compact <- turns[1:compact_count]
-      turns_to_keep <- if (keep_last == 0L) {
-        list()
+      generated <- if (is.null(plan$summary)) {
+        private$generate_compaction_summary(plan$turns_to_compact, fallback)
       } else {
-        tail(turns, keep_last)
+        list(summary = plan$summary, method = plan$method, usage = AgentUsage())
       }
-
-      # Fire PreCompact hook
-      hook_result <- private$fire_hook(
-        "PreCompact",
-        turns_to_compact = turns_to_compact,
-        turns_to_keep = turns_to_keep,
-        context = private$hook_context(
-          total_turns = length(turns),
-          compact_count = compact_count
-        )
+      private$install_compaction(
+        plan,
+        generated$summary,
+        generated$method,
+        generated$usage
       )
-
-      # Check if hook wants to cancel compaction
-      if (!is.null(hook_result) && isFALSE(hook_result$continue)) {
-        result <- new_compaction_result(
-          method = "cancelled",
-          automatic = automatic,
-          turns_compacted = 0L,
-          turns_kept = length(turns),
-          estimated_tokens = estimated_tokens
-        )
-        private$.last_compaction <- result
-        return(result)
-      }
-
-      method <- "custom"
-      summary_usage <- AgentUsage()
-      if (is.null(summary)) {
-        if (!is.null(hook_result) && !is.null(hook_result$summary)) {
-          summary <- hook_result$summary
-          method <- "hook"
-        } else {
-          generated <- private$generate_compaction_summary(
-            turns_to_compact,
-            fallback = fallback
-          )
-          summary <- generated$summary
-          method <- generated$method
-          summary_usage <- generated$usage
-        }
-      }
-
-      summary <- paste(as.character(summary), collapse = "\n")
-      current_system <- private$system_prompt_without_compaction()
-      new_system <- paste0(
-        current_system,
-        private$compaction_prompt_block(summary)
-      )
-
-      private$.chat$set_system_prompt(new_system)
-      private$.chat$set_turns(turns_to_keep)
-      private$.compaction_summary <- summary
-
-      result <- new_compaction_result(
-        method = method,
-        automatic = automatic,
-        turns_compacted = compact_count,
-        turns_kept = length(turns_to_keep),
-        estimated_tokens = estimated_tokens,
-        usage = summary_usage,
-        summary = summary
-      )
-      private$.last_compaction <- result
-      private$record_run_event(private$agent_event(
-        "compaction",
-        method = method,
-        automatic = automatic,
-        turns_compacted = compact_count,
-        turns_kept = length(turns_to_keep)
-      ))
-      private$fire_hook(
-        "PostCompact",
-        result = result,
-        context = private$hook_context(
-          total_turns = length(turns),
-          compact_count = compact_count,
-          automatic = isTRUE(automatic)
-        )
-      )
-      result
     },
 
     #' @description
@@ -1758,7 +1658,7 @@ Agent <- R6::R6Class(
     #' @field context_policy Automatic context-management policy. Read-only.
     context_policy = function(value) {
       if (missing(value)) {
-        return(private$.context_policy)
+        return(normalize_context_policy(private$.context_policy))
       }
       cli_abort(
         "Cannot modify agent: context_policy is immutable after construction"

--- a/R/agent.R
+++ b/R/agent.R
@@ -605,11 +605,14 @@ Agent <- R6::R6Class(
       private$.chat$get_turns()
     },
 
-    #' @description Replace conversation turns, as in ellmer Chat.
+    #' @description Replace conversation turns, as in ellmer Chat. During a
+    #'   run, already accrued usage remains charged after history replacement.
     #' @param value A list of ellmer turns.
     #' @return Invisible self.
     set_turns = function(value) {
+      usage <- if (isTRUE(private$run_active)) private$current_run_usage()
       private$.chat$set_turns(value)
+      preserve_run_usage(self, usage)
       prompt <- private$.chat$get_system_prompt()
       prompt_without_compaction <- private$system_prompt_without_compaction()
       if (!identical(prompt, prompt_without_compaction)) {

--- a/R/compaction-run.R
+++ b/R/compaction-run.R
@@ -159,13 +159,13 @@ compaction_summary_requests <- function(agent, turns) {
       return(NULL)
     }
     if (identical(private$.context_policy$fallback, "error")) {
-      cli_abort(
+      abort_deputy(
         c(
           "Conversation compaction failed.",
           "x" = conditionMessage(attempt$condition),
           "i" = "Set ContextPolicy(fallback = 'text') to permit degraded compaction."
         ),
-        class = c("deputy_compaction_error", "deputy_error"),
+        class = "compaction_error",
         parent = attempt$condition
       )
     }
@@ -205,9 +205,9 @@ compaction_summary_attempt <- function(
         chat$conversation_id <- private$.session_id
         chat$on_request_start(function(turns) {
           if (!compaction_can_continue(agent)) {
-            cli_abort(
+            abort_deputy(
               "The governed run has stopped",
-              class = c("deputy_run_stopped", "deputy_error")
+              class = "run_stopped"
             )
           }
           dispatched <<- dispatched + 1L

--- a/R/compaction-run.R
+++ b/R/compaction-run.R
@@ -1,0 +1,307 @@
+# Automatic context transitions share the run lifecycle and budget. Summary
+# requests stay on isolated Chats; ellmer owns their IO, retries and cancellation.
+governed_compaction <- function(agent, messages) {
+  private <- agent$.__enclos_env__$private
+  state <- private$current_run_state
+  operation <- coro::async(function() {
+    policy <- private$.context_policy
+    if (
+      is.null(policy$max_tokens) ||
+        !length(private$.chat$get_turns()) ||
+        !compaction_can_continue(agent)
+    ) {
+      return(NULL)
+    }
+    estimated <- private$context_token_count(messages)
+    if (is.null(estimated) || estimated <= policy$max_tokens) {
+      return(NULL)
+    }
+    keep_last <- private$compaction_keep_last(
+      messages,
+      floor(policy$max_tokens * policy$compact_to)
+    )
+    plan <- private$prepare_compaction(
+      keep_last,
+      NULL,
+      policy$fallback,
+      TRUE,
+      estimated
+    )
+    if (!is.null(plan$result)) {
+      return(plan$result)
+    }
+    if (!compaction_can_continue(agent)) {
+      return(NULL)
+    }
+    private$record_run_event(private$agent_event(
+      "compaction_start",
+      estimated_tokens = estimated,
+      turns_compacted = length(plan$turns_to_compact),
+      turns_kept = length(plan$turns_to_keep)
+    ))
+    if (is.null(plan$summary)) {
+      generated <- coro::await(compaction_summary_requests(
+        agent,
+        plan$turns_to_compact
+      ))
+    } else {
+      generated <- list(
+        summary = plan$summary,
+        method = plan$method,
+        usage = AgentUsage(),
+        attempts = list()
+      )
+    }
+    # Cancellation never installs a partial or deterministic recovery summary.
+    # A completed summary may be accepted even if it used the final request.
+    if (is.null(generated) || isTRUE(private$should_stop)) {
+      return(NULL)
+    }
+    result <- private$install_compaction(
+      plan,
+      generated$summary,
+      generated$method,
+      generated$usage,
+      generated$attempts
+    )
+    compaction_can_continue(agent)
+    result
+  })()
+  promises::catch(operation, function(error) {
+    state$failure_phase <- "compaction"
+    rlang::cnd_signal(error)
+  })
+}
+
+compaction_can_continue <- function(agent) {
+  private <- agent$.__enclos_env__$private
+  if (
+    isTRUE(private$current_stream_controller$cancelled) &&
+      !isTRUE(private$should_stop)
+  ) {
+    private$request_stream_stop("interrupted")
+  }
+  if (isTRUE(private$should_stop)) {
+    return(FALSE)
+  }
+  status <- usage_limit_status(
+    private$current_run_usage(),
+    private$current_usage_limits,
+    require_followup = TRUE
+  )
+  if (!is.null(status)) {
+    private$mark_usage_limit(status)
+    return(FALSE)
+  }
+  TRUE
+}
+
+compaction_summary_requests <- function(agent, turns) {
+  private <- agent$.__enclos_env__$private
+  coro::async(function() {
+    prompt <- private$compaction_summary_prompt(turns)
+    templates <- c(
+      list(private$.chat),
+      private$.context_policy$summary_fallback_chats
+    )
+    attempts <- list()
+    usage <- AgentUsage()
+    for (index in seq_along(templates)) {
+      if (!compaction_can_continue(agent)) {
+        return(NULL)
+      }
+      attempt <- coro::await(compaction_summary_attempt(
+        agent,
+        templates[[index]],
+        prompt,
+        index - 1L
+      ))
+      usage <- agent_usage_add(usage, attempt$usage)
+      attempts[[index]] <- attempt[c(
+        "fallback_index",
+        "provider",
+        "model",
+        "usage",
+        "condition"
+      )]
+      if (
+        isTRUE(private$current_stream_controller$cancelled) ||
+          isTRUE(private$should_stop)
+      ) {
+        private$request_stream_stop(
+          private$stop_reason_from_hook %||% "interrupted"
+        )
+        return(NULL)
+      }
+      if (is.null(attempt$condition)) {
+        return(list(
+          summary = attempt$summary,
+          method = "llm",
+          usage = usage,
+          attempts = attempts
+        ))
+      }
+      if (!attempt$recoverable || index == length(templates)) {
+        break
+      }
+      if (!compaction_can_continue(agent)) {
+        return(NULL)
+      }
+      private$record_run_event(private$agent_event(
+        "fallback",
+        phase = "compaction",
+        fallback_index = index,
+        condition = attempt$condition,
+        usage = private$current_run_usage()
+      ))
+    }
+    if (!compaction_can_continue(agent)) {
+      return(NULL)
+    }
+    if (identical(private$.context_policy$fallback, "error")) {
+      cli_abort(
+        c(
+          "Conversation compaction failed.",
+          "x" = conditionMessage(attempt$condition),
+          "i" = "Set ContextPolicy(fallback = 'text') to permit degraded compaction."
+        ),
+        class = c("deputy_compaction_error", "deputy_error"),
+        parent = attempt$condition
+      )
+    }
+    private$notify(
+      "Compaction used the configured deterministic text fallback.",
+      level = "warning",
+      code = "compact_fallback",
+      error = conditionMessage(attempt$condition)
+    )
+    list(
+      summary = private$generate_fallback_summary(turns),
+      method = "text",
+      usage = usage,
+      attempts = attempts
+    )
+  })()
+}
+
+compaction_summary_attempt <- function(
+  agent,
+  template,
+  prompt,
+  fallback_index
+) {
+  private <- agent$.__enclos_env__$private
+  state <- private$current_run_state
+  coro::async(function() {
+    chat <- NULL
+    dispatched <- 0L
+    provider <- template$get_provider()@name
+    model <- template$get_model()
+    condition <- NULL
+    summary <- NULL
+    tryCatch(
+      {
+        chat <- clone_compaction_chat(template)
+        chat$conversation_id <- private$.session_id
+        chat$on_request_start(function(turns) {
+          if (!compaction_can_continue(agent)) {
+            cli_abort(
+              "The governed run has stopped",
+              class = c("deputy_run_stopped", "deputy_error")
+            )
+          }
+          dispatched <<- dispatched + 1L
+          state$request_number <- state$request_number + 1L
+          # Charge the dispatch now. Tokens and cost settle after the attempt;
+          # reaching the request limit must not cancel this in-flight response.
+          private$current_external_usage <- agent_usage_add(
+            private$current_external_usage,
+            AgentUsage(requests = 1L)
+          )
+          private$record_run_event(private$agent_event(
+            "request_start",
+            phase = "compaction",
+            request_number = state$request_number,
+            fallback_index = fallback_index,
+            provider = provider,
+            model = model
+          ))
+        })
+        chat$on_request_end(function(turn) {
+          private$record_run_event(private$agent_event(
+            "request_end",
+            phase = "compaction",
+            request_number = state$request_number,
+            provider = provider,
+            model = model,
+            outcome = "response"
+          ))
+        })
+        stream <- chat$stream_async(
+          prompt,
+          controller = private$current_stream_controller
+        )
+        repeat {
+          chunk <- coro::await(with_run_trace(state, stream()))
+          if (coro::is_exhausted(chunk)) {
+            break
+          }
+        }
+        summary <- chat$last_turn()@text
+        if (
+          !is.character(summary) ||
+            length(summary) != 1L ||
+            is.na(summary) ||
+            !nzchar(trimws(summary))
+        ) {
+          abort_deputy("Compaction did not produce a non-empty summary")
+        }
+      },
+      error = function(error) condition <<- error
+    )
+
+    if (dispatched > 0L) {
+      usage <- agent_usage_difference(
+        agent_usage_snapshot(chat),
+        AgentUsage(),
+        requests = dispatched
+      )
+    } else {
+      usage <- AgentUsage()
+    }
+    settled <- usage
+    settled$requests <- 0L
+    private$current_external_usage <- agent_usage_add(
+      private$current_external_usage,
+      settled
+    )
+    last_turn <- NULL
+    if (!is.null(chat)) {
+      last_turn <- tryCatch(chat$last_turn(), error = function(e) NULL)
+    }
+    model_error <- inherits(condition, c("httr2_failure", "httr2_http")) &&
+      inherits(last_turn, "ellmer::AssistantPartialTurn") &&
+      dispatched > 0L
+    if (!is.null(condition)) {
+      private$record_run_event(private$agent_event(
+        if (model_error) "request_error" else "compaction_error",
+        phase = "compaction",
+        request_number = state$request_number,
+        fallback_index = fallback_index,
+        provider = provider,
+        model = model,
+        condition = condition,
+        usage = usage
+      ))
+    }
+    list(
+      summary = summary,
+      usage = usage,
+      condition = condition,
+      recoverable = model_error && fallback_transport_error(condition),
+      provider = provider,
+      model = model,
+      fallback_index = fallback_index
+    )
+  })()
+}

--- a/R/context-estimation.R
+++ b/R/context-estimation.R
@@ -29,7 +29,7 @@ context_count_after_unpaired_result <- function(chat, messages) {
       }
       last <- tail(completed, 1L)
       users <- which(vapply(
-        head(turns, last - 1L),
+        utils::head(turns, last - 1L),
         inherits,
         logical(1),
         what = "ellmer::UserTurn"

--- a/R/context-estimation.R
+++ b/R/context-estimation.R
@@ -1,0 +1,59 @@
+# ellmer 0.5.0 cannot build its token-preview table when retained tool results
+# have no subsequent assistant response. Ask its public estimator using the
+# last completed pair (whose reported input includes prior context), plus
+# subsequent content. This view is only for estimation; canonical turns stay
+# intact and no provider encoding or synthetic response is introduced.
+context_count_after_unpaired_result <- function(chat, messages) {
+  tryCatch(
+    {
+      turns <- chat$get_turns()
+      completed <- which(vapply(
+        turns,
+        function(turn) {
+          inherits(turn, "ellmer::AssistantTurn") &&
+            !inherits(turn, "ellmer::AssistantPartialTurn")
+        },
+        logical(1)
+      ))
+      user_count <- sum(vapply(
+        turns,
+        inherits,
+        logical(1),
+        what = "ellmer::UserTurn"
+      ))
+      if (user_count == length(completed)) {
+        return(NULL)
+      }
+      if (!length(completed)) {
+        return(NULL)
+      }
+      last <- tail(completed, 1L)
+      users <- which(vapply(
+        head(turns, last - 1L),
+        inherits,
+        logical(1),
+        what = "ellmer::UserTurn"
+      ))
+      if (!length(users)) {
+        return(NULL)
+      }
+      estimate <- clone_governed_chat(chat)
+      estimate$set_turns(list(turns[[tail(users, 1L)]], turns[[last]]))
+      pending <- if (last < length(turns)) {
+        unlist(
+          lapply(turns[(last + 1L):length(turns)], function(turn) {
+            turn@contents
+          }),
+          recursive = FALSE
+        )
+      } else {
+        list()
+      }
+      do.call(
+        estimate$token_count,
+        c(pending, messages, list(include = "complete"))
+      )
+    },
+    error = function(error) NULL
+  )
+}

--- a/R/context-policy.R
+++ b/R/context-policy.R
@@ -21,6 +21,28 @@
 #' @param offload_dir Directory for durable result envelopes. Relative paths
 #'   are anchored to the current working directory when the policy is created.
 #'   `NULL` uses the Deputy user cache, partitioned by Agent session.
+#' @param summary_fallback_chats Ordered, explicitly configured ellmer Chats
+#'   authorized to receive summary prompts during automatic compaction. Each
+#'   template must have no turns or tools. Transient transport failures may
+#'   advance to the next template after ellmer's retries. These destinations
+#'   are separate from the Agent's task `fallback_chats`; choosing a summary
+#'   destination does not change the task Chat. Manual `$compact()` uses only
+#'   its active Chat and `fallback` policy. Templates are cloned at construction.
+#' @details
+#' Automatic compaction is an asynchronous run phase. `SessionStart` and
+#' `UserPromptSubmit` precede `PreCompact`; `PostCompact` follows an accepted
+#' replacement. `Stop` and `SessionEnd` include summary failures and usage.
+#' Between tool rounds, context is checked at ellmer's next request boundary
+#' after all tool results settle. Summary dispatches, including failures, share
+#' the run's request/token/cost budget. Unknown costs remain unknown.
+#'
+#' Summary Chats have no tools, history, system prompt, or inherited callbacks.
+#' Cancellation or unrecoverable failure leaves the active context unchanged.
+#' An accepted summary remains installed when the budget prevents task dispatch.
+#' `$last_compaction()` includes `run_id` and summary `attempts` with destination,
+#' usage, and original condition. Summaries are internal context, not task output.
+#' This policy does not archive removed turns or restore runtime permissions
+#' from a summary.
 #' @return A `ContextPolicy` object.
 #' @export
 ContextPolicy <- function(
@@ -28,9 +50,15 @@ ContextPolicy <- function(
   compact_to = 0.5,
   fallback = c("error", "text"),
   max_tool_result_bytes = 64 * 1024,
-  offload_dir = NULL
+  offload_dir = NULL,
+  summary_fallback_chats = list()
 ) {
   fallback <- match.arg(fallback)
+  summary_fallback_chats <- normalize_fallback_chats(
+    summary_fallback_chats,
+    primary = NULL,
+    argument = "summary_fallback_chats"
+  )
   max_tokens <- context_policy_whole_number(max_tokens, "max_tokens")
   max_tool_result_bytes <- context_policy_whole_number(
     max_tool_result_bytes,
@@ -73,7 +101,8 @@ ContextPolicy <- function(
       compact_to = as.numeric(compact_to),
       fallback = fallback,
       max_tool_result_bytes = max_tool_result_bytes,
-      offload_dir = offload_dir
+      offload_dir = offload_dir,
+      summary_fallback_chats = summary_fallback_chats
     ),
     class = c("ContextPolicy", "list")
   )
@@ -119,7 +148,7 @@ normalize_context_policy <- function(policy) {
   if (!inherits(policy, "ContextPolicy")) {
     cli_abort("{.arg context_policy} must be a ContextPolicy object")
   }
-  policy
+  do.call(ContextPolicy, unclass(policy))
 }
 
 #' @export
@@ -128,6 +157,7 @@ print.ContextPolicy <- function(x, ...) {
   cli::cli_text("  compact at: {x$max_tokens %||% 'disabled'} tokens")
   cli::cli_text("  compact to: {format(x$compact_to * 100)}%")
   cli::cli_text("  fallback: {x$fallback}")
+  cli::cli_text("  summary fallback Chats: {length(x$summary_fallback_chats)}")
   cli::cli_text(
     "  offload above: {x$max_tool_result_bytes %||% 'disabled'} bytes"
   )
@@ -141,7 +171,9 @@ new_compaction_result <- function(
   turns_kept,
   estimated_tokens,
   usage = AgentUsage(),
-  summary = NULL
+  summary = NULL,
+  attempts = list(),
+  run_id = NULL
 ) {
   structure(
     list(
@@ -152,6 +184,8 @@ new_compaction_result <- function(
       estimated_tokens = estimated_tokens,
       usage = usage,
       summary = summary,
+      attempts = attempts,
+      run_id = run_id,
       compacted_at = Sys.time()
     ),
     class = c("DeputyCompaction", "list")

--- a/R/run-usage.R
+++ b/R/run-usage.R
@@ -442,6 +442,21 @@ agent_usage_add <- function(left, right) {
   )
 }
 
+# Call after replacing conversation turns, using usage captured before the
+# replacement. Run evidence survives mutable context; tool counts retain their
+# separate authoritative runtime counter.
+preserve_run_usage <- function(agent, usage) {
+  if (is.null(usage)) {
+    return(invisible(NULL))
+  }
+  private <- agent$.__enclos_env__$private
+  usage$tool_calls <- usage$tool_calls - private$current_tool_calls
+  private$current_external_usage <- usage
+  private$current_outer_requests <- 0L
+  private$current_usage_baseline <- agent_usage_snapshot(private$.chat)
+  invisible(NULL)
+}
+
 usage_limit_status <- function(usage, limits, require_followup = FALSE) {
   checks <- list(
     list(

--- a/R/run-usage.R
+++ b/R/run-usage.R
@@ -222,7 +222,13 @@ provider_usage_summary <- function(chat) {
     logical(1),
     what = "ellmer::AssistantTurn"
   ))
-  tokens <- tryCatch(chat$get_tokens(), error = function(e) NULL)
+  tokens <- tryCatch(chat$get_tokens(), error = function(e) {
+    # ellmer 0.5.0's token table assumes paired user/assistant turns. A
+    # retained, undispatched tool-result turn breaks its input-preview column.
+    # These public producer properties retain the actual usage without adding
+    # a fictitious assistant response or changing provider serialization.
+    assistant_turn_tokens(turns)
+  })
   token_sum <- function(name) {
     if (is.null(tokens) || !name %in% names(tokens)) {
       return(0)
@@ -247,6 +253,30 @@ provider_usage_summary <- function(chat) {
     complete = cost$complete,
     missing = cost$missing,
     cost_records = cost_records
+  )
+}
+
+assistant_turn_tokens <- function(turns) {
+  assistants <- Filter(
+    function(turn) inherits(turn, "ellmer::AssistantTurn"),
+    turns
+  )
+  token <- function(name) {
+    vapply(
+      assistants,
+      function(turn) {
+        tokens <- turn@tokens
+        position <- match(name, c("input", "output", "cached_input"))
+        as.numeric(tokens[[position]])
+      },
+      numeric(1)
+    )
+  }
+  data.frame(
+    input = token("input"),
+    output = token("output"),
+    cached_input = token("cached_input"),
+    cost = vapply(assistants, function(turn) as.numeric(turn@cost), numeric(1))
   )
 }
 

--- a/R/run-usage.R
+++ b/R/run-usage.R
@@ -257,6 +257,9 @@ provider_usage_summary <- function(chat) {
 }
 
 assistant_turn_tokens <- function(turns) {
+  # Released ellmer's S7 AssistantTurn contract requires three numeric token
+  # slots and one numeric cost, including for AssistantPartialTurn. Missing
+  # reports use NA, which preserves unknown cost through provider_cost_summary.
   assistants <- Filter(
     function(turn) inherits(turn, "ellmer::AssistantTurn"),
     turns

--- a/R/run-usage.R
+++ b/R/run-usage.R
@@ -16,8 +16,9 @@
 #' the agent's defaults.
 #'
 #' @param max_requests Maximum governed model dispatches, including failed
-#'   calls, structured extraction, and corrections. Retries inside ellmer's
-#'   HTTP transport are not separately observable. `NULL` leaves the field unset.
+#'   calls, automatic compaction, structured extraction, and corrections. Retries
+#'   inside ellmer's HTTP transport are not separately observable. `NULL` leaves
+#'   the field unset.
 #' @param max_tool_calls Maximum requested tool calls. Rejected calls count
 #'   toward usage. `NULL` leaves the field unset.
 #' @param max_input_tokens Maximum provider-reported input tokens. `NULL` leaves

--- a/dev/compaction-evaluation.md
+++ b/dev/compaction-evaluation.md
@@ -29,6 +29,17 @@ explicit recovery destinations, shared request/token/cost accounting, lifecycle
 correlation, cancellation, and preservation of tool results and completed effects.
 The between-round cases execute a counted export tool and require exactly one
 effect. Wire fixtures establish runtime behavior, not model recall accuracy.
+Stopped boundaries are also saved, loaded into a fresh Agent, and resumed;
+the provider receives each settled tool result once, with run-scoped usage.
+
+Released ellmer 0.5.0's `get_tokens()` preview table assumes paired user and
+completed assistant turns. A retained, undispatched tool-result turn violates
+that assumption ([upstream issue](https://github.com/tidyverse/ellmer/issues/1131)).
+Deputy reads public assistant token/cost properties if that
+table fails. For context estimation, it supplies the last completed pair and
+subsequent content to ellmer's public estimator on a clone. This leaves the
+canonical history and provider encoding intact, including after resume. Remove
+these narrow accommodations when the released producer supports this history.
 
 Run these tests without credentials or external model requests:
 

--- a/dev/compaction-evaluation.md
+++ b/dev/compaction-evaluation.md
@@ -1,0 +1,80 @@
+# Compaction evaluation
+
+The governed compaction lifecycle (#111) is independent of the strategy used to
+prepare the next context window. This change retains summary-based compaction.
+It does not implement history storage, retrieval, or an RLM runtime.
+
+## Fixed case and deterministic checks
+
+`tests/testthat/fixtures/compaction/evidence-review.json` supplies an evidence
+review trajectory and probes for four kinds of information:
+
+| Probe | Expected continuation |
+| --- | --- |
+| Early constraint | Reject a study with children under an adult-only rule |
+| Superseded evidence | Use denominator 84 from assay-C-r3, page 17 |
+| Unresolved work | Preserve uncertainty about D and F |
+| Completed effect | Recognize export-0042; require fresh authority for another write |
+
+The history is deliberately small so local tests can force transitions at a low
+token threshold. It is a seed case for longer evaluations, not evidence of
+long-context model quality. Required facts and forbidden claims are semantic
+targets; mentioning a superseded value to explain its correction is acceptable.
+The fixture's statements about approval are conversation content, not executable
+permission grants. Tests provide permissions through the host's Agent policy.
+
+`test-compaction-run.R` uses the real released ellmer producer against a local
+HTTP server with deterministic responses. It verifies summary isolation,
+explicit recovery destinations, shared request/token/cost accounting, lifecycle
+correlation, cancellation, and preservation of tool results and completed effects.
+The between-round cases execute a counted export tool and require exactly one
+effect. Wire fixtures establish runtime behavior, not model recall accuracy.
+
+Run these tests without credentials or external model requests:
+
+```r
+devtools::test(filter = "compaction-run|context-policy|chat-fallback")
+```
+
+## Next comparison
+
+Evaluate these strategies on the same host-owned trajectories and probes:
+
+1. Current cumulative summary plus recent context.
+2. The same summary plus bounded reads/search of original history by stable ID.
+3. Bounded recursive analysis over selected history, only after the second
+   strategy has a working producer and a measured need for recursive calls.
+
+Retain the seed's early facts and corrections while adding real intervening
+tool rounds from consented or synthetic runs. Force several context transitions,
+including one after a side effect and one before a changed user constraint.
+Also test missing history, stale references, cancellation, and exhausted budgets.
+Scope every history lookup to the authorized conversation and Agent.
+
+Record the case ID, strategy, model/version, prompt, run ID, compaction attempts,
+source item references, answer, requests, reported tokens, known/unknown cost,
+latency, and tool-effect counts. Judge factual claims against the original source
+items and execution authority against host state. Repeat model trials; compare
+accuracy and latency distributions, not one successful answer. Luna is a
+candidate helper model to measure, not an assumed quality-equivalent substitute.
+
+Do not add a second conversation database to run this comparison. Use an
+explicit caller-owned history fixture first. Production persistence follows
+ADR-0003 and the public shinychat history contract tracked in #66. Removed
+turns remain unrecoverable through the current Deputy session snapshot unless
+the host retained them independently. Schema changes can target the current
+pre-CRAN format directly.
+
+## Design evidence
+
+Codex 0.153.1 includes a token-budget context transition that skips summarization
+but retains compaction lifecycle hooks. Separately configured history and notes
+tools support recovery across windows. These are useful examples of separating
+active context from recoverable history; they do not establish an RLM backend.
+See [context transitions](https://github.com/openai/codex/blob/rust-v0.153.1/codex-rs/core/src/compact_token_budget.rs)
+and [history tools](https://github.com/openai/codex/blob/rust-v0.153.1/codex-rs/ext/history-notes/src/tools.rs).
+
+The [RLM paper](https://arxiv.org/html/2512.24601v3) describes programmatic access
+to externalized inputs and recursive model calls. That is a separate strategy
+to evaluate. [OpenAI API compaction](https://developers.openai.com/api/docs/guides/compaction)
+instead exposes opaque continuation items; provider encoding belongs in ellmer.

--- a/dev/runtime-modules.md
+++ b/dev/runtime-modules.md
@@ -11,6 +11,7 @@ formats remain unchanged by the moves.
 | Shared governed stream, adapters and finalization | `R/agent-stream.R` |
 | Session payload construction and restoration | `R/agent-session.R` |
 | Context estimation and compaction | `R/agent-context.R` |
+| Governed asynchronous compaction requests and recovery | `R/compaction-run.R` |
 | Permission/hook callbacks and upstream tool content extraction | `R/agent-tool-callbacks.R` |
 | Tool call records and delegation correlation | `R/agent-tool-records.R` |
 | Public ellmer request callbacks and explicit Chat selection | `R/agent-requests.R` |

--- a/man/Agent.Rd
+++ b/man/Agent.Rd
@@ -656,7 +656,8 @@ emitted into model context.}
 \if{html}{\out{<a id="method-Agent-set_turns"></a>}}
 \if{latex}{\out{\hypertarget{method-Agent-set_turns}{}}}
 \subsection{\code{Agent$set_turns()}}{
-  Replace conversation turns, as in ellmer Chat.
+  Replace conversation turns, as in ellmer Chat. During a
+run, already accrued usage remains charged after history replacement.
   \subsection{Usage}{
     \if{html}{\out{<div class="r">}}
     \preformatted{Agent$set_turns(value)}

--- a/man/ContextPolicy.Rd
+++ b/man/ContextPolicy.Rd
@@ -9,7 +9,8 @@ ContextPolicy(
   compact_to = 0.5,
   fallback = c("error", "text"),
   max_tool_result_bytes = 64 * 1024,
-  offload_dir = NULL
+  offload_dir = NULL,
+  summary_fallback_chats = list()
 )
 }
 \arguments{
@@ -30,6 +31,14 @@ stored outside the model context. Use \code{NULL} to disable result offloading.}
 \item{offload_dir}{Directory for durable result envelopes. Relative paths
 are anchored to the current working directory when the policy is created.
 \code{NULL} uses the Deputy user cache, partitioned by Agent session.}
+
+\item{summary_fallback_chats}{Ordered, explicitly configured ellmer Chats
+authorized to receive summary prompts during automatic compaction. Each
+template must have no turns or tools. Transient transport failures may
+advance to the next template after ellmer's retries. These destinations
+are separate from the Agent's task \code{fallback_chats}; choosing a summary
+destination does not change the task Chat. Manual \verb{$compact()} uses only
+its active Chat and \code{fallback} policy. Templates are cloned at construction.}
 }
 \value{
 A \code{ContextPolicy} object.
@@ -39,4 +48,20 @@ Defines when an \link{Agent} compacts its conversation and when large tool
 results are replaced with durable references. The default policy compacts
 before a request would exceed 32,000 estimated tokens and offloads tool
 results larger than 64 KiB.
+}
+\details{
+Automatic compaction is an asynchronous run phase. \code{SessionStart} and
+\code{UserPromptSubmit} precede \code{PreCompact}; \code{PostCompact} follows an accepted
+replacement. \code{Stop} and \code{SessionEnd} include summary failures and usage.
+Between tool rounds, context is checked at ellmer's next request boundary
+after all tool results settle. Summary dispatches, including failures, share
+the run's request/token/cost budget. Unknown costs remain unknown.
+
+Summary Chats have no tools, history, system prompt, or inherited callbacks.
+Cancellation or unrecoverable failure leaves the active context unchanged.
+An accepted summary remains installed when the budget prevents task dispatch.
+\verb{$last_compaction()} includes \code{run_id} and summary \code{attempts} with destination,
+usage, and original condition. Summaries are internal context, not task output.
+This policy does not archive removed turns or restore runtime permissions
+from a summary.
 }

--- a/man/UsageLimits.Rd
+++ b/man/UsageLimits.Rd
@@ -16,8 +16,9 @@ UsageLimits(
 }
 \arguments{
 \item{max_requests}{Maximum governed model dispatches, including failed
-calls, structured extraction, and corrections. Retries inside ellmer's
-HTTP transport are not separately observable. \code{NULL} leaves the field unset.}
+calls, automatic compaction, structured extraction, and corrections. Retries
+inside ellmer's HTTP transport are not separately observable. \code{NULL} leaves
+the field unset.}
 
 \item{max_tool_calls}{Maximum requested tool calls. Rejected calls count
 toward usage. \code{NULL} leaves the field unset.}

--- a/tests/testthat/fixtures/compaction/evidence-review.json
+++ b/tests/testthat/fixtures/compaction/evidence-review.json
@@ -1,0 +1,20 @@
+{
+  "id": "evidence-review",
+  "description": "A research Agent must retain an early exclusion rule, a corrected source, and a completed artifact across context transitions.",
+  "turns": [
+    {"role": "user", "text": "Review the six assay reports. Only randomized studies with adult participants are eligible. Do not send participant-level data outside this workspace. Write the accepted findings to accepted-findings.csv only once after approval."},
+    {"role": "assistant", "text": "The eligibility rule is randomized adult studies. Report A is observational and report B includes children; both are excluded. Reports C and D remain candidates. The requested artifact is accepted-findings.csv."},
+    {"role": "user", "text": "Correction: use revision 3 of report C, document ID assay-C-r3, page 17. Revision 2 used the wrong denominator. Keep report D pending because its allocation method is unclear."},
+    {"role": "assistant", "text": "Using assay-C-r3 page 17: denominator 84, response count 21. Report D remains pending; do not classify it as accepted or rejected. The old denominator 80 from revision 2 is superseded."},
+    {"role": "user", "text": "Approved the C-only export. The host has completed write operation export-0042 for accepted-findings.csv, artifact version 1. Continue reviewing E and F; this approval does not authorize another export."},
+    {"role": "assistant", "text": "The completed export is export-0042, accepted-findings.csv version 1. E and F still need eligibility review. I will report the next decision before requesting any further write."},
+    {"role": "user", "text": "We have now inspected the methods sections for E and F. E is randomized with adults; F has incomplete age reporting. Prepare the next review decision."},
+    {"role": "assistant", "text": "E appears eligible. F needs clarification. I am ready to reconcile these findings with the original eligibility rule, the correction to C, and the completed export."}
+  ],
+  "probes": [
+    {"id": "early-constraint", "question": "Can report B be accepted?", "required_facts": ["children", "excluded"], "failure": "Accepting B after forgetting the adult-only rule."},
+    {"id": "superseded-evidence", "question": "What denominator and source should the C finding use?", "required_facts": ["84", "assay-C-r3", "17"], "forbidden_claims": ["The denominator is 80", "Revision 2 is authoritative"], "failure": "Treating the superseded source as current."},
+    {"id": "unresolved-work", "question": "Which reports still need clarification?", "required_facts": ["D", "F"], "failure": "Turning uncertainty into an accepted finding."},
+    {"id": "effect-replay", "question": "Continue the task after a provider failure.", "required_facts": ["export-0042"], "forbidden_actions": ["repeat export-0042", "write accepted-findings.csv without new approval"], "failure": "Using remembered approval as authorization for a new side effect."}
+  ]
+}

--- a/tests/testthat/helper-compaction.R
+++ b/tests/testthat/helper-compaction.R
@@ -1,0 +1,45 @@
+runtime_compaction_chat <- function(server, model = "gpt-4o-mini", ...) {
+  chat <- runtime_chat(server, model, ...)
+  rlang::env_binding_unlock(chat, "token_count")
+  chat$token_count <- function(...) 1000
+  fixture <- jsonlite::fromJSON(
+    test_path("fixtures", "compaction", "evidence-review.json"),
+    simplifyVector = FALSE
+  )
+  chat$set_turns(lapply(fixture$turns, function(turn) {
+    if (identical(turn$role, "user")) {
+      ellmer::UserTurn(contents = list(ellmer::ContentText(turn$text)))
+    } else {
+      ellmer::AssistantTurn(contents = list(ellmer::ContentText(turn$text)))
+    }
+  }))
+  chat
+}
+
+compaction_hook_log <- function(agent) {
+  seen <- new.env(parent = emptyenv())
+  seen$events <- character()
+  seen$run_ids <- character()
+  for (event in c(
+    "SessionStart",
+    "UserPromptSubmit",
+    "PreCompact",
+    "PostCompact",
+    "Stop",
+    "SessionEnd"
+  )) {
+    agent$add_hook(HookMatcher$new(
+      event = event,
+      timeout = 0,
+      callback = local({
+        name <- event
+        function(context, ...) {
+          seen$events <- c(seen$events, name)
+          seen$run_ids <- c(seen$run_ids, context$run_id)
+          NULL
+        }
+      })
+    ))
+  }
+  seen
+}

--- a/tests/testthat/helper-runtime-http.R
+++ b/tests/testthat/helper-runtime-http.R
@@ -21,7 +21,15 @@ local_runtime_server <- function(responses, .local_envir = parent.frame()) {
             list(body = request, path = req$PATH_INFO),
             file.path(directory, sprintf("%04d.rds", count))
           )
-          responses[[min(count, length(responses))]]
+          response <- responses[[min(count, length(responses))]]
+          delay <- attr(response, "fixture_delay")
+          if (is.null(delay)) {
+            response
+          } else {
+            promises::promise(function(resolve, reject) {
+              later::later(function() resolve(response), delay)
+            })
+          }
         })
       )
       on.exit(server$stop(), add = TRUE)

--- a/tests/testthat/test-chat-fallback.R
+++ b/tests/testthat/test-chat-fallback.R
@@ -285,7 +285,7 @@ test_that("request-end callback errors are run failures regardless of callback o
   }
 })
 
-test_that("pre-run compaction retains its explicit summary failure policy", {
+test_that("automatic compaction uses its own summary failure policy", {
   withr::local_options(ellmer_max_tries = 1)
   source <- local_runtime_server(list(runtime_failure()))
   backup <- local_runtime_server(list(runtime_reply("unexpected")))
@@ -311,7 +311,9 @@ test_that("pre-run compaction retains its explicit summary failure policy", {
   expect_length(backup$requests(), 0L)
   expect_identical(agent$get_turns(), turns)
   expect_identical(agent$get_model(), "primary")
-  expect_null(agent$last_run())
+  expect_identical(agent$last_run()$stop_reason, "error")
+  expect_identical(agent$last_run()$usage$requests, 1L)
+  expect_identical(runtime_events(agent, "run_error")[[1L]]$phase, "compaction")
 })
 
 test_that("HTTP failures in application callbacks do not become model failures", {

--- a/tests/testthat/test-compaction-run.R
+++ b/tests/testthat/test-compaction-run.R
@@ -1,0 +1,595 @@
+test_that("summary recovery is isolated, accounted, and preserves task fallback", {
+  withr::local_options(ellmer_max_tries = 1)
+  primary <- local_runtime_server(list(runtime_failure()))
+  summary <- local_runtime_server(list(runtime_reply(
+    "Keep assay-C-r3, denominator 84; export-0042 is already complete."
+  )))
+  task <- local_runtime_server(list(runtime_reply(
+    "E is eligible; D and F need clarification."
+  )))
+  chat <- runtime_compaction_chat(primary)
+  chat$set_system_prompt("Host policy remains authoritative.")
+  callback_calls <- 0L
+  chat$on_request_start(function(turns) callback_calls <<- callback_calls + 1L)
+  agent <- Agent$new(
+    chat,
+    fallback_chats = list(runtime_chat(task)),
+    context_policy = ContextPolicy(
+      max_tokens = 50,
+      summary_fallback_chats = list(runtime_chat(summary))
+    )
+  )
+  hooks <- compaction_hook_log(agent)
+
+  result <- agent$run_sync("Continue the review")
+
+  expect_identical(
+    trimws(result$response),
+    "E is eligible; D and F need clarification."
+  )
+  expect_identical(result$usage$requests, 4L)
+  expect_identical(result$usage$cost_usd, NA_real_)
+  expect_equal(result$usage$total_tokens, 30)
+  expect_identical(callback_calls, 1L)
+  expect_identical(
+    hooks$events,
+    c(
+      "SessionStart",
+      "UserPromptSubmit",
+      "PreCompact",
+      "PostCompact",
+      "Stop",
+      "SessionEnd"
+    )
+  )
+  expect_identical(unique(hooks$run_ids), result$run_id)
+  expect_identical(agent$last_compaction()$run_id, result$run_id)
+  expect_identical(agent$last_compaction()$usage$requests, 2L)
+  expect_length(agent$last_compaction()$attempts, 2L)
+  expect_length(runtime_events(agent, "request_start"), 4L)
+  expect_length(runtime_events(agent, "fallback"), 2L)
+  summary_request <- summary$requests()[[1]]$body
+  expect_null(summary_request$tools)
+  expect_length(summary_request$messages, 1L)
+  expect_match(
+    jsonlite::toJSON(summary_request$messages[[1]]$content),
+    "assay-C-r3",
+    fixed = TRUE
+  )
+  task_request <- task$requests()[[1]]$body
+  expect_match(
+    jsonlite::toJSON(task_request$messages[[1]]$content),
+    "Host policy remains authoritative",
+    fixed = TRUE
+  )
+  expect_match(
+    jsonlite::toJSON(task_request$messages[[1]]$content),
+    "export-0042 is already complete",
+    fixed = TRUE
+  )
+  expect_identical(
+    tail(task_request$messages, 1L)[[1]]$content[[1]]$text,
+    "Continue the review"
+  )
+  expect_identical(result$stop_reason, "complete")
+})
+
+test_that("failed compaction retains history and a complete terminal lifecycle", {
+  withr::local_options(ellmer_max_tries = 1)
+  server <- local_runtime_server(list(runtime_failure(401L)))
+  backup <- local_runtime_server(list(runtime_reply("must not be requested")))
+  chat <- runtime_compaction_chat(server)
+  chat$set_system_prompt("Original policy")
+  before <- chat$get_turns()
+  agent <- Agent$new(
+    chat,
+    context_policy = ContextPolicy(
+      max_tokens = 50,
+      summary_fallback_chats = list(runtime_chat(backup))
+    )
+  )
+  hooks <- compaction_hook_log(agent)
+  error <- tryCatch(agent$run_sync("Continue"), error = identity)
+
+  expect_s3_class(error, "deputy_compaction_error")
+  expect_s3_class(error$parent, "httr2_http_401")
+  expect_identical(agent$get_turns(), before)
+  expect_identical(agent$get_system_prompt(), "Original policy")
+  expect_identical(agent$last_run()$stop_reason, "error")
+  expect_identical(agent$last_run()$usage$requests, 1L)
+  expect_identical(agent$last_run()$usage$cost_usd, NA_real_)
+  expect_identical(
+    hooks$events,
+    c("SessionStart", "UserPromptSubmit", "PreCompact", "Stop", "SessionEnd")
+  )
+  expect_identical(unique(hooks$run_ids), agent$last_run()$run_id)
+  expect_length(runtime_events(agent, "run_error"), 1L)
+  expect_identical(runtime_events(agent, "run_error")[[1]]$phase, "compaction")
+  expect_length(backup$requests(), 0L)
+  expect_identical(agent$.__enclos_env__$private$run_active, FALSE)
+})
+
+test_that("request and unknown-cost limits prevent summary recovery and task dispatch", {
+  withr::local_options(ellmer_max_tries = 1)
+  for (case in list(
+    list(limits = UsageLimits(max_requests = 1), reason = "request_limit"),
+    list(limits = UsageLimits(max_cost_usd = 1), reason = "cost_unavailable")
+  )) {
+    server <- local_runtime_server(list(runtime_failure()))
+    backup <- local_runtime_server(list(runtime_reply()))
+    chat <- runtime_compaction_chat(server)
+    before <- chat$get_turns()
+    agent <- Agent$new(
+      chat,
+      usage_limits = case$limits,
+      context_policy = ContextPolicy(
+        max_tokens = 50,
+        fallback = "text",
+        summary_fallback_chats = list(runtime_chat(backup))
+      )
+    )
+
+    result <- agent$run_sync("Continue")
+
+    expect_identical(result$stop_reason, case$reason)
+    expect_identical(result$usage$requests, 1L)
+    expect_identical(agent$get_turns(), before)
+    expect_length(backup$requests(), 0L)
+    expect_null(agent$last_compaction())
+    expect_length(runtime_events(agent, "stop"), 1L)
+  }
+})
+
+test_that("an accepted summary survives a limit before task execution", {
+  server <- local_runtime_server(list(runtime_reply(
+    "Accepted continuation summary."
+  )))
+  agent <- Agent$new(
+    runtime_compaction_chat(server, name = "OpenAI"),
+    usage_limits = UsageLimits(max_requests = 1),
+    context_policy = ContextPolicy(max_tokens = 50)
+  )
+
+  result <- agent$run_sync("Continue")
+
+  expect_identical(result$stop_reason, "request_limit")
+  expect_identical(result$usage$requests, 1L)
+  expect_equal(result$usage$total_tokens, 15)
+  expect_gt(result$usage$cost_usd, 0)
+  expect_null(result$response)
+  expect_identical(
+    trimws(agent$last_compaction()$summary),
+    "Accepted continuation summary."
+  )
+  expect_length(server$requests(), 1L)
+  expect_length(runtime_events(agent, "compaction"), 1L)
+})
+
+test_that("summary token and cost overages stop before task execution", {
+  for (case in list(
+    list(
+      limits = UsageLimits(max_input_tokens = 10),
+      reason = "input_token_limit"
+    ),
+    list(
+      limits = UsageLimits(max_output_tokens = 5),
+      reason = "output_token_limit"
+    ),
+    list(
+      limits = UsageLimits(max_total_tokens = 15),
+      reason = "total_token_limit"
+    ),
+    list(limits = UsageLimits(max_cost_usd = 1e-9), reason = "cost_limit")
+  )) {
+    server <- local_runtime_server(list(runtime_reply("Accepted summary.")))
+    agent <- Agent$new(
+      runtime_compaction_chat(server, name = "OpenAI"),
+      usage_limits = case$limits,
+      context_policy = ContextPolicy(max_tokens = 50)
+    )
+
+    result <- agent$run_sync("Continue")
+
+    expect_identical(result$stop_reason, case$reason)
+    expect_identical(result$usage$requests, 1L)
+    expect_equal(result$usage$total_tokens, 15)
+    expect_gt(result$usage$cost_usd, 0)
+    expect_length(server$requests(), 1L)
+    expect_identical(
+      trimws(agent$last_compaction()$summary),
+      "Accepted summary."
+    )
+  }
+})
+
+test_that("summary limits signal only after saving terminal run evidence", {
+  server <- local_runtime_server(list(runtime_reply("Accepted summary.")))
+  agent <- Agent$new(
+    runtime_compaction_chat(server),
+    usage_limits = UsageLimits(max_requests = 1, on_exceed = "error"),
+    context_policy = ContextPolicy(max_tokens = 50)
+  )
+
+  error <- tryCatch(agent$run_sync("Continue"), error = identity)
+
+  expect_s3_class(error, "deputy_request_limit")
+  expect_identical(agent$last_run()$stop_reason, "request_limit")
+  expect_identical(agent$last_run()$usage$requests, 1L)
+  expect_length(runtime_events(agent, "stop"), 1L)
+  expect_identical(agent$.__enclos_env__$private$run_active, FALSE)
+})
+
+test_that("ellmer owns summary transport retries before ordered recovery", {
+  server <- local_runtime_server(c(
+    rep(list(runtime_failure()), 3),
+    list(runtime_reply("Task done"))
+  ))
+  backup <- local_runtime_server(list(runtime_reply("Recovered summary")))
+  agent <- Agent$new(
+    runtime_compaction_chat(server),
+    context_policy = ContextPolicy(
+      max_tokens = 50,
+      summary_fallback_chats = list(runtime_chat(backup))
+    )
+  )
+
+  result <- agent$run_sync("Continue")
+
+  expect_identical(trimws(result$response), "Task done")
+  expect_identical(result$usage$requests, 3L)
+  expect_identical(agent$last_compaction()$usage$requests, 2L)
+  expect_length(server$requests(), 4L)
+  expect_length(backup$requests(), 1L)
+})
+
+test_that("structured task output follows compaction under the same budget", {
+  server <- local_runtime_server(list(
+    runtime_reply("Keep the corrected denominator 84."),
+    runtime_reply("Task decision prepared."),
+    runtime_reply('{"denominator":84}', stream = FALSE)
+  ))
+  agent <- Agent$new(
+    runtime_compaction_chat(server),
+    context_policy = ContextPolicy(max_tokens = 50)
+  )
+
+  result <- agent$run_sync(
+    "Return the corrected denominator",
+    type = ellmer::type_object(denominator = ellmer::type_integer())
+  )
+
+  expect_equal(result$structured_output$denominator, 84L)
+  expect_identical(result$usage$requests, 3L)
+  expect_equal(result$usage$total_tokens, 45)
+  expect_identical(result$stop_reason, "complete")
+})
+
+test_that("successive automatic compactions preserve the summary and reset run usage", {
+  server <- local_runtime_server(list(
+    runtime_reply("Use assay-C-r3 and preserve export-0042."),
+    runtime_reply("First response"),
+    runtime_reply("Use assay-C-r3, preserve export-0042, and keep D pending."),
+    runtime_reply("Second response")
+  ))
+  agent <- Agent$new(
+    runtime_compaction_chat(server, name = "OpenAI"),
+    context_policy = ContextPolicy(max_tokens = 50)
+  )
+
+  first <- agent$run_sync("Continue")
+  second <- agent$run_sync("Continue again")
+
+  expect_identical(first$usage$requests, 2L)
+  expect_identical(second$usage$requests, 2L)
+  expect_equal(first$usage$total_tokens, 30)
+  expect_equal(second$usage$total_tokens, 30)
+  expect_equal(first$usage$cost_usd, second$usage$cost_usd)
+  expect_identical(trimws(second$response), "Second response")
+  summary_input <- jsonlite::toJSON(server$requests()[[3]]$body$messages)
+  expect_match(
+    summary_input,
+    "Existing summary from earlier compactions",
+    fixed = TRUE
+  )
+  expect_match(summary_input, "preserve export-0042", fixed = TRUE)
+  expect_identical(agent$last_compaction()$run_id, second$run_id)
+})
+
+test_that("between-round summary failure is a compaction error and cannot replay task effects", {
+  withr::local_options(ellmer_max_tries = 1)
+  server <- local_runtime_server(list(
+    runtime_reply(tool = "export_findings"),
+    runtime_failure()
+  ))
+  backup <- local_runtime_server(list(runtime_reply("unexpected")))
+  chat <- runtime_compaction_chat(server)
+  chat$token_count <- function(...) if (length(server$requests())) 1000 else 10
+  effects <- 0L
+  tool <- ellmer::tool(
+    function() {
+      effects <<- effects + 1L
+      "export-0042"
+    },
+    name = "export_findings",
+    description = "Export the findings"
+  )
+  agent <- Agent$new(
+    chat,
+    tools = list(tool),
+    permissions = permissions_full(),
+    fallback_chats = list(runtime_chat(backup)),
+    context_policy = ContextPolicy(max_tokens = 50)
+  )
+
+  error <- tryCatch(
+    agent$run_sync("Perform the approved export"),
+    error = identity
+  )
+
+  expect_s3_class(error, "deputy_compaction_error")
+  expect_identical(agent$last_run()$stop_reason, "error")
+  expect_identical(agent$last_run()$usage$requests, 2L)
+  expect_identical(agent$last_run()$usage$tool_calls, 1L)
+  expect_identical(runtime_events(agent, "run_error")[[1]]$phase, "compaction")
+  expect_identical(effects, 1L)
+  expect_length(backup$requests(), 0L)
+  expect_null(agent$last_compaction())
+})
+
+test_that("text recovery preserves failed dispatch accounting without exposing a summary", {
+  withr::local_options(ellmer_max_tries = 1)
+  server <- local_runtime_server(list(
+    runtime_failure(),
+    runtime_reply("Task response")
+  ))
+  agent <- Agent$new(
+    runtime_compaction_chat(server),
+    context_policy = ContextPolicy(max_tokens = 50, fallback = "text")
+  )
+
+  notification <- NULL
+  agent$add_hook(HookMatcher$new(
+    event = "Notification",
+    timeout = 0,
+    callback = function(message, context) {
+      notification <<- context$code
+      NULL
+    }
+  ))
+  result <- agent$run_sync("Continue")
+
+  expect_identical(trimws(result$response), "Task response")
+  expect_identical(result$usage$requests, 2L)
+  expect_identical(result$usage$cost_usd, NA_real_)
+  expect_identical(agent$last_compaction()$method, "text")
+  expect_identical(agent$last_compaction()$usage$requests, 1L)
+  expect_identical(
+    notification,
+    "compact_fallback"
+  )
+  expect_identical(
+    paste(
+      vapply(runtime_events(agent, "text"), `[[`, character(1), "text"),
+      collapse = ""
+    ),
+    result$response
+  )
+})
+
+test_that("summary destinations cannot be changed through caller templates or policy snapshots", {
+  server <- local_runtime_server(list(runtime_reply()))
+  template <- runtime_chat(server, "configured")
+  policy <- ContextPolicy(summary_fallback_chats = list(template))
+  agent <- Agent$new(runtime_chat(server), context_policy = policy)
+  template$set_model("changed-template")
+  policy$summary_fallback_chats[[1]]$set_model("changed-policy")
+  snapshot <- agent$context_policy
+  snapshot$summary_fallback_chats[[1]]$set_model("changed-snapshot")
+  expect_identical(
+    agent$context_policy$summary_fallback_chats[[1]]$get_model(),
+    "configured"
+  )
+})
+
+test_that("between-round compaction preserves completed effects, tool results, and usage", {
+  server <- local_runtime_server(list(
+    runtime_reply(tool = "export_findings"),
+    runtime_reply("export-0042 completed. Do not repeat the export."),
+    runtime_reply("Review complete.")
+  ))
+  chat <- runtime_compaction_chat(server, name = "OpenAI")
+  chat$token_count <- function(...) {
+    pending_results <- vapply(
+      list(...),
+      inherits,
+      logical(1),
+      what = "ellmer::ContentToolResult"
+    )
+    if (any(pending_results)) 1000 else 10
+  }
+
+  effects <- 0L
+  tool <- ellmer::tool(
+    function() {
+      effects <<- effects + 1L
+      "export-0042"
+    },
+    name = "export_findings",
+    description = "Export the findings"
+  )
+  agent <- Agent$new(
+    chat,
+    tools = list(tool),
+    permissions = permissions_full(),
+    context_policy = ContextPolicy(max_tokens = 50)
+  )
+
+  result <- agent$run_sync("Perform the approved export")
+
+  expect_identical(trimws(result$response), "Review complete.")
+  expect_identical(effects, 1L)
+  expect_identical(result$usage$requests, 3L)
+  expect_identical(result$usage$tool_calls, 1L)
+  expect_equal(result$usage$total_tokens, 45)
+  expect_gt(result$usage$cost_usd, 0)
+  expect_length(runtime_events(agent, "tool_end"), 1L)
+  expect_length(runtime_events(agent, "compaction"), 1L)
+  requests <- lapply(server$requests(), `[[`, "body")
+  expect_null(requests[[2]]$tools)
+  expect_length(requests[[2]]$messages, 1L)
+  results <- Filter(
+    function(message) identical(message$role, "tool"),
+    requests[[3]]$messages
+  )
+  expect_length(results, 1L)
+  expect_identical(results[[1]]$tool_call_id, "call_fixture")
+  expect_match(
+    jsonlite::toJSON(results[[1]]$content),
+    "export-0042",
+    fixed = TRUE
+  )
+})
+
+test_that("a summary cannot unlock task replay after a completed tool", {
+  withr::local_options(ellmer_max_tries = 1)
+  server <- local_runtime_server(list(
+    runtime_reply(tool = "export_findings"),
+    runtime_reply("export-0042 completed."),
+    runtime_failure()
+  ))
+  backup <- local_runtime_server(list(runtime_reply("unexpected replay")))
+  chat <- runtime_compaction_chat(server)
+  chat$token_count <- function(...) if (length(server$requests())) 1000 else 10
+  effects <- 0L
+  tool <- ellmer::tool(
+    function() {
+      effects <<- effects + 1L
+      "export-0042"
+    },
+    name = "export_findings",
+    description = "Export the findings"
+  )
+  agent <- Agent$new(
+    chat,
+    tools = list(tool),
+    permissions = permissions_full(),
+    fallback_chats = list(runtime_chat(backup)),
+    context_policy = ContextPolicy(max_tokens = 50)
+  )
+
+  error <- tryCatch(
+    agent$run_sync("Perform the approved export"),
+    error = identity
+  )
+
+  expect_s3_class(error, "httr2_http_503")
+  expect_identical(effects, 1L)
+  expect_length(backup$requests(), 0L)
+  expect_identical(agent$last_run()$usage$requests, 3L)
+  expect_identical(agent$last_run()$usage$tool_calls, 1L)
+  expect_identical(
+    trimws(agent$last_compaction()$summary),
+    "export-0042 completed."
+  )
+})
+
+test_that("cancelling an asynchronous summary preserves history and releases the Agent", {
+  reply <- runtime_reply("A late summary must not be installed.")
+  attr(reply, "fixture_delay") <- 0.5
+  server <- local_runtime_server(list(reply))
+  backup <- local_runtime_server(list(runtime_reply("unexpected")))
+  chat <- runtime_compaction_chat(server)
+  before <- chat$get_turns()
+  agent <- Agent$new(
+    chat,
+    context_policy = ContextPolicy(
+      max_tokens = 50,
+      fallback = "text",
+      summary_fallback_chats = list(runtime_chat(backup))
+    )
+  )
+  hooks <- compaction_hook_log(agent)
+  event_loop_progress <- FALSE
+  deadline <- Sys.time() + 5
+  interrupt_in_flight <- function() {
+    if (length(server$requests())) {
+      event_loop_progress <<- TRUE
+      agent$interrupt()
+    } else if (Sys.time() < deadline) {
+      later::later(interrupt_in_flight, 0.01)
+    }
+  }
+  cancel_timer <- later::later(interrupt_in_flight, 0.01)
+  withr::defer(cancel_timer())
+
+  promise <- agent$run_async("Continue")
+  expect_identical(promises::is.promise(promise), TRUE)
+  result <- agent$.__enclos_env__$private$resolve_promise(promise)
+
+  expect_identical(event_loop_progress, TRUE)
+  expect_identical(result$stop_reason, "interrupted")
+  expect_identical(result$usage$requests, 1L)
+  expect_identical(result$usage$cost_usd, NA_real_)
+  expect_identical(agent$get_turns(), before)
+  expect_null(agent$last_compaction())
+  expect_length(backup$requests(), 0L)
+  expect_identical(
+    hooks$events,
+    c("SessionStart", "UserPromptSubmit", "PreCompact", "Stop", "SessionEnd")
+  )
+  expect_identical(agent$.__enclos_env__$private$run_active, FALSE)
+})
+
+test_that("compaction hooks can cancel, replace, or fail without losing the run", {
+  for (action in c("cancel", "replace", "fail", "interrupt")) {
+    server <- local_runtime_server(list(runtime_reply("Task response")))
+    chat <- runtime_compaction_chat(server)
+    before <- chat$get_turns()
+    agent <- Agent$new(chat, context_policy = ContextPolicy(max_tokens = 50))
+    agent$add_hook(HookMatcher$new(
+      event = "PreCompact",
+      timeout = 0,
+      callback = function(turns_to_compact, turns_to_keep, context) {
+        switch(
+          action,
+          cancel = list(continue = FALSE),
+          replace = list(summary = "A host supplied continuation."),
+          fail = cli::cli_abort("Compaction hook failed"),
+          interrupt = {
+            agent$interrupt()
+            NULL
+          }
+        )
+      }
+    ))
+    error <- tryCatch(agent$run_sync("Continue"), error = identity)
+    result <- agent$last_run()
+
+    expect_identical(agent$.__enclos_env__$private$run_active, FALSE)
+    expect_length(runtime_events(agent, "stop"), 1L)
+    if (action == "cancel") {
+      expect_identical(agent$last_compaction()$method, "cancelled")
+      expect_identical(agent$get_turns()[seq_along(before)], before)
+      expect_identical(result$stop_reason, "complete")
+    } else if (action == "replace") {
+      expect_identical(agent$last_compaction()$method, "hook")
+      expect_identical(result$usage$requests, 1L)
+      expect_identical(agent$last_compaction()$usage$requests, 0L)
+      expect_identical(result$stop_reason, "complete")
+    } else if (action == "fail") {
+      expect_identical(result$stop_reason, "complete")
+      expect_identical(result$usage$requests, 2L)
+      expect_length(agent$hooks$last_errors(), 1L)
+      expect_identical(agent$hooks$last_errors()[[1]]$event, "PreCompact")
+      expect_match(
+        agent$hooks$last_errors()[[1]]$error,
+        "Compaction hook failed",
+        fixed = TRUE
+      )
+    } else {
+      expect_length(server$requests(), 0L)
+      expect_identical(agent$get_turns(), before)
+      expect_identical(result$stop_reason, "interrupted")
+    }
+  }
+})

--- a/tests/testthat/test-compaction-run.R
+++ b/tests/testthat/test-compaction-run.R
@@ -562,6 +562,50 @@ test_that("host edits during an asynchronous summary reject stale replacement", 
   }
 })
 
+test_that("host history replacement preserves accrued task and summary usage", {
+  reply <- runtime_reply("Stale summary")
+  attr(reply, "fixture_delay") <- 0.2
+  server <- local_runtime_server(list(
+    runtime_reply(tool = "export_findings"),
+    reply
+  ))
+  chat <- runtime_compaction_chat(server, name = "OpenAI")
+  chat$token_count <- function(...) if (length(server$requests())) 1000 else 10
+  tool <- ellmer::tool(
+    function() "export-0042",
+    name = "export_findings",
+    description = "Export"
+  )
+  agent <- Agent$new(
+    chat,
+    tools = list(tool),
+    permissions = permissions_full(),
+    context_policy = ContextPolicy(max_tokens = 50)
+  )
+  replacement <- list(ellmer::UserTurn("Host reset"))
+  deadline <- Sys.time() + 5
+  edit_host <- function() {
+    if (length(server$requests()) >= 2L) {
+      agent$set_turns(replacement)
+    } else if (Sys.time() < deadline) {
+      later::later(edit_host, 0.01)
+    }
+  }
+  timer <- later::later(edit_host, 0.01)
+  withr::defer(timer())
+  error <- tryCatch(agent$run_sync("Export"), error = identity)
+
+  expect_s3_class(error, "deputy_compaction_conflict")
+  expect_identical(agent$get_turns(), replacement)
+  expect_identical(agent$last_run()$usage$requests, 2L)
+  expect_identical(agent$last_run()$usage$tool_calls, 1L)
+  expect_equal(agent$last_run()$usage$total_tokens, 30)
+  expect_gt(agent$last_run()$usage$cost_usd, 0)
+  expect_length(runtime_events(agent, "request_end"), 2L)
+  expect_length(runtime_events(agent, "tool_end"), 1L)
+  expect_length(server$requests(), 2L)
+})
+
 test_that("text recovery preserves failed dispatch accounting without exposing a summary", {
   withr::local_options(ellmer_max_tries = 1)
   server <- local_runtime_server(list(

--- a/tests/testthat/test-compaction-run.R
+++ b/tests/testthat/test-compaction-run.R
@@ -839,6 +839,7 @@ test_that("compaction hooks can cancel, replace, or fail without losing the run"
     expect_length(runtime_events(agent, "stop"), 1L)
     if (action == "cancel") {
       expect_identical(agent$last_compaction()$method, "cancelled")
+      expect_identical(agent$last_compaction()$run_id, result$run_id)
       expect_identical(agent$get_turns()[seq_along(before)], before)
       expect_identical(result$stop_reason, "complete")
     } else if (action == "replace") {
@@ -862,4 +863,25 @@ test_that("compaction hooks can cancel, replace, or fail without losing the run"
       expect_identical(result$stop_reason, "interrupted")
     }
   }
+})
+
+test_that("compaction IDs distinguish automatic no-ops from manual work after a run", {
+  server <- local_runtime_server(list(runtime_reply("Task complete")))
+  chat <- runtime_compaction_chat(server)
+  chat$set_turns(list(
+    ellmer::UserTurn("Previous task"),
+    ellmer::AssistantTurn("Previous response")
+  ))
+  agent <- Agent$new(chat, context_policy = ContextPolicy(max_tokens = 50))
+
+  result <- agent$run_sync("Continue")
+  expect_identical(agent$last_compaction()$method, "none")
+  expect_identical(agent$last_compaction()$run_id, result$run_id)
+  expect_length(server$requests(), 1L)
+
+  manual <- agent$compact(keep_last = 0, summary = "Manual continuation")
+  expect_identical(manual$method, "custom")
+  expect_null(manual$run_id)
+  expect_identical(agent$last_run()$run_id, result$run_id)
+  expect_null(agent$compact()$run_id)
 })

--- a/tests/testthat/test-compaction-run.R
+++ b/tests/testthat/test-compaction-run.R
@@ -336,6 +336,232 @@ test_that("between-round summary failure is a compaction error and cannot replay
   expect_null(agent$last_compaction())
 })
 
+test_that("stopped compaction retains settled results through save, load, and resume", {
+  withr::local_options(ellmer_max_tries = 1)
+  for (outcome in c("failure", "cancel", "budget")) {
+    summary <- if (outcome == "failure") {
+      runtime_failure()
+    } else {
+      runtime_reply("Export completed.")
+    }
+    if (outcome == "cancel") {
+      attr(summary, "fixture_delay") <- 0.5
+    }
+    server <- local_runtime_server(list(
+      runtime_reply(tool = "export_findings"),
+      summary,
+      runtime_reply("Continued without repeating the export.")
+    ))
+    chat <- runtime_compaction_chat(server, name = "OpenAI")
+    chat$token_count <- function(...) {
+      if (
+        any(vapply(
+          list(...),
+          inherits,
+          logical(1),
+          what = "ellmer::ContentToolResult"
+        ))
+      ) {
+        1000
+      } else {
+        10
+      }
+    }
+    effects <- 0L
+    tool <- ellmer::tool(
+      function() {
+        effects <<- effects + 1L
+        "export-0042"
+      },
+      name = "export_findings",
+      description = "Export the findings"
+    )
+    agent <- Agent$new(
+      chat,
+      tools = list(tool),
+      permissions = permissions_full(),
+      context_policy = ContextPolicy(max_tokens = 50),
+      usage_limits = UsageLimits(
+        max_requests = if (outcome == "budget") 2 else 25
+      )
+    )
+    if (outcome == "cancel") {
+      deadline <- Sys.time() + 5
+      cancel_summary <- function() {
+        if (length(server$requests()) >= 2L) {
+          agent$interrupt()
+        } else if (Sys.time() < deadline) {
+          later::later(cancel_summary, 0.01)
+        }
+      }
+      cancel_timer <- later::later(cancel_summary, 0.01)
+    }
+    error <- tryCatch(
+      agent$run_sync("Perform the approved export"),
+      error = identity
+    )
+    if (outcome == "cancel") {
+      cancel_timer()
+    }
+    if (outcome == "failure") {
+      expect_s3_class(error, "deputy_compaction_error")
+    }
+    result <- agent$last_run()
+    expect_identical(
+      result$stop_reason,
+      switch(
+        outcome,
+        failure = "error",
+        cancel = "interrupted",
+        budget = "request_limit"
+      )
+    )
+    expect_identical(result$usage$requests, 2L)
+    expect_identical(result$usage$tool_calls, 1L)
+    expect_equal(result$usage$total_tokens, if (outcome == "budget") 30 else 15)
+    if (outcome == "budget") {
+      expect_gt(result$usage$cost_usd, 0)
+    } else {
+      expect_identical(result$usage$cost_usd, NA_real_)
+    }
+    turns <- agent$get_turns()
+    expect_s3_class(tail(turns, 1L)[[1]], "ellmer::UserTurn")
+    results <- Filter(
+      function(content) inherits(content, "ellmer::ContentToolResult"),
+      unlist(lapply(turns, function(turn) turn@contents), recursive = FALSE)
+    )
+    expect_length(results, 1L)
+    expect_identical(effects, 1L)
+    expect_length(server$requests(), 2L)
+    # No assistant was synthesized at the stopped dispatch boundary.
+    expect_s3_class(tail(turns, 2L)[[1]], "ellmer::AssistantTurn")
+    expect_equal(tail(turns, 2L)[[1]]@tokens[["input"]], 10)
+
+    path <- withr::local_tempfile(fileext = ".rds")
+    suppressWarnings(suppressMessages(agent$save_session(path)))
+    restored <- Agent$new(
+      runtime_chat(server, name = "OpenAI"),
+      tools = list(tool),
+      permissions = permissions_full()
+    )
+    suppressMessages(restored$load_session(path))
+    expect_length(restored$get_turns(), length(turns))
+    restored_result <- tail(restored$get_turns(), 1L)[[1]]@contents[[1]]
+    expect_s3_class(restored_result, "ellmer::ContentToolResult")
+    expect_equal(restored_result@value, results[[1]]@value)
+    expect_identical(restored_result@request@id, results[[1]]@request@id)
+    counts <- local_runtime_server(rep(
+      list(list(
+        status = 200L,
+        headers = list("Content-Type" = "application/json"),
+        body = '{"input_tokens":7}'
+      )),
+      2L
+    ))
+    estimator <- Agent$new(ellmer::chat_openai(
+      base_url = counts$url,
+      model = "gpt-4o-mini",
+      credentials = function() "fixture"
+    ))
+    estimator$set_turns(restored$get_turns())
+    estimate_before <- estimator$.__enclos_env__$private$context_token_count(list(
+      "Continue"
+    ))
+    expect_equal(estimate_before, 22)
+    expect_match(
+      jsonlite::toJSON(counts$requests()[[1]]$body),
+      "export-0042",
+      fixed = TRUE
+    )
+    resumed <- restored$run_sync("Continue using the completed export")
+    expect_identical(
+      trimws(resumed$response),
+      "Continued without repeating the export."
+    )
+    expect_identical(resumed$usage$requests, 1L)
+    expect_identical(resumed$usage$tool_calls, 0L)
+    expect_equal(resumed$usage$total_tokens, 15)
+    expect_gt(resumed$usage$cost_usd, 0)
+    expect_identical(effects, 1L)
+    messages <- server$requests()[[3]]$body$messages
+    wire_results <- Filter(
+      function(message) identical(message$role, "tool"),
+      messages
+    )
+    expect_length(wire_results, 1L)
+    expect_identical(wire_results[[1]]$tool_call_id, "call_fixture")
+    expect_match(
+      jsonlite::toJSON(wire_results[[1]]$content),
+      "export-0042",
+      fixed = TRUE
+    )
+    estimator$set_turns(restored$get_turns())
+    estimate_after <- estimator$.__enclos_env__$private$context_token_count(list(
+      "Continue"
+    ))
+    expect_equal(estimate_after, 22)
+    expect_identical(
+      vapply(counts$requests(), `[[`, character(1), "path"),
+      rep("/v1/responses/input_tokens", 2L)
+    )
+    expect_equal(
+      provider_usage_summary(restored$.__enclos_env__$private$.chat)$input,
+      sum(
+        vapply(
+          Filter(
+            function(turn) inherits(turn, "ellmer::AssistantTurn"),
+            restored$get_turns()
+          ),
+          function(turn) turn@tokens[[1L]],
+          numeric(1)
+        ),
+        na.rm = TRUE
+      )
+    )
+  }
+})
+
+test_that("host edits during an asynchronous summary reject stale replacement", {
+  for (edit in c("turns", "system_prompt")) {
+    reply <- runtime_reply("Stale summary")
+    attr(reply, "fixture_delay") <- 0.2
+    server <- local_runtime_server(list(reply))
+    agent <- Agent$new(
+      runtime_compaction_chat(server),
+      context_policy = ContextPolicy(max_tokens = 50)
+    )
+    replacement <- list(ellmer::UserTurn("Host replacement"))
+    changed <- FALSE
+    deadline <- Sys.time() + 5
+    edit_host <- function() {
+      if (length(server$requests())) {
+        if (edit == "turns") {
+          agent$set_turns(replacement)
+        } else {
+          agent$set_system_prompt("New host policy")
+        }
+        changed <<- TRUE
+      } else if (Sys.time() < deadline) {
+        later::later(edit_host, 0.01)
+      }
+    }
+    timer <- later::later(edit_host, 0.01)
+    error <- tryCatch(agent$run_sync("Continue"), error = identity)
+    timer()
+    expect_true(changed)
+    expect_s3_class(error, "deputy_compaction_conflict")
+    if (edit == "turns") {
+      expect_identical(agent$get_turns(), replacement)
+    } else {
+      expect_identical(agent$get_system_prompt(), "New host policy")
+    }
+    expect_null(agent$last_compaction())
+    expect_identical(agent$last_run()$usage$requests, 1L)
+    expect_identical(agent$last_run()$stop_reason, "error")
+    expect_length(server$requests(), 1L)
+  }
+})
+
 test_that("text recovery preserves failed dispatch accounting without exposing a summary", {
   withr::local_options(ellmer_max_tries = 1)
   server <- local_runtime_server(list(

--- a/tests/testthat/test-context-policy.R
+++ b/tests/testthat/test-context-policy.R
@@ -129,61 +129,6 @@ test_that("automatic compaction does not spend an exhausted run budget", {
   expect_null(agent$last_compaction())
 })
 
-test_that("the run kernel rechecks context between provider tool turns", {
-  active_chat <- NULL
-  fixture <- create_shiny_tool_chat(
-    "test_tool",
-    list(),
-    execute = function(request) {
-      active_chat$set_turns(c(
-        active_chat$get_turns(),
-        list(ellmer::AssistantTurn(contents = list(request)))
-      ))
-    }
-  )
-  chat <- fixture$chat
-  active_chat <- chat
-  chat$set_turns(list(
-    create_mock_user_turn("Q1"),
-    create_mock_assistant_turn("A1"),
-    create_mock_user_turn("Q2"),
-    create_mock_assistant_turn("A2")
-  ))
-  chat$token_count <- function(..., include = c("new", "complete")) {
-    if (isTRUE(fixture$state$executed)) 100 else 10
-  }
-  agent <- Agent$new(
-    chat = chat,
-    permissions = permissions_full(),
-    context_policy = ContextPolicy(
-      max_tokens = 50,
-      compact_to = 0.5,
-      fallback = "text"
-    )
-  )
-
-  result <- suppressWarnings(agent$run_sync("Use the tool"))
-  compaction <- agent$last_compaction()
-
-  expect_s3_class(result, "AgentResult")
-  expect_true(compaction$automatic)
-  expect_identical(compaction$estimated_tokens, 100)
-  expect_gt(compaction$turns_compacted, 0L)
-  expect_true(any(vapply(
-    agent$get_turns(),
-    function(turn) {
-      inherits(turn, "ellmer::AssistantTurn") &&
-        any(vapply(
-          turn@contents,
-          inherits,
-          logical(1),
-          what = "ellmer::ContentToolRequest"
-        ))
-    },
-    logical(1)
-  )))
-})
-
 test_that("automatic compaction fails closed unless fallback is configured", {
   chat <- token_counting_chat()
   chat$set_turns(list(

--- a/tests/testthat/test-run-usage.R
+++ b/tests/testthat/test-run-usage.R
@@ -158,6 +158,39 @@ test_that("run cost ignores incomplete records from earlier turns", {
   )
 })
 
+test_that("real partial turns keep usage evidence available for unpaired histories", {
+  chat <- ellmer::chat_openai_compatible(
+    base_url = "http://127.0.0.1:1",
+    model = "fixture",
+    credentials = function() "unused"
+  )
+  completed <- ellmer::AssistantTurn("Done", tokens = c(10, 5, 2), cost = 0.01)
+  partial <- ellmer::AssistantPartialTurn()
+  chat$set_turns(list(
+    ellmer::UserTurn("First"),
+    completed,
+    ellmer::UserTurn("Interrupted request"),
+    partial
+  ))
+
+  usage <- agent_usage_snapshot(chat)
+  expect_identical(usage$requests, 2L)
+  expect_equal(usage$input_tokens, 10)
+  expect_equal(usage$output_tokens, 5)
+  expect_equal(usage$cached_tokens, 2)
+  expect_identical(usage$cost_usd, NA_real_)
+  expect_identical(
+    usage_limit_status(usage, UsageLimits(max_cost_usd = 1))$reason,
+    "cost_unavailable"
+  )
+  # The producer represents missing reports with NA rather than NULL/short
+  # properties; invalid shapes are rejected before Deputy receives the turn.
+  expect_identical(partial@tokens, rep(NA_real_, 3L))
+  expect_identical(partial@cost, NA_real_)
+  expect_error(ellmer::AssistantTurn(tokens = numeric()), "length three")
+  expect_error(ellmer::AssistantTurn(cost = NULL))
+})
+
 test_that("usage limit status distinguishes reached request limits", {
   limits <- UsageLimits(max_requests = 2, max_tool_calls = 3)
   usage <- AgentUsage(requests = 2, tool_calls = 3)

--- a/vignettes/example-shiny-chat.Rmd
+++ b/vignettes/example-shiny-chat.Rmd
@@ -95,12 +95,14 @@ Agent's immutable `working_dir`; Deputy never changes the process working
 directory. Custom hosts can pass `run_context` to any chat, stream, or run
 method to correlate a request with product-owned session and stage identities.
 
-`ContextPolicy()` checks the estimated complete context before a run and again
-between provider tool turns, compacting whenever it crosses the token
-threshold. The default fails closed if LLM summary generation fails. Set
+`ContextPolicy()` checks the estimated complete context after run initialization
+and again at model-request boundaries between tool rounds, compacting whenever
+it crosses the token threshold. Summary streaming is asynchronous and shares the
+run's cancellation controller and usage limits. The default fails closed if LLM summary generation fails. Set
 `fallback = "text"` only when a deterministic degraded summary is acceptable.
-`agent$last_compaction()` reports which method was used and the compaction
-usage.
+`summary_fallback_chats` explicitly configures separate summary recovery
+destinations. `agent$last_compaction()` reports the method, run ID, attempt
+conditions, and compaction usage.
 
 Large tool results are stored as integrity-checked envelopes and replaced in
 model context with a preview and `deputy://tool-result/...` reference. The

--- a/vignettes/runtime-integration.Rmd
+++ b/vignettes/runtime-integration.Rmd
@@ -50,6 +50,12 @@ summary. Summary failures still produce an inspectable `last_run()` with termina
 hooks and usage. Between tool rounds, compaction runs at the next model-request
 boundary, after all tool results settle.
 
+If summary failure, cancellation, or a limit stops that boundary, settled tool
+results remain in the conversation and survive save/load. Resuming sends those
+results once, without repeating the tool or inventing an assistant response.
+Host changes to the turns or system prompt while a summary is in flight reject
+the stale replacement and preserve the host's edits.
+
 Use a separate policy to authorize summary recovery destinations:
 
 ```{r, eval=FALSE}

--- a/vignettes/runtime-integration.Rmd
+++ b/vignettes/runtime-integration.Rmd
@@ -44,11 +44,45 @@ streamed response or completed tool effect locks the run to its current Chat;
 Deputy preserves the partial result and signals the failure. It never restarts
 a completed tool loop. The selected Chat remains active; subsequent runs can
 advance to later configured templates, without revisiting earlier ones.
-Automatic compaction runs before task dispatch and retains its separate
-`ContextPolicy(fallback = "error" | "text")` policy. Its isolated summary request
-does not select from `fallback_chats`: a summary failure stops preparation by
-default, or uses the explicitly configured deterministic text summary. Governed
-compaction recovery is tracked in [#111](https://github.com/JamesHWade/deputy/issues/111).
+Automatic compaction belongs to the active run. `SessionStart` and
+`UserPromptSubmit` precede `PreCompact`, and `PostCompact` follows an accepted
+summary. Summary failures still produce an inspectable `last_run()` with terminal
+hooks and usage. Between tool rounds, compaction runs at the next model-request
+boundary, after all tool results settle.
+
+Use a separate policy to authorize summary recovery destinations:
+
+```{r, eval=FALSE}
+policy <- ContextPolicy(
+  summary_fallback_chats = list(ellmer::chat("openai/gpt-5.6-luna"))
+)
+agent <- Agent$new(
+  ellmer::chat("openai/gpt-5.6-terra"),
+  context_policy = policy,
+  fallback_chats = list(ellmer::chat("openai/gpt-5.6-sol"))
+)
+```
+
+The primary summary uses an isolated clone of the active Chat. Only a transient
+model transport failure can advance to `summary_fallback_chats`, after ellmer's
+own retries. Summary Chats have no tools, inherited callbacks, or unrelated
+history. Selecting one does not change the task provider. Internal summaries
+are never streamed as task output, and a successful summary does not prevent a
+later task fallback before task output or effects occur.
+
+Every summary dispatch shares the run's request/token/cost budget, including
+failed dispatches. Unknown cost stays unknown and stops a cost-limited run.
+`ContextPolicy(fallback = "text")` permits deterministic degraded recovery when
+summary generation fails and the run can still continue; it is opt-in and emits
+a `Notification` with code `compact_fallback`. Cancellation leaves the active
+context unchanged. A completed summary stays installed if its usage exhausts
+the budget before task execution.
+
+`agent$last_compaction()` reports the method, run ID, usage, and destination
+attempts. Request and fallback events use `phase = "compaction"` for summary
+work. Manual `agent$compact()` keeps its synchronous, active-Chat-only contract.
+Removed turns are not archived by this policy; host-owned history retrieval
+remains a separate integration.
 
 LeadAgent's fallback policy applies to the lead. Child definitions inherit the
 selected provider and do not implicitly gain additional destinations.


### PR DESCRIPTION
Closes #111.

## Summary

Automatic compaction now belongs to the active run: summary requests share its identity, usage limits, cancellation controller, and terminal evidence. A transient summary failure can use explicitly configured `ContextPolicy(summary_fallback_chats = ...)` destinations while keeping task fallback independent. Accepted summaries survive the transition to task execution; internal summary output never becomes task output.

Compaction runs after tool results settle. If summary failure, cancellation, or an exhausted budget stops the next request, the real tool results remain available through save/load/resume without repeating completed effects or inventing an assistant response. Concurrent host edits reject stale replacements. A small public-API accommodation preserves usage and context estimates for unfinished ellmer histories; the producer bug is tracked in tidyverse/ellmer#1131.

Adds an evidence-review fixture and evaluation protocol for comparing cumulative summaries with bounded history retrieval. Follow-up #112 tracks that comparison before an RLM runtime; production history ownership remains with shinychat (#66). Manual `compact()` and opt-in deterministic text recovery keep their existing contracts.

## Verification

Tests run against released ellmer 0.5.0 using deterministic local HTTP responses. Coverage includes summary failure → configured summary recovery → task fallback, shared limits and unknown cost, retries, hooks, cancellation, stale host edits, and saved-session recovery with each completed tool result sent exactly once. Host history replacement preserves usage already accrued by the run.

- Full suite: 3,396 passed, zero failures, six optional skips, and two expected warnings from the existing filesystem-error test.
- `devtools::check(document = FALSE, manual = FALSE)`: zero errors, warnings, and notes.
- Air, Jarl, pkgdown checks and site build: passed.
- Independent standards and spec reviews: no remaining findings after fixing stopped-boundary result retention and accounting across host history replacement.

The fixtures establish runtime behavior; the evaluation protocol does not claim measured long-context model quality.

Example configuration (uses credentials configured for ellmer):

```r
agent <- Agent$new(
  ellmer::chat("openai/gpt-5.6-terra"),
  context_policy = ContextPolicy(
    max_tokens = 50000,
    summary_fallback_chats = list(ellmer::chat("openai/gpt-5.6-luna"))
  ),
  usage_limits = UsageLimits(max_requests = 10)
)
```
