### PR TITLE
Make README and pkgdown guides clear and practical

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,17 +1,14 @@
 Package: deputy
-Title: Governed Agentic Artificial Intelligence Workflows
+Title: Run Tasks with Language Models and R Tools
 Version: 0.0.0.9000
 Authors@R:
     person("James", "Wade", , "github@jameshwade.com", role = c("aut", "cre", "cph"),
            comment = c(ORCID = "0000-0002-9740-1905"))
-Description: Run provider-agnostic, agentic artificial intelligence (AI)
-    workflows with explicit boundaries for tools, permissions, budgets, and
-    filesystem access. Builds on 'ellmer' to provide multi-step reasoning,
-    lifecycle hooks, structured events, human input, session persistence, and
-    delegation. Returns inspectable results and supports synchronous,
-    asynchronous, terminal, and 'Shiny' hosts. Designed for applications that
-    need governance and observability around tool-using language models in
-    'R'.
+Description: Run tasks with language models and R tools using 'ellmer'.
+    Control tool access with permissions, set limits on requests and usage,
+    and inspect responses, tool calls, and the reason each run stopped.
+    Supports streaming output, 'Shiny' applications, saved conversations,
+    file checkpoints, and delegation to other agents.
 URL: https://github.com/JamesHWade/deputy, https://jameshwade.github.io/deputy/
 BugReports: https://github.com/JamesHWade/deputy/issues
 License: MIT + file LICENSE

--- a/R/deputy-package.R
+++ b/R/deputy-package.R
@@ -12,19 +12,11 @@
 NULL
 
 # Package-level documentation
-#' deputy: Agentic AI Workflows for R
-#'
-#' @description
-#' A provider-agnostic framework for building agentic AI workflows in R.
-#' Built on ellmer, it enables multi-step reasoning with tool use,
-#' permissions, hooks, human-in-the-loop capabilities, and multi-agent
-#' delegation.
-#'
 #' @section Main Functions:
 #' * [Agent] - The main class for creating agents
 #' * [LeadAgent] - Coordinate specialized delegated agents
-#' * [tools_preset()] - Curated built-in tool collections
-#' * [UsageLimits()] - Run-scoped request, tool, token, and cost limits
+#' * [tools_preset()] - Choose a set of built-in tools
+#' * [UsageLimits()] - Set request, tool, token, and cost limits
 #' * [permissions_standard()] - Standard permission policy
 #' * [permissions_plan()] - Planning permission policy
 #' * [permissions_readonly()] - Read-only permission policy
@@ -33,19 +25,17 @@ NULL
 #' ```r
 #' library(deputy)
 #'
-#' # Create an agent with file tools
 #' agent <- Agent$new(
 #'   chat = ellmer::chat("openai/gpt-5.6-luna"),
-#'   tools = tools_preset("standard")
+#'   tools = tools_preset("minimal"),
+#'   permissions = permissions_readonly(),
+#'   usage_limits = UsageLimits(max_requests = 6, max_tool_calls = 8),
+#'   working_dir = getwd()
 #' )
 #'
-#' # Run a task with streaming output
-#' events <- agent$run("List files in current directory")
-#' repeat {
-#'   event <- events()
-#'   if (coro::is_exhausted(event)) break
-#'   if (event$type == "text") cat(event$text)
-#' }
+#' result <- agent$run_sync("Read DESCRIPTION and explain what this package does.")
+#' result$response
+#' result$stop_reason
 #' ```
 #'
 #' @name deputy-package

--- a/README.Rmd
+++ b/README.Rmd
@@ -22,191 +22,111 @@ knitr::opts_chunk$set(
 [![Codecov test coverage](https://codecov.io/gh/JamesHWade/deputy/graph/badge.svg)](https://app.codecov.io/gh/JamesHWade/deputy)
 <!-- badges: end -->
 
-Deputy turns an [ellmer](https://ellmer.tidyverse.org/) chat into a governed R
-Agent. Give it tools, a workspace, and explicit limits; get back an observable
-run you can inspect, stream into Shiny, save, or delegate.
+Deputy runs tasks with an [ellmer](https://ellmer.tidyverse.org/) chat and R
+tools. Use it to review source files, analyse data, or extract information,
+with permissions that control tool access and limits on each run.
 
-## Why Deputy?
-
-ellmer gives R a provider-independent chat interface and tools. Deputy adds the
-runtime around that chat when a tool-using conversation becomes a real job:
-
-| Start with ellmer | Add Deputy when you need |
-|---|---|
-| Chats and provider APIs | Explicit tool permissions and run limits |
-| Tool registration | Hooks, semantic events, and inspectable results |
-| Streaming model output | A stable stream for terminals and Shiny hosts |
-| Conversation state | Automatic compaction, persistence, and checkpoints |
-| One tool-using chat | Correlated delegation to specialist Agents |
-
-The core object model stays small:
-
-```text
-ellmer Chat + Tools + Permissions + Limits
-                     |
-                  Deputy Agent
-                     |
-        AgentResult + Events + Checkpoints
-```
-
-Deputy requires released ellmer 0.5.0 or later. Structured output uses ellmer
-types, with bounded application corrections under the same run budget. Explicit
-fallback Chats and OpenTelemetry governance compose with ellmer's provider
-transport and tracing. See [runtime integration](articles/runtime-integration.html)
-and [structured output](articles/structured-output.html).
-
-The Agent itself implements ellmer's Chat protocol. Use `agent$chat()` and
-`agent$stream()` in synchronous code, or pass the Agent directly to
-`shinychat::chat_server()`. Those paths use the same governed kernel as
-`run_sync()` and `run_async()`; the latter pair return richer `AgentResult`
-metadata when the host needs to inspect the run. Product hosts may attach
-per-run correlation with the optional `run_context` argument on every chat,
-stream, and run method.
+ellmer handles the model connection and tool calls. Deputy checks permissions,
+tracks usage, and records why the run stopped. You can inspect the result in R,
+stream it into Shiny, or save the conversation for later.
 
 ## Installation
 
-Before Deputy's first CRAN release, install the development version from
-GitHub:
+Install the development version from GitHub:
 
 ```r
 # install.packages("pak")
 pak::pak("JamesHWade/deputy")
 ```
 
-After the release is available from CRAN, install the released package with:
+Deputy requires ellmer 0.5.0 or later. It is not yet on CRAN.
 
-```r
-install.packages("deputy")
-```
+## Review an R package
 
-For the optional Shiny host, also install shinychat:
-
-```r
-install.packages("shinychat")
-```
-
-## A safe first run
-
-Start with a small, read-only toolset and a bounded run. This setup is
-provider-independent and is executed whenever the README is rendered:
-
-```{r first-policy}
-library(deputy)
-
-workspace <- normalizePath(getwd(), winslash = "/")
-first_tools <- tools_preset("minimal")
-first_permissions <- permissions_readonly()
-first_limits <- UsageLimits(max_requests = 6, max_tool_calls = 8)
-first_context <- ContextPolicy(max_tokens = 32000, fallback = "error")
-
-stopifnot(
-  length(first_tools) == 3L,
-  identical(first_permissions$mode, "readonly"),
-  identical(first_limits$max_requests, 6L)
-)
-```
-
-The examples use `gpt-5.6-luna`, the inexpensive GPT-5.6 model. Choose any
-provider supported by ellmer when creating your own Chat. The model call is
-not executed while building the documentation:
+Run this from an R package directory. Set `OPENAI_API_KEY` before creating the
+chat, or use another [ellmer provider](https://ellmer.tidyverse.org/reference/index.html).
+The example uses the same model as Deputy's terminal app.
 
 ```{r first-agent, eval = FALSE}
-chat <- ellmer::chat("openai/gpt-5.6-luna")
+library(deputy)
 
 agent <- Agent$new(
-  chat = chat,
-  tools = first_tools,
-  permissions = first_permissions,
-  usage_limits = first_limits,
-  context_policy = first_context,
-  working_dir = workspace
+  chat = ellmer::chat("openai/gpt-5.6-luna"),
+  tools = tools_preset("minimal"),
+  permissions = permissions_readonly(),
+  usage_limits = UsageLimits(max_requests = 6, max_tool_calls = 8),
+  working_dir = getwd()
 )
 
 result <- agent$run_sync(
-  "Explain what this R package does. Support the answer with file paths."
+  "Read DESCRIPTION and list R/. Explain what this package does and cite the files you used."
 )
+
+result$response
+result$stop_reason
 ```
 
-Set `OPENAI_API_KEY` for these examples. To use a larger GPT-5.6 model, replace
-`gpt-5.6-luna` with `gpt-5.6-terra` (balanced) or `gpt-5.6-sol` (flagship).
-Use the explicit tier name: `gpt-5.6` is an alias for Sol. See OpenAI's
-[model guide](https://developers.openai.com/api/docs/guides/latest-model?model=gpt-5.6)
-for the tier tradeoffs. Deputy preserves the model and parameters of the Chat
-you supply, including when it creates inherited child Chats.
+The agent can read files and list directories. It cannot write files or run R
+or shell code. `working_dir` sets the base for relative paths; reads can still
+reach other files accessible to your R process.
 
-`run_sync()` returns an `AgentResult`, not just text:
+`run_sync()` waits for the run to finish and returns an `AgentResult`.
+A `stop_reason` of `"complete"` means the agent finished; a limit or error may
+leave a partial response. Inspect the work behind the answer with:
 
 ```{r inspect-result, eval = FALSE}
-cat(result$response)
-result$stop_reason
 result$usage
 result$tool_calls()
 result$tool_results()
 ```
 
-Read [Getting Started](https://jameshwade.github.io/deputy/articles/getting-started.html)
-to turn on a workspace-scoped write permission deliberately, create a file
-checkpoint, and recover from common failures.
+The [getting-started guide](https://jameshwade.github.io/deputy/articles/getting-started.html)
+explains these settings, shows how to allow file writes, and covers common
+errors.
 
-## The safety boundary
+## Work with familiar R tools
 
-Deputy enforces application-level policy at tool boundaries. It does not turn
-model-generated code into untrusted code you can execute safely:
+- Define a tool from an R function with `ellmer::tool()`. Deputy uses ellmer's
+  argument types and tool annotations. See [Tools](https://jameshwade.github.io/deputy/articles/tools.html).
+- Extract lists and data frames with ellmer's `type_object()` and
+  `type_array()`. See [Structured output](https://jameshwade.github.io/deputy/articles/structured-output.html).
+- Report tool activity with `hook_log_tools()`, or write a hook that uses
+  `cli::cli_inform()`. See [Hooks](https://jameshwade.github.io/deputy/articles/hooks.html).
+- Pass an Agent to `shinychat::chat_server()` to build a chat app. See
+  [Shiny chat](https://jameshwade.github.io/deputy/articles/example-shiny-chat.html).
 
-- `permissions_readonly()` denies Deputy's write, shell, R execution, web, and
-  package-install capabilities.
-- `permissions_standard()` permits accessible reads and workspace-scoped native
-  file writes, but denies arbitrary R and shell execution by default.
-- A directory-valued `file_write` permission confines Deputy's native file
-  writes to that canonical root. File reads remain limited by the R process,
-  not by an operating-system sandbox.
-- `run_r_code` uses a separate R process; that process separation is not an OS
-  security sandbox. `run_bash` executes with the current user's privileges.
-- File checkpoints cover Deputy's native write, edit, and multi-edit tools.
-  They are recovery machinery, not a substitute for version control or backups.
+## Choose a guide
 
-Start read-only, grant the narrowest capability that completes the job, and use
-a real isolation boundary for untrusted code. `tools_mcp_repl()` loads an
-explicitly configured [mcp-repl](https://github.com/posit-dev/mcp-repl) R
-session only after verifying that its `read-only` or `workspace-write` OS
-sandbox matches the requested policy; a missing or weaker policy is an error.
-
-## Choose your path
-
-| Goal | Read next |
+| Task | Guide |
 |---|---|
-| Understand tools and presets | [Tools](https://jameshwade.github.io/deputy/articles/tools.html) |
-| Design a least-authority policy | [Permissions and Safety](https://jameshwade.github.io/deputy/articles/permissions.html) |
-| Observe or intervene in a run | [Hooks](https://jameshwade.github.io/deputy/articles/hooks.html) |
-| Embed an Agent in an app | [Shiny Chat](https://jameshwade.github.io/deputy/articles/example-shiny-chat.html) |
-| Delegate to specialist Agents | [Multi-Agent Orchestration](https://jameshwade.github.io/deputy/articles/multi-agent.html) |
-| Build a concrete workflow | [Recipes](https://jameshwade.github.io/deputy/articles/example-data-analysis.html) |
+| Choose which files and tools an agent can use | [Permissions](https://jameshwade.github.io/deputy/articles/permissions.html) |
+| Explore a dataset with R | [Data analysis](https://jameshwade.github.io/deputy/articles/example-data-analysis.html) |
+| Pass structured results between steps | [Extraction pipeline](https://jameshwade.github.io/deputy/articles/example-extraction-pipeline.html) |
+| Assign parts of a task to separate agents | [Multiple agents](https://jameshwade.github.io/deputy/articles/multi-agent.html) |
+| Configure fallback models, context limits, or tracing | [Runtime integration](https://jameshwade.github.io/deputy/articles/runtime-integration.html) |
 
-## Terminal use
+## Run from a terminal
 
-Deputy also ships a [Rapp](https://github.com/r-lib/Rapp) package executable.
-Run it without a global Deputy installation, or install a persistent launcher:
+Deputy includes a command-line app built with [Rapp](https://github.com/r-lib/Rapp).
+Use [ir](https://github.com/r-lib/ir) to run it or install a launcher:
 
 ```bash
 uv tool install r-lib-ir
 rx --from github::JamesHWade/deputy deputy --help
-rx --from github::JamesHWade/deputy deputy \
-  --provider openai "Summarize the R files in this project"
+rx --from github::JamesHWade/deputy deputy --tools minimal \
+  "Summarize the R files in this project"
 
 ir tool install github::JamesHWade/deputy
 deputy --tools minimal
-deputy --model gpt-5.6-terra --tools minimal
 ```
 
-The CLI defaults to OpenAI with `gpt-5.6-luna`. Use `--model` to select another
-model or `--provider` to select another provider, such as `--provider anthropic`.
-Other providers retain their own model defaults when `--model` is omitted.
+The CLI defaults to OpenAI with `gpt-5.6-luna`. Use `--model` to choose a model
+or `--provider` to choose a provider, such as `--provider anthropic`.
 
 ## Status
 
-Deputy is experimental. Its contracts are being sharpened through real package,
-CLI, and Shiny integrations. Please report problems and design gaps in
-[GitHub Issues](https://github.com/JamesHWade/deputy/issues).
+Deputy is experimental: its API may change. Report bugs or suggest improvements
+in [GitHub Issues](https://github.com/JamesHWade/deputy/issues).
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -13,203 +13,122 @@ experimental](https://img.shields.io/badge/lifecycle-experimental-orange.svg)](h
 coverage](https://codecov.io/gh/JamesHWade/deputy/graph/badge.svg)](https://app.codecov.io/gh/JamesHWade/deputy)
 <!-- badges: end -->
 
-Deputy turns an [ellmer](https://ellmer.tidyverse.org/) chat into a
-governed R Agent. Give it tools, a workspace, and explicit limits; get
-back an observable run you can inspect, stream into Shiny, save, or
-delegate.
+Deputy runs tasks with an [ellmer](https://ellmer.tidyverse.org/) chat
+and R tools. Use it to review source files, analyse data, or extract
+information, with permissions that control tool access and limits on
+each run.
 
-## Why Deputy?
-
-ellmer gives R a provider-independent chat interface and tools. Deputy
-adds the runtime around that chat when a tool-using conversation becomes
-a real job:
-
-| Start with ellmer | Add Deputy when you need |
-|----|----|
-| Chats and provider APIs | Explicit tool permissions and run limits |
-| Tool registration | Hooks, semantic events, and inspectable results |
-| Streaming model output | A stable stream for terminals and Shiny hosts |
-| Conversation state | Automatic compaction, persistence, and checkpoints |
-| One tool-using chat | Correlated delegation to specialist Agents |
-
-The core object model stays small:
-
-``` text
-ellmer Chat + Tools + Permissions + Limits
-                     |
-                  Deputy Agent
-                     |
-        AgentResult + Events + Checkpoints
-```
-
-Deputy requires released ellmer 0.5.0 or later. Structured output uses
-ellmer types, with bounded application corrections under the same run
-budget. Explicit fallback Chats and OpenTelemetry governance compose
-with ellmer’s provider transport and tracing. See [runtime
-integration](articles/runtime-integration.html) and [structured
-output](articles/structured-output.html).
-
-The Agent itself implements ellmer’s Chat protocol. Use `agent$chat()`
-and `agent$stream()` in synchronous code, or pass the Agent directly to
-`shinychat::chat_server()`. Those paths use the same governed kernel as
-`run_sync()` and `run_async()`; the latter pair return richer
-`AgentResult` metadata when the host needs to inspect the run. Product
-hosts may attach per-run correlation with the optional `run_context`
-argument on every chat, stream, and run method.
+ellmer handles the model connection and tool calls. Deputy checks
+permissions, tracks usage, and records why the run stopped. You can
+inspect the result in R, stream it into Shiny, or save the conversation
+for later.
 
 ## Installation
 
-Before Deputy’s first CRAN release, install the development version from
-GitHub:
+Install the development version from GitHub:
 
 ``` r
 # install.packages("pak")
 pak::pak("JamesHWade/deputy")
 ```
 
-After the release is available from CRAN, install the released package
-with:
+Deputy requires ellmer 0.5.0 or later. It is not yet on CRAN.
 
-``` r
-install.packages("deputy")
-```
+## Review an R package
 
-For the optional Shiny host, also install shinychat:
-
-``` r
-install.packages("shinychat")
-```
-
-## A safe first run
-
-Start with a small, read-only toolset and a bounded run. This setup is
-provider-independent and is executed whenever the README is rendered:
+Run this from an R package directory. Set `OPENAI_API_KEY` before
+creating the chat, or use another [ellmer
+provider](https://ellmer.tidyverse.org/reference/index.html). The
+example uses the same model as Deputy’s terminal app.
 
 ``` r
 library(deputy)
 
-workspace <- normalizePath(getwd(), winslash = "/")
-first_tools <- tools_preset("minimal")
-first_permissions <- permissions_readonly()
-first_limits <- UsageLimits(max_requests = 6, max_tool_calls = 8)
-first_context <- ContextPolicy(max_tokens = 32000, fallback = "error")
-
-stopifnot(
-  length(first_tools) == 3L,
-  identical(first_permissions$mode, "readonly"),
-  identical(first_limits$max_requests, 6L)
-)
-```
-
-The examples use `gpt-5.6-luna`, the inexpensive GPT-5.6 model. Choose
-any provider supported by ellmer when creating your own Chat. The model
-call is not executed while building the documentation:
-
-``` r
-chat <- ellmer::chat("openai/gpt-5.6-luna")
-
 agent <- Agent$new(
-  chat = chat,
-  tools = first_tools,
-  permissions = first_permissions,
-  usage_limits = first_limits,
-  context_policy = first_context,
-  working_dir = workspace
+  chat = ellmer::chat("openai/gpt-5.6-luna"),
+  tools = tools_preset("minimal"),
+  permissions = permissions_readonly(),
+  usage_limits = UsageLimits(max_requests = 6, max_tool_calls = 8),
+  working_dir = getwd()
 )
 
 result <- agent$run_sync(
-  "Explain what this R package does. Support the answer with file paths."
+  "Read DESCRIPTION and list R/. Explain what this package does and cite the files you used."
 )
+
+result$response
+result$stop_reason
 ```
 
-Set `OPENAI_API_KEY` for these examples. To use a larger GPT-5.6 model,
-replace `gpt-5.6-luna` with `gpt-5.6-terra` (balanced) or `gpt-5.6-sol`
-(flagship). Use the explicit tier name: `gpt-5.6` is an alias for Sol.
-See OpenAI’s [model
-guide](https://developers.openai.com/api/docs/guides/latest-model?model=gpt-5.6)
-for the tier tradeoffs. Deputy preserves the model and parameters of the
-Chat you supply, including when it creates inherited child Chats.
+The agent can read files and list directories. It cannot write files or
+run R or shell code. `working_dir` sets the base for relative paths;
+reads can still reach other files accessible to your R process.
 
-`run_sync()` returns an `AgentResult`, not just text:
+`run_sync()` waits for the run to finish and returns an `AgentResult`. A
+`stop_reason` of `"complete"` means the agent finished; a limit or error
+may leave a partial response. Inspect the work behind the answer with:
 
 ``` r
-cat(result$response)
-result$stop_reason
 result$usage
 result$tool_calls()
 result$tool_results()
 ```
 
-Read [Getting
-Started](https://jameshwade.github.io/deputy/articles/getting-started.html)
-to turn on a workspace-scoped write permission deliberately, create a
-file checkpoint, and recover from common failures.
+The [getting-started
+guide](https://jameshwade.github.io/deputy/articles/getting-started.html)
+explains these settings, shows how to allow file writes, and covers
+common errors.
 
-## The safety boundary
+## Work with familiar R tools
 
-Deputy enforces application-level policy at tool boundaries. It does not
-turn model-generated code into untrusted code you can execute safely:
+- Define a tool from an R function with `ellmer::tool()`. Deputy uses
+  ellmer’s argument types and tool annotations. See
+  [Tools](https://jameshwade.github.io/deputy/articles/tools.html).
+- Extract lists and data frames with ellmer’s `type_object()` and
+  `type_array()`. See [Structured
+  output](https://jameshwade.github.io/deputy/articles/structured-output.html).
+- Report tool activity with `hook_log_tools()`, or write a hook that
+  uses `cli::cli_inform()`. See
+  [Hooks](https://jameshwade.github.io/deputy/articles/hooks.html).
+- Pass an Agent to `shinychat::chat_server()` to build a chat app. See
+  [Shiny
+  chat](https://jameshwade.github.io/deputy/articles/example-shiny-chat.html).
 
-- `permissions_readonly()` denies Deputy’s write, shell, R execution,
-  web, and package-install capabilities.
-- `permissions_standard()` permits accessible reads and workspace-scoped
-  native file writes, but denies arbitrary R and shell execution by
-  default.
-- A directory-valued `file_write` permission confines Deputy’s native
-  file writes to that canonical root. File reads remain limited by the R
-  process, not by an operating-system sandbox.
-- `run_r_code` uses a separate R process; that process separation is not
-  an OS security sandbox. `run_bash` executes with the current user’s
-  privileges.
-- File checkpoints cover Deputy’s native write, edit, and multi-edit
-  tools. They are recovery machinery, not a substitute for version
-  control or backups.
+## Choose a guide
 
-Start read-only, grant the narrowest capability that completes the job,
-and use a real isolation boundary for untrusted code. `tools_mcp_repl()`
-loads an explicitly configured
-[mcp-repl](https://github.com/posit-dev/mcp-repl) R session only after
-verifying that its `read-only` or `workspace-write` OS sandbox matches
-the requested policy; a missing or weaker policy is an error.
-
-## Choose your path
-
-| Goal | Read next |
+| Task | Guide |
 |----|----|
-| Understand tools and presets | [Tools](https://jameshwade.github.io/deputy/articles/tools.html) |
-| Design a least-authority policy | [Permissions and Safety](https://jameshwade.github.io/deputy/articles/permissions.html) |
-| Observe or intervene in a run | [Hooks](https://jameshwade.github.io/deputy/articles/hooks.html) |
-| Embed an Agent in an app | [Shiny Chat](https://jameshwade.github.io/deputy/articles/example-shiny-chat.html) |
-| Delegate to specialist Agents | [Multi-Agent Orchestration](https://jameshwade.github.io/deputy/articles/multi-agent.html) |
-| Build a concrete workflow | [Recipes](https://jameshwade.github.io/deputy/articles/example-data-analysis.html) |
+| Choose which files and tools an agent can use | [Permissions](https://jameshwade.github.io/deputy/articles/permissions.html) |
+| Explore a dataset with R | [Data analysis](https://jameshwade.github.io/deputy/articles/example-data-analysis.html) |
+| Pass structured results between steps | [Extraction pipeline](https://jameshwade.github.io/deputy/articles/example-extraction-pipeline.html) |
+| Assign parts of a task to separate agents | [Multiple agents](https://jameshwade.github.io/deputy/articles/multi-agent.html) |
+| Configure fallback models, context limits, or tracing | [Runtime integration](https://jameshwade.github.io/deputy/articles/runtime-integration.html) |
 
-## Terminal use
+## Run from a terminal
 
-Deputy also ships a [Rapp](https://github.com/r-lib/Rapp) package
-executable. Run it without a global Deputy installation, or install a
-persistent launcher:
+Deputy includes a command-line app built with
+[Rapp](https://github.com/r-lib/Rapp). Use
+[ir](https://github.com/r-lib/ir) to run it or install a launcher:
 
 ``` bash
 uv tool install r-lib-ir
 rx --from github::JamesHWade/deputy deputy --help
-rx --from github::JamesHWade/deputy deputy \
-  --provider openai "Summarize the R files in this project"
+rx --from github::JamesHWade/deputy deputy --tools minimal \
+  "Summarize the R files in this project"
 
 ir tool install github::JamesHWade/deputy
 deputy --tools minimal
-deputy --model gpt-5.6-terra --tools minimal
 ```
 
-The CLI defaults to OpenAI with `gpt-5.6-luna`. Use `--model` to select
-another model or `--provider` to select another provider, such as
-`--provider anthropic`. Other providers retain their own model defaults
-when `--model` is omitted.
+The CLI defaults to OpenAI with `gpt-5.6-luna`. Use `--model` to choose
+a model or `--provider` to choose a provider, such as
+`--provider anthropic`.
 
 ## Status
 
-Deputy is experimental. Its contracts are being sharpened through real
-package, CLI, and Shiny integrations. Please report problems and design
-gaps in [GitHub Issues](https://github.com/JamesHWade/deputy/issues).
+Deputy is experimental: its API may change. Report bugs or suggest
+improvements in [GitHub
+Issues](https://github.com/JamesHWade/deputy/issues).
 
 ## License
 

--- a/_pkgdown.yml
+++ b/_pkgdown.yml
@@ -6,17 +6,16 @@ template:
 
 navbar:
   structure:
-    left: [intro, reference, articles]
+    left: [intro, articles, reference]
     right: [search, github]
   components:
+    intro:
+      text: Get started
+      href: articles/getting-started.html
     articles:
       text: Articles
       menu:
-      - text: "Intro"
-      - text: Getting Started
-        href: articles/getting-started.html
-      - text: "---"
-      - text: "Concepts"
+      - text: "Guides"
       - text: Tools and Tool Bundles
         href: articles/tools.html
       - text: Permissions and Safety
@@ -24,7 +23,7 @@ navbar:
       - text: Hooks
         href: articles/hooks.html
       - text: "---"
-      - text: "Hosts"
+      - text: "Apps"
       - text: Shiny Chat
         href: articles/example-shiny-chat.html
       - text: "---"
@@ -47,7 +46,7 @@ navbar:
 reference:
 - title: Agent
 
-  desc: Core agent class for agentic AI workflows
+  desc: Run a task and inspect its response, tool calls, and usage.
   contents:
   - Agent
   - AgentResult
@@ -111,7 +110,7 @@ reference:
   - hook_limit_file_writes
 
 - title: Skills
-  desc: Extend agents with specialized capabilities
+  desc: Load reusable instructions for an agent.
   contents:
   - Skill
   - skill_load
@@ -127,7 +126,7 @@ reference:
   - agent_definition_read
 
 - title: Errors
-  desc: Identify structured Deputy conditions
+  desc: Catch errors by class and inspect their details.
   contents:
   - deputy-errors
   - is_deputy_error
@@ -137,12 +136,12 @@ articles:
   navbar: ~
   contents:
   - getting-started
-- title: Concepts
+- title: Guides
   contents:
   - tools
   - permissions
   - hooks
-- title: Hosts
+- title: Apps
   contents:
   - example-shiny-chat
 - title: Advanced

--- a/man/deputy-package.Rd
+++ b/man/deputy-package.Rd
@@ -4,24 +4,19 @@
 \name{deputy-package}
 \alias{deputy-package}
 \alias{deputy}
-\title{deputy: Governed Agentic Artificial Intelligence Workflows}
+\title{deputy: Run Tasks with Language Models and R Tools}
 \description{
 \if{html}{\figure{logo.svg}{options: style='float: right' alt='logo' width='120'}}
 
-Run provider-agnostic, agentic artificial intelligence (AI) workflows with explicit boundaries for tools, permissions, budgets, and filesystem access. Builds on 'ellmer' to provide multi-step reasoning, lifecycle hooks, structured events, human input, session persistence, and delegation. Returns inspectable results and supports synchronous, asynchronous, terminal, and 'Shiny' hosts. Designed for applications that need governance and observability around tool-using language models in 'R'.
-
-A provider-agnostic framework for building agentic AI workflows in R.
-Built on ellmer, it enables multi-step reasoning with tool use,
-permissions, hooks, human-in-the-loop capabilities, and multi-agent
-delegation.
+Run tasks with language models and R tools using 'ellmer'. Control tool access with permissions, set limits on requests and usage, and inspect responses, tool calls, and the reason each run stopped. Supports streaming output, 'Shiny' applications, saved conversations, file checkpoints, and delegation to other agents.
 }
 \section{Main Functions}{
 
 \itemize{
 \item \link{Agent} - The main class for creating agents
 \item \link{LeadAgent} - Coordinate specialized delegated agents
-\item \code{\link[=tools_preset]{tools_preset()}} - Curated built-in tool collections
-\item \code{\link[=UsageLimits]{UsageLimits()}} - Run-scoped request, tool, token, and cost limits
+\item \code{\link[=tools_preset]{tools_preset()}} - Choose a set of built-in tools
+\item \code{\link[=UsageLimits]{UsageLimits()}} - Set request, tool, token, and cost limits
 \item \code{\link[=permissions_standard]{permissions_standard()}} - Standard permission policy
 \item \code{\link[=permissions_plan]{permissions_plan()}} - Planning permission policy
 \item \code{\link[=permissions_readonly]{permissions_readonly()}} - Read-only permission policy
@@ -33,19 +28,17 @@ delegation.
 
 \if{html}{\out{<div class="sourceCode r">}}\preformatted{library(deputy)
 
-# Create an agent with file tools
 agent <- Agent$new(
   chat = ellmer::chat("openai/gpt-5.6-luna"),
-  tools = tools_preset("standard")
+  tools = tools_preset("minimal"),
+  permissions = permissions_readonly(),
+  usage_limits = UsageLimits(max_requests = 6, max_tool_calls = 8),
+  working_dir = getwd()
 )
 
-# Run a task with streaming output
-events <- agent$run("List files in current directory")
-repeat \{
-  event <- events()
-  if (coro::is_exhausted(event)) break
-  if (event$type == "text") cat(event$text)
-\}
+result <- agent$run_sync("Read DESCRIPTION and explain what this package does.")
+result$response
+result$stop_reason
 }\if{html}{\out{</div>}}
 }
 

--- a/vignettes/example-code-review.Rmd
+++ b/vignettes/example-code-review.Rmd
@@ -15,25 +15,10 @@ knitr::opts_chunk$set(
 )
 ```
 
-This example builds a code review system using multiple specialised agents
-coordinated by a lead agent. Each reviewer focuses on a different aspect
-of code quality, and the lead synthesises their findings into a structured
-report.
-
-This follows the **Orchestrator-Workers** pattern: a lead agent delegates
-to specialised sub-agents, each with their own expertise and tools.
-
-## When to Use Multi-Agent
-
-Multi-agent orchestration works well when:
-
-- Different aspects of a task need different expertise
-- Sub-tasks benefit from isolated system prompts
-- You want per-agent audit trails and cost tracking
-- A single "do everything" prompt would be too broad
-
-For simpler tasks, a single agent is usually enough. For sequential
-pipelines, see `vignette("example-extraction-pipeline")`.
+This example assigns separate reviewers to bugs, code style, and documentation
+in an R package. A lead agent combines their findings into a report. Each
+reviewer has its own prompt and conversation, so you can inspect its results
+separately.
 
 ## Define the Reviewer Agents
 

--- a/vignettes/example-data-analysis.Rmd
+++ b/vignettes/example-data-analysis.Rmd
@@ -15,26 +15,14 @@ knitr::opts_chunk$set(
 )
 ```
 
-This example builds an autonomous agent that performs exploratory data analysis
-on a dataset. The agent decides what to investigate, writes and runs R code in
-an explicitly trusted local subprocess, and iterates until it understands the
-data. For untrusted inputs or prompts, replace `tools_code()` with an mcp-repl
-tool loaded by `tools_mcp_repl()`.
+This example asks an agent to explore a dataset, run R calculations, and
+report what it finds. The agent chooses its next calculation from the results
+of earlier ones. For a fixed sequence of steps, see the
+[extraction pipeline](example-extraction-pipeline.html).
 
-This follows the **Autonomous Agent** pattern: a single agent with tools,
-given a goal and left to iterate through analysis steps on its own.
-
-## When to Use an Autonomous Agent
-
-An autonomous agent works well when:
-
-- The task is open-ended (you don't know the exact steps in advance)
-- The agent needs to react to intermediate results (e.g., spotting outliers
-  and then investigating them)
-- You want the LLM to drive the analysis methodology
-
-For tasks with a fixed sequence of steps, consider prompt chaining instead
-(see `vignette("example-extraction-pipeline")`).
+The example permits R code to run in a separate process with your user
+account's access. For untrusted inputs or prompts, use an OS sandbox such as
+mcp-repl through `tools_mcp_repl()`.
 
 ## Setup
 

--- a/vignettes/example-extraction-pipeline.Rmd
+++ b/vignettes/example-extraction-pipeline.Rmd
@@ -19,20 +19,9 @@ This example builds a pipeline that extracts structured metadata from an R
 package's source files. Each step is a separate agent call, with the output
 of one step feeding into the next.
 
-This follows the **Prompt Chaining** pattern: sequential agents where each
-step has a focused task and produces structured output for the next.
-
-## When to Use Prompt Chaining
-
-Prompt chaining works well when:
-
-- The task has distinct phases (extract, transform, report)
-- Each phase benefits from a different system prompt or focus
-- You need validated structured data between steps
-- A single monolithic prompt would be too complex or unreliable
-
-For open-ended exploration, an autonomous agent is better
-(see `vignette("example-data-analysis")`).
+Use separate steps when you need to inspect or validate an intermediate
+result before continuing. Here, you can review the extracted metadata before
+asking for categories and a report.
 
 ## The Pipeline
 
@@ -42,7 +31,8 @@ Our pipeline has three steps:
 2. **Enrich** -- Categorise and annotate the extracted metadata
 3. **Report** -- Produce a human-readable summary
 
-Each step supplies an ellmer `type` to extract a structured result after its tool work.
+The first two steps use ellmer types for structured results. The final step
+returns a report as text.
 
 ## Step 1: Extract Package Metadata
 
@@ -108,8 +98,9 @@ step1 <- extractor$run_sync(
   type = ellmer::type_from_schema(jsonlite::toJSON(extract_schema, auto_unbox = TRUE))
 )
 
-# Validate the output before proceeding
-stopifnot(step1$is_success())
+if (!step1$is_success()) {
+  cli::cli_abort("Extraction stopped early: {step1$stop_reason}.")
+}
 
 pkg_metadata <- step1$structured_output
 pkg_metadata$name
@@ -183,7 +174,9 @@ step2 <- enricher$run_sync(
   type = ellmer::type_from_schema(jsonlite::toJSON(enrich_schema, auto_unbox = TRUE))
 )
 
-stopifnot(step2$is_success())
+if (!step2$is_success()) {
+  cli::cli_abort("Enrichment stopped early: {step2$stop_reason}.")
+}
 enriched <- step2$structured_output
 enriched$category_tags
 enriched$complexity
@@ -237,7 +230,7 @@ extraction_pipeline <- function(package_dir = ".") {
   )
 
   if (!step1$is_success()) {
-    stop("Extraction failed: ", step1$stop_reason)
+    cli::cli_abort("Extraction stopped early: {step1$stop_reason}.")
   }
 
   # Step 2: Enrich
@@ -260,7 +253,7 @@ extraction_pipeline <- function(package_dir = ".") {
   )
 
   if (!step2$is_success()) {
-    stop("Enrichment failed: ", step2$stop_reason)
+    cli::cli_abort("Enrichment stopped early: {step2$stop_reason}.")
   }
 
   # Step 3: Report

--- a/vignettes/example-shiny-chat.Rmd
+++ b/vignettes/example-shiny-chat.Rmd
@@ -17,11 +17,11 @@ knitr::opts_chunk$set(
 
 Deputy Agents implement the ellmer chat methods used by
 [shinychat](https://posit-dev.github.io/shinychat/). Pass an Agent directly to
-`chat_server()`; there is no separate Shiny bridge and no path that bypasses
-Deputy's governance.
+`chat_server()` to stream responses and tool activity while Deputy checks
+permissions and tracks usage.
 
 ```text
-shinychat input -> Agent$stream_async() -> one governed run kernel -> ellmer
+shinychat input -> Agent$stream_async() -> ellmer
                                       \-> AgentResult + hooks + usage
 ```
 
@@ -50,7 +50,7 @@ server <- function(input, output, session) {
 
   agent <- Agent$new(
     chat = chat,
-    tools = c(tools_file(), tools_data()),
+    tools = tools_data(),
     permissions = permissions_readonly(),
     usage_limits = UsageLimits(
       max_requests = 10,
@@ -72,11 +72,11 @@ shinyApp(ui, server)
 
 `chat_server()` passes both plain text and attachment-enabled ellmer content to
 the Agent unchanged. It also supplies shinychat history and cancellation around
-Deputy's governed stream.
+Deputy's stream.
 
 ## What the Agent Adds
 
-Every public chat and run method uses the same kernel:
+Choose a method by the result your application needs:
 
 | Method | Native return | Typical host |
 |---|---|---|

--- a/vignettes/getting-started.Rmd
+++ b/vignettes/getting-started.Rmd
@@ -63,8 +63,9 @@ Each setting has one job:
   requests.
 - `usage_limits` stops the run after at most six model requests or eight tool
   calls.
-- `working_dir` sets the base for relative file paths. Replace `getwd()` with
-  your package's path if it is elsewhere.
+- `working_dir = workspace` sets the base for relative file paths. To inspect
+  a package elsewhere, replace `getwd()` in the `workspace <- normalizePath(...)`
+  line with that package's path.
 
 The read-only policy still allows access to files outside `working_dir` when
 the R process can read them. It is not a filesystem sandbox.

--- a/vignettes/getting-started.Rmd
+++ b/vignettes/getting-started.Rmd
@@ -14,250 +14,175 @@ knitr::opts_chunk$set(
 )
 ```
 
-Deputy turns an ellmer chat into a governed R Agent. In this guide you will
-create a bounded, read-only Agent; inspect its result; then deliberately grant
-one workspace-scoped write capability and protect it with a checkpoint.
+This guide uses Deputy to explain an R package from its source files. You will
+run a task, inspect the answer and tool calls, then create an agent that can
+write a summary file.
 
-## Before you begin
+## Install and connect
 
-Before Deputy's first CRAN release, install the development version from
-GitHub:
+Install Deputy from GitHub:
 
 ```r
 # install.packages("pak")
 pak::pak("JamesHWade/deputy")
 ```
 
-After the release is available from CRAN, install the released package with:
+You need credentials for an [ellmer provider](https://ellmer.tidyverse.org/reference/index.html).
+These examples use OpenAI with `gpt-5.6-luna`. Set `OPENAI_API_KEY` in your R
+environment before running them. You can edit your user `.Renviron` file with
+[`usethis::edit_r_environ()`](https://usethis.r-lib.org/reference/edit.html) if you have usethis installed; restart R after
+saving it. Keep credentials out of scripts and version control.
 
-```r
-install.packages("deputy")
-```
+Use another ellmer chat constructor if you prefer a different provider. Deputy
+keeps the model and parameters of the chat you supply.
 
-You also need credentials for one
-[ellmer provider](https://ellmer.tidyverse.org/reference/index.html). The
-examples use OpenAI's `gpt-5.6-luna` with `OPENAI_API_KEY`, but the Deputy API is
-provider-independent. To use a larger GPT-5.6 model, select `gpt-5.6-terra` or
-`gpt-5.6-sol` explicitly when creating the Chat. The `gpt-5.6` alias selects Sol.
+## Create an agent
 
-## 1. Define the workspace and limits
-
-Make the authority for the first run visible before creating a chat. The
-`minimal` preset contains only `read_file`, `read_markdown`, and `list_files`.
-The permission policy denies writes, code execution, shell commands, web
-requests, and package installation. The run also has finite request and
-tool-call budgets.
-
-```{r first-policy}
-library(deputy)
-
-workspace <- normalizePath(getwd(), winslash = "/")
-first_tools <- tools_preset("minimal")
-first_permissions <- permissions_readonly()
-first_limits <- UsageLimits(max_requests = 6, max_tool_calls = 8)
-
-stopifnot(
-  dir.exists(workspace),
-  length(first_tools) == 3L,
-  identical(first_permissions$mode, "readonly"),
-  identical(first_limits$max_tool_calls, 8L)
-)
-```
-
-Run this from the package you want to inspect, or replace `getwd()` with that
-package's absolute path.
-
-`working_dir` gives relative paths a stable base. It does not create a read
-sandbox: a read permission can reach files that the R process can reach. Keep
-the task narrow and run Deputy with operating-system isolation when the input
-or generated code is untrusted.
-
-## 2. Create the Agent
-
-An `Agent` combines an ellmer chat with the runtime policy you just defined.
-This chunk makes a provider request, so it is displayed but not run while the
-vignette is built.
+Open an R session in the package you want to inspect, then run:
 
 ```{r first-agent, eval = FALSE}
-chat <- ellmer::chat("openai/gpt-5.6-luna")
+library(deputy)
+
+workspace <- normalizePath(getwd(), winslash = "/", mustWork = TRUE)
 
 agent <- Agent$new(
-  chat = chat,
-  tools = first_tools,
-  permissions = first_permissions,
-  usage_limits = first_limits,
-  working_dir = workspace,
-  agent_name = "package-scout"
+  chat = ellmer::chat("openai/gpt-5.6-luna"),
+  tools = tools_preset("minimal"),
+  permissions = permissions_readonly(),
+  usage_limits = UsageLimits(max_requests = 6, max_tool_calls = 8),
+  working_dir = workspace
 )
 ```
 
-The chat owns provider interaction. Deputy owns the tool loop around it:
-permissions, hooks, limits, events, persistence, checkpoints, and delegation.
+Each setting has one job:
 
-## 3. Run one useful task
+- `chat` connects to the model through ellmer.
+- `tools` gives the model three tools: `read_file`, `read_markdown`, and
+  `list_files`.
+- `permissions` allows those reads and denies writes, code execution, and web
+  requests.
+- `usage_limits` stops the run after at most six model requests or eight tool
+  calls.
+- `working_dir` sets the base for relative file paths. Replace `getwd()` with
+  your package's path if it is elsewhere.
 
-Ask for an answer that the available tools can support. A read-only package
-inspection is a better first task than an open-ended request to “improve the
-code.”
+The read-only policy still allows access to files outside `working_dir` when
+the R process can read them. It is not a filesystem sandbox.
+
+## Run a task
+
+Ask for an answer that the available files can support:
 
 ```{r first-run, eval = FALSE}
 result <- agent$run_sync(
-  paste(
-    "Read DESCRIPTION and list the R/ directory.",
-    "Explain the package purpose and identify three good entry-point files.",
-    "Cite the paths you used. Do not propose or make edits."
-  ),
-  run_context = list(stage = "package-review")
+  "Read DESCRIPTION and list R/. Explain what this package does and cite the files you used."
 )
+
+result$response
 ```
 
-`run_sync()` blocks until the run stops and returns an `AgentResult`. The result
-keeps the outcome and the evidence needed to understand how it happened:
+`run_sync()` waits until the run stops, then returns an `AgentResult`.
+The answer depends on the package and model. Check whether it finished before
+using the response:
 
 ```{r inspect-result, eval = FALSE}
-cat(result$response)
-
 result$stop_reason
 result$usage
-result$session_id
-result$run_id
+```
+
+`"complete"` means the task finished. Other reasons include `"request_limit"`
+and `"tool_call_limit"`. A stopped run can still have a partial response.
+`result$usage` reports requests, tokens, and any cost reported by the provider.
+
+Inspect the tool calls to see which files the agent used:
+
+```{r inspect-tools, eval = FALSE}
 result$tool_calls()
 result$tool_results()
 ```
 
-Check `stop_reason` before treating the response as complete. A request,
-tool-call, token, or cost limit produces a typed stop reason rather than a
-silently truncated success. `"tool_loop"` means the model requested the same
-tool with the same arguments and received the same result three times
-consecutively; changing results count as progress. If a cost limit is set but
-the provider omits any cost record, Deputy stops with
-`"cost_unavailable"`; it never presents a known lower bound as the total.
+The [AgentResult reference](../reference/AgentResult.html) describes the other
+fields, including events and run identifiers.
 
-## 4. Grant writes deliberately
+## Show progress in the console
 
-When a task really needs to create a file, replace the read-only policy with an
-explicit one. This policy permits Deputy's native file tools to write only
-inside the canonical workspace. R execution, shell access, web access, and
-package installation remain off.
+Add a logging hook before the next run to see tool activity as it happens:
 
-```{r write-policy}
-write_permissions <- Permissions$new(
-  mode = "standard",
-  file_read = TRUE,
-  file_write = workspace,
-  bash = FALSE,
-  r_code = FALSE,
-  web = FALSE,
-  install_packages = FALSE
-)
-
-stopifnot(
-  identical(write_permissions$file_write, workspace),
-  identical(write_permissions$r_code, FALSE),
-  identical(write_permissions$bash, FALSE)
-)
+```{r log-tools, eval = FALSE}
+agent$add_hook(hook_log_tools())
+result <- agent$run_sync("Read DESCRIPTION and name the package's imported dependencies.")
+result$response
 ```
 
-Create a separate Agent with file checkpointing enabled. The checkpoint marks
-the state before the task. Deputy records preimages when its native write,
-edit, and multi-edit tools change files.
+`hook_log_tools()` uses cli for console output. See [Hooks](hooks.html) to
+write a callback or change what gets reported.
+
+## Write a summary file
+
+Writing needs a different permission policy. Create a new agent: permissions
+on an existing agent can be narrowed, but cannot be expanded beyond those set
+at construction.
+
+This policy permits native file writes inside `workspace`. R execution, shell
+commands, web requests, and package installation remain disabled by default.
 
 ```{r write-agent, eval = FALSE}
 write_agent <- Agent$new(
-  chat = chat$clone()$set_turns(list()),
+  chat = ellmer::chat("openai/gpt-5.6-luna"),
   tools = tools_file(),
-  permissions = write_permissions,
-  usage_limits = first_limits,
+  permissions = Permissions$new(file_write = workspace),
+  usage_limits = UsageLimits(max_requests = 6, max_tool_calls = 8),
   enable_file_checkpointing = TRUE,
-  working_dir = workspace,
-  agent_name = "summary-writer"
+  working_dir = workspace
 )
 
 checkpoint_id <- write_agent$checkpoint("before package summary")
 
 write_result <- write_agent$run_sync(
-  paste(
-    "Read DESCRIPTION and write a concise package summary to deputy-summary.md.",
-    "Do not modify any other file."
-  )
+  "Read DESCRIPTION and write a short package summary to deputy-summary.md. Leave other files unchanged."
 )
+
+write_result$stop_reason
+write_result$tool_calls()
 ```
 
-Review the result and the actual diff. If the native file-tool changes are not
-useful, rewind them:
+Open `deputy-summary.md` and review the changes in Git. Deputy saved the
+previous contents of files changed by its native write tools after the
+checkpoint. If you want to undo those changes, run:
 
 ```{r rewind, eval = FALSE}
-write_result$stop_reason
-write_agent$list_checkpoints()
 write_agent$rewind_files(checkpoint_id)
 ```
 
-Checkpoints do not capture changes made outside Deputy's native file tools, and
-they do not replace Git or backups.
+Checkpoints cover Deputy's native write, edit, and multi-edit tools. They do
+not capture changes made by R code, shell commands, or other programs. See
+[Permissions](permissions.html) for the limits of file policies and code
+execution.
 
-## Common failures
+## Troubleshooting
 
 ### The provider cannot authenticate
 
-Configure the credential expected by your chosen ellmer provider, then verify a
-plain ellmer chat before adding Deputy. Deputy does not manage provider keys.
+Check the credential expected by your ellmer provider. Try a plain ellmer
+chat to confirm the connection before adding tools or Deputy settings.
 
 ### A tool call is denied
 
-Treat the denial as useful policy feedback. Check that the tool belongs in this
-task, that it is registered, and that the relevant capability is explicit. Do
-not switch to `permissions_full()` merely to make the error disappear.
+Check that the tool is registered and that its required permission is enabled.
+For custom tools, check their annotations and any allowlist as well. The
+[Tools guide](tools.html) includes a complete custom-tool example.
 
-### The run stops at a limit
+### The run stops before finishing
 
-Inspect `result$stop_reason` and `result$usage`. Tighten the task first; increase
-only the specific limit whose additional work is justified.
+Inspect `result$stop_reason` and `result$usage`. Try a smaller task, or raise the
+limit that was reached. `"tool_loop"` means an identical tool call returned the
+same result three times in a row. `"cost_unavailable"` means a cost limit was
+set, but the provider did not report enough cost information to enforce it.
+See `UsageLimits()` for all stop reasons.
 
-### Code execution sounds safer than it is
+## Next steps
 
-`run_r_code` starts a separate R process, but process separation is not an OS
-sandbox. `run_bash` runs with the current user's privileges. Both are denied by
-`permissions_standard()`. For untrusted model-generated R, configure mcp-repl
-with an explicit OS policy and load it through `tools_mcp_repl()`; Deputy
-refuses to load a server whose effective sandbox differs from the requested
-one.
-
-### A Shiny task reads the wrong directory
-
-Shiny process working directories can differ from the app directory. Pass an
-existing absolute `working_dir` and construct any directory-valued write grant
-from that same path.
-
-## Where next?
-
-| If you want to... | Continue with... |
-|---|---|
-| Choose or build tools | `vignette("tools", package = "deputy")` |
-| Design permission policy | `vignette("permissions", package = "deputy")` |
-| Observe and intervene in runs | `vignette("hooks", package = "deputy")` |
-| Stream an Agent into an app | `vignette("example-shiny-chat", package = "deputy")` |
-| Delegate to specialist Agents | `vignette("multi-agent", package = "deputy")` |
-| Require typed model output | `vignette("structured-output", package = "deputy")` |
-| Build a concrete workflow | `vignette("example-data-analysis", package = "deputy")` |
-
-The durable pattern is the same in every host: make the workspace, tools,
-permissions, and limits explicit; run one bounded job; then inspect the typed
-result before granting more authority.
-
-
-## Standalone scripts
-
-The package includes eight independent scripts for basic runs, tools,
-permissions, hooks, delegation, structured output, session resume, and skills.
-They are executed in CI with deterministic provider responses. To run one
-against OpenAI, set `OPENAI_API_KEY` and source the installed file:
-
-```{r, eval = FALSE}
-source(system.file("examples", "standalone", "01-basic.R", package = "deputy"))
-```
-
-Find the other scripts and their setup guide with:
-
-```{r, eval = FALSE}
-list.files(system.file("examples", "standalone", package = "deputy"))
-```
+- [Tools](tools.html): select a preset or register an R function.
+- [Structured output](structured-output.html): extract data with ellmer types.
+- [Shiny chat](example-shiny-chat.html): use the agent in an app.
+- [Multiple agents](multi-agent.html): give separate tasks to other agents.

--- a/vignettes/hooks.Rmd
+++ b/vignettes/hooks.Rmd
@@ -15,9 +15,8 @@ knitr::opts_chunk$set(
 )
 ```
 
-Hooks let you intercept agent behaviour at key points in the execution
-lifecycle. Use them for logging, auditing, blocking dangerous actions, or
-injecting custom logic.
+Hooks run R callbacks before or after an agent action. Use them to report
+tool activity with cli, reject a tool call, or record results for your app.
 
 ## Hook Events
 
@@ -118,9 +117,9 @@ agent$add_hook(hook_block_dangerous_bash(
 
 ### Limiting File Writes
 
-Configure the Agent's `Permissions` when a directory is an authority boundary.
-`hook_limit_file_writes()` is a defense-in-depth convenience hook that delegates
-to the same canonical path policy for `write_file`, `edit_file`, and
+Set `Permissions$new(file_write = output_dir)` to restrict native file writes
+to a directory. `hook_limit_file_writes()` adds a second check using the same
+path rules for `write_file`, `edit_file`, and
 `multi_edit`. The directory must already exist:
 
 ```{r, eval = FALSE}
@@ -202,7 +201,7 @@ Session hooks fire at the start and end of a session:
 HookMatcher$new(
   event = "SessionStart",
   callback = function(context) {
-    message("Session started at ", Sys.time())
+    cli::cli_inform("Session started at {Sys.time()}")
     NULL
   }
 )

--- a/vignettes/permissions.Rmd
+++ b/vignettes/permissions.Rmd
@@ -15,9 +15,9 @@ knitr::opts_chunk$set(
 )
 ```
 
-Permissions control what an agent is allowed to do. They sit between the LLM
-and tool execution, checking every tool call before it runs. deputy ships
-with sensible presets and makes it easy to build custom policies.
+Permissions control which tool calls an agent can run. Use a preset for
+common read or write tasks, or a `Permissions` object to allow specific
+capabilities. Deputy checks the policy before running a tool.
 
 ## Permission Presets
 

--- a/vignettes/structured-output.Rmd
+++ b/vignettes/structured-output.Rmd
@@ -12,14 +12,14 @@ knitr::opts_chunk$set(eval = FALSE)
 library(deputy)
 ```
 
-Deputy uses ellmer's types, provider schema transport, JSON extraction, and R
-conversion. A structured result is the value ellmer returns, available directly
-in `AgentResult$structured_output`. There is no separate Deputy schema format.
+Use ellmer types to ask for a list or data frame with specified fields. Deputy
+stores the converted R value in `result$structured_output` so you can use it
+in the next step of your analysis.
 
 ## Extract directly
 
 Use `chat_structured()` when the conversation already contains the information
-to extract. It makes a governed structured request and suppresses ordinary tools,
+to extract. It makes one structured request without calling ordinary tools,
 as ellmer does. `chat_structured_async()` returns a promise with the same value.
 
 ```{r direct}
@@ -33,7 +33,7 @@ agent$last_run()$usage
 ```
 
 Existing JSON Schema can enter through `ellmer::type_from_schema(text = ...)`.
-Schema support and conversion remain ellmer's contract.
+ellmer handles schema support and conversion to R values.
 
 ```{r schema}
 status_type <- ellmer::type_from_schema(
@@ -59,7 +59,9 @@ agent <- Agent$new(
   usage_limits = UsageLimits(max_requests = 8)
 )
 result <- agent$run_sync("Review the README", type = status_type)
-stopifnot(result$is_success())
+if (!result$is_success()) {
+  cli::cli_abort("Review stopped early: {result$stop_reason}.")
+}
 result$structured_output
 ```
 

--- a/vignettes/structured-output.Rmd
+++ b/vignettes/structured-output.Rmd
@@ -19,8 +19,10 @@ in the next step of your analysis.
 ## Extract directly
 
 Use `chat_structured()` when the conversation already contains the information
-to extract. It makes one structured request without calling ordinary tools,
+to extract. It requests structured output without calling ordinary tools,
 as ellmer does. `chat_structured_async()` returns a promise with the same value.
+Automatic compaction and optional validation corrections can add model requests;
+all count toward the run's usage limits.
 
 ```{r direct}
 agent <- Agent$new(ellmer::chat("openai/gpt-5.6-luna"))
@@ -49,7 +51,7 @@ from that conversation. Both phases share one run ID, hook lifecycle, permission
 policy, and request/token/cost budget. The extraction never repeats tool work.
 The `response` is the task's text; `structured_output` is the extracted value.
 Even a task without tools uses these two explicit phases; use
-`chat_structured()` for direct extraction in one request.
+`chat_structured()` to extract directly without the initial task phase.
 
 ```{r task}
 agent <- Agent$new(

--- a/vignettes/tools.Rmd
+++ b/vignettes/tools.Rmd
@@ -15,8 +15,9 @@ knitr::opts_chunk$set(
 )
 ```
 
-Tools are how agents interact with the world. deputy provides built-in tools
-for common tasks and makes it easy to create your own.
+Tools let a model call R functions: read a file, fetch a page, or run a
+calculation. Choose built-in tools or register functions with `ellmer::tool()`.
+Permissions determine which calls can run.
 
 ## Built-in Tools
 
@@ -44,77 +45,6 @@ whether the agent is allowed to use it. See `vignette("permissions")` for
 details.
 
 ## Tool Bundles
-
-Use `ellmer::tool()` for local functions, package exports, and service call
-wrappers, then register those objects through the same Agent API. Registration
-does not load packages or infer a function's effects. Describe them explicitly:
-
-```{r registration-contract, eval=TRUE}
-library(deputy)
-uppercase <- ellmer::tool(
-  base::toupper,
-  name = "uppercase",
-  description = "Uppercase local text.",
-  arguments = list(x = ellmer::type_string()),
-  annotations = ellmer::tool_annotations(
-    read_only_hint = TRUE, destructive_hint = FALSE,
-    open_world_hint = FALSE, idempotent_hint = TRUE
-  )
-)
-# Constructing this Chat does not make a model request.
-chat <- ellmer::chat_openai(credentials = function() "example", model = "gpt-5.6-luna")
-agent <- Agent$new(chat = chat, tools = list(uppercase))
-agent$get_tools()$uppercase("hello")
-agent$register_tool(uppercase, replace = TRUE)
-```
-
-Existing names are errors unless `replace = TRUE` is explicit. Repeated names
-inside one batch always fail, including with replacement enabled. List names
-do not rename a tool. `set_tools()` replaces the whole user registry. Both
-methods and construction validate and adapt the complete batch before changing
-the backend registry; a malformed later tool leaves earlier tools untouched.
-Skills use `load_skill(..., allow_conflicts = TRUE)` for explicit replacement.
-
-Missing annotations stay absent on the source object. For custom tools,
-permissions assume possible modification, destruction, and external access,
-and no idempotence. An explicit read-only annotation makes an omitted
-destructive annotation irrelevant. A local read tool therefore needs at least
-`read_only_hint = TRUE` and `open_world_hint = FALSE` under standard permissions.
-Readonly mode additionally requires an explicit allowlist entry for custom
-tools. Annotations do not grant authority or verify a service's trustworthiness.
-See `PermissionMode` for callback and mode behavior.
-
-Inspect the supplied fields and defaults without executing the tool:
-
-```{r tool-metadata, eval=TRUE}
-tool_metadata(agent$get_tools()$uppercase)
-```
-
-For service tools, `tools_mcp(config, servers = "evidence")` selects an exact
-configured server name before connecting. The qualified mcptools 1.0.2 bridge
-retains annotations from the server and records `source$type = "mcp"`, its
-server name, and tool name. It reports missing metadata rather than inventing
-safe effects. Other mcptools versions fail explicitly pending qualification.
-The caller must trust the configured service; metadata does not establish trust.
-
-Pass these objects to `Agent$new(tools = ...)`, `register_tools()`, or an
-explicit tool registry used by `agent_definition_read()`. The same metadata
-survives YAML selection, Agent wrapping, cloning, and delegation. Permission
-callbacks receive it as `context$tool_metadata`, alongside the supplied
-`context$tool_annotations`. A service called `read_file` still uses its service
-annotations and capabilities; its name does not confer native file access.
-Local file checkpointing excludes MCP calls, so rewinding files never treats a
-remote service write as a change to the local workspace.
-
-Reconnecting a server invalidates tools from its old connection. Reload and
-replace explicitly with `agent$load_mcp(config, servers = "evidence", replace = TRUE)`.
-This refresh removes obsolete tools from the selected servers, including when
-discovery succeeds with an empty tool set. Unrelated tools remain registered.
-A load failure records a failed attempt in `mcp_status()`. Tools that still
-have working connections remain registered. If mcptools already closed an
-old connection, its invalidated handles are removed even when discovery or
-registration fails. Malformed metadata never silently becomes an unannotated
-executable.
 
 Bundles group related tools together:
 
@@ -159,22 +89,19 @@ tools_preset("full")
 | `dev` | native files plus trusted R and shell execution |
 | `full` | every built-in tool |
 
-## Creating Custom Tools
+## Create a tool from an R function
 
-Use `ellmer::tool()` to define custom tools with type-safe arguments and
-annotations:
+A tool wraps an R function with a name, a description, and argument types that
+the model can use. Start with a function you can call directly. This example
+wraps `toupper()`; a package function or your own function works the same way.
 
-```{r, eval = FALSE}
-tool_lookup_user <- ellmer::tool(
-  fun = function(user_id) {
-    # your implementation
-    list(name = "Alice", email = "alice@example.com")
-  },
-  name = "lookup_user",
-  description = "Look up a user by their ID",
-  arguments = list(
-    user_id = ellmer::type_string("The user ID to look up")
-  ),
+```{r custom-tool, eval = TRUE}
+library(deputy)
+uppercase <- ellmer::tool(
+  base::toupper,
+  name = "uppercase",
+  description = "Uppercase local text.",
+  arguments = list(x = ellmer::type_string()),
   annotations = ellmer::tool_annotations(
     read_only_hint = TRUE,
     destructive_hint = FALSE,
@@ -182,38 +109,58 @@ tool_lookup_user <- ellmer::tool(
     idempotent_hint = TRUE
   )
 )
+uppercase("hello")
 ```
 
-The `annotations` are optional but recommended. They tell the permission
-system about the tool's behaviour:
+Register the tool when constructing the agent:
 
-- `read_only_hint` -- Tool does not change state
-- `destructive_hint` -- Tool may delete or overwrite data
-- `open_world_hint` -- Tool accesses external systems (network, APIs)
-- `idempotent_hint` -- Safe to call multiple times with same input
-
-### Using a Custom Tool
-
-```{r tools-custom-demo}
-library(deputy)
-
-tool_dice <- ellmer::tool(
-  fun = function(n = 1, sides = 6) {
-    rolls <- sample(sides, n, replace = TRUE)
-    paste("Rolled:", paste(rolls, collapse = ", "))
-  },
-  name = "roll_dice",
-  description = "Roll one or more dice",
-  arguments = list(
-    n = ellmer::type_integer("Number of dice to roll"),
-    sides = ellmer::type_integer("Number of sides per die")
-  )
+```{r custom-agent, eval = FALSE}
+agent <- Agent$new(
+  chat = ellmer::chat("openai/gpt-5.6-luna"),
+  tools = list(uppercase),
+  permissions = Permissions$new(file_write = FALSE)
 )
+result <- agent$run_sync("Use uppercase to convert 'hello' to capitals.")
+result$response
+```
 
-chat <- ellmer::chat_openai(model = "gpt-5.6-luna")
-agent <- Agent$new(chat = chat, tools = list(tool_dice))
-result <- agent$run_sync("Roll 2d20 for me")
-cat(result$response)
+The annotations describe the function's effects. Here the tool changes no
+files, uses no network, and returns the same answer for the same input. Deputy
+uses these declarations when checking permissions; it does not inspect the
+function body to verify them.
+
+| Annotation | Meaning when `TRUE` |
+|---|---|
+| `read_only_hint` | Does not change state |
+| `destructive_hint` | May delete or overwrite data |
+| `open_world_hint` | Accesses external systems |
+| `idempotent_hint` | Repeated calls have the same effect |
+
+### Replace or inspect registered tools
+
+Use `agent$register_tool(tool)` to add a tool to an existing agent, or
+`agent$register_tool(tool, replace = TRUE)` to replace a tool with the same name.
+
+Existing names are errors unless `replace = TRUE` is explicit. Repeated names
+inside one batch always fail, including with replacement enabled. List names
+do not rename a tool. `set_tools()` replaces the whole user registry. Both
+methods and construction validate and adapt the complete batch before changing
+the backend registry; a malformed later tool leaves earlier tools untouched.
+Skills use `load_skill(..., allow_conflicts = TRUE)` for explicit replacement.
+
+Missing annotations stay absent on the source object. For custom tools,
+permissions assume possible modification, destruction, and external access,
+and no idempotence. An explicit read-only annotation makes an omitted
+destructive annotation irrelevant. A local read tool therefore needs at least
+`read_only_hint = TRUE` and `open_world_hint = FALSE` under standard permissions.
+Readonly mode additionally requires an explicit allowlist entry for custom
+tools. Annotations do not grant authority or verify a service's trustworthiness.
+See `PermissionMode` for callback and mode behavior.
+
+Inspect the supplied fields and defaults without executing the tool:
+
+```{r tool-metadata, eval = TRUE}
+tool_metadata(uppercase)
 ```
 
 ## Web Tools
@@ -265,6 +212,34 @@ agent <- Agent$new(
 `tools_mcp()` returns an empty list with a warning when `mcptools` is not
 installed or no tools are available. MCP servers are configured in
 `~/.config/mcptools/config.json`; see the mcptools documentation for setup.
+
+### Server metadata and reconnection
+
+For service tools, `tools_mcp(config, servers = "evidence")` selects an exact
+configured server name before connecting. The qualified mcptools 1.0.2 bridge
+retains annotations from the server and records `source$type = "mcp"`, its
+server name, and tool name. It reports missing metadata rather than inventing
+safe effects. Other mcptools versions fail explicitly pending qualification.
+The caller must trust the configured service; metadata does not establish trust.
+
+Pass these objects to `Agent$new(tools = ...)`, `register_tools()`, or an
+explicit tool registry used by `agent_definition_read()`. The same metadata
+survives YAML selection, Agent wrapping, cloning, and delegation. Permission
+callbacks receive it as `context$tool_metadata`, alongside the supplied
+`context$tool_annotations`. A service called `read_file` still uses its service
+annotations and capabilities; its name does not confer native file access.
+Local file checkpointing excludes MCP calls, so rewinding files never treats a
+remote service write as a change to the local workspace.
+
+Reconnecting a server invalidates tools from its old connection. Reload and
+replace explicitly with `agent$load_mcp(config, servers = "evidence", replace = TRUE)`.
+This refresh removes obsolete tools from the selected servers, including when
+discovery succeeds with an empty tool set. Unrelated tools remain registered.
+A load failure records a failed attempt in `mcp_status()`. Tools that still
+have working connections remain registered. If mcptools already closed an
+old connection, its invalidated handles are removed even when discovery or
+registration fails. Malformed metadata never silently becomes an unannotated
+executable.
 
 ### Sandboxed R with mcp-repl
 


### PR DESCRIPTION
Closes #115

The first-run docs required readers to assemble policy objects and run assertions about package internals before trying a task. The README, getting-started guide, and package help now start with a read-only package review, explain the result, and introduce writing and checkpoints when they are needed.

Simplifies the package description and recipe introductions, moves tool registration details after tool selection, and gives pkgdown a direct Get started link. Examples use ellmer tools, cli messages, and usethis credential setup. Removes tutorial stopifnot() checks; pipeline failures retain explicit checks with helpful cli errors. The Shiny example uses one tool bundle to avoid duplicate names that prevent Agent construction.

Validation: README regenerated; pkgdown built and homepage/getting-started layouts reviewed in a browser; all displayed R chunks parsed; first-run, read/write/rewind, custom-tool, and Shiny registration smoke checks passed against a local deterministic provider. Air and Jarl passed. Full suite: 4,067 assertions passed, six optional skips, and two warnings from the existing nonexistent-path error test. The full R CMD check passed with a note about a generated README.html preview; that file was removed, and the final documentation/package check with --no-tests returned zero errors, warnings, or notes. No paid model calls were used.
