### PR TITLE
Make Claude review completion and blocked outcomes observable

### DIFF
--- a/.github/scripts/claude-review-outcome.cjs
+++ b/.github/scripts/claude-review-outcome.cjs
@@ -1,0 +1,102 @@
+// Publish only allowlisted diagnostics; never serialize SDK messages or tool inputs.
+const fs = require('node:fs');
+
+const knownTools = new Set([
+  'Agent', 'Task', 'TaskOutput', 'TaskCreate', 'TaskUpdate', 'TaskList',
+  'TodoWrite', 'Skill', 'Read', 'Glob', 'Grep', 'Bash',
+  'mcp__github_inline_comment__create_inline_comment',
+]);
+const commands = [
+  'gh pr view', 'gh pr diff', 'gh pr list', 'gh pr comment',
+  'gh issue view', 'gh issue list', 'gh search', 'gh api',
+  'git diff', 'git show', 'git log', 'git rev-parse',
+];
+
+function diagnostics(messages) {
+  const result = Array.isArray(messages)
+    ? messages.findLast((message) => message.type === 'result') : undefined;
+  const denials = Array.isArray(result?.permission_denials) ? result.permission_denials : [];
+  return {
+    sdk_success: result?.subtype === 'success' && result?.is_error === false,
+    permission_denials_count: denials.length,
+    denied_operations: [...new Set(denials.map((denial) => {
+      const tool = knownTools.has(denial.tool_name) ? denial.tool_name : 'other-tool';
+      if (tool !== 'Bash') return tool;
+      const command = denial.tool_input?.command;
+      const prefix = typeof command === 'string' && commands.find((candidate) =>
+        command === candidate || command.startsWith(candidate + ' '));
+      return prefix ? `Bash(${prefix})` : 'Bash(other-command)';
+    }))].sort(),
+  };
+}
+
+function classify({ diagnostic, sha, currentSha, comments, inline, marker, started, actionOutcome }) {
+  const blocked = (reason) => ({ outcome: 'blocked/failed', reason });
+  if (sha !== currentSha) return blocked('PR head changed during review');
+  if (actionOutcome !== 'success' || !diagnostic.sdk_success) return blocked('Claude did not complete successfully');
+  if (diagnostic.permission_denials_count) return blocked('Claude tool permission denied');
+  const fresh = (comment) => comment.user?.login === 'claude[bot]' &&
+    Date.parse(comment.created_at) >= Date.parse(started);
+  const summaries = comments.filter(fresh);
+  const findings = inline.filter((comment) => fresh(comment) && comment.commit_id === sha);
+  const withFindings = summaries.some((comment) => comment.body?.includes(`${marker}:with-findings -->`));
+  const withoutFindings = summaries.some((comment) => comment.body?.includes(`${marker}:without-findings -->`));
+  if (withFindings && !withoutFindings && findings.length) {
+    return { outcome: 'completed with findings', reason: 'Current-run summary and exact-commit inline findings verified' };
+  }
+  if (withoutFindings && !withFindings && !findings.length) {
+    return { outcome: 'completed without findings', reason: 'Current-run exact-commit clean summary verified' };
+  }
+  return blocked('No consistent current-run exact-commit review evidence');
+}
+
+async function main() {
+  const env = process.env;
+  const sha = env.REVIEW_SHA;
+  if (!/^[a-f0-9]{40}$/.test(sha || '')) throw new Error('Invalid review SHA');
+  let diagnostic = diagnostics([]);
+  let result = { outcome: 'blocked/failed', reason: 'Review evidence unavailable' };
+  try {
+    const execution = env.EXECUTION_FILE || `${env.RUNNER_TEMP}/claude-execution-output.json`;
+    diagnostic = diagnostics(JSON.parse(fs.readFileSync(execution, 'utf8')));
+    async function get(path) {
+      const response = await fetch(`https://api.github.com/repos/${env.GITHUB_REPOSITORY}/${path}`, {
+        headers: { Authorization: `Bearer ${env.GH_TOKEN}`, Accept: 'application/vnd.github+json' },
+      });
+      if (!response.ok) throw new Error('GitHub evidence request failed');
+      return response.json();
+    }
+    async function pages(path) {
+      const values = [];
+      for (let page = 1; ; page++) {
+        const batch = await get(`${path}?per_page=100&page=${page}`);
+        values.push(...batch);
+        if (batch.length < 100) return values;
+      }
+    }
+    const [pr, comments, inline] = await Promise.all([
+      get(`pulls/${env.PR_NUMBER}`), pages(`issues/${env.PR_NUMBER}/comments`),
+      pages(`pulls/${env.PR_NUMBER}/comments`),
+    ]);
+    result = classify({ diagnostic, sha, currentSha: pr.head.sha, comments, inline,
+      marker: `<!-- deputy-claude-review:${sha}:${env.GITHUB_RUN_ID}:${env.GITHUB_RUN_ATTEMPT}`,
+      started: env.REVIEW_STARTED, actionOutcome: env.ACTION_OUTCOME });
+  } catch {
+    // Errors can include server responses, file contents, or token-bearing URLs.
+    // Keep the public failure categorical; never print the caught value.
+  }
+  const safe = { ...result, reviewed_sha: sha, ...diagnostic };
+  fs.writeFileSync(`${env.RUNNER_TEMP}/claude-review-outcome.json`, JSON.stringify(safe, null, 2));
+  fs.appendFileSync(env.GITHUB_STEP_SUMMARY,
+    `### Claude review: ${safe.outcome}\n\nCommit: \`${sha}\`\n\n${safe.reason}.\n\n` +
+    `Permission denials: ${safe.permission_denials_count}. ` +
+    `Operations: ${safe.denied_operations.join(', ') || 'none'}.\n`);
+  console.log(JSON.stringify(safe));
+  if (safe.outcome === 'blocked/failed') process.exitCode = 1;
+}
+
+module.exports = { diagnostics, classify };
+if (require.main === module) main().catch(() => {
+  console.error('Claude review outcome verification failed');
+  process.exitCode = 1;
+});

--- a/.github/scripts/claude-review-outcome.cjs
+++ b/.github/scripts/claude-review-outcome.cjs
@@ -73,6 +73,9 @@ function classify({ diagnostic, sha, currentSha, comments, inline, marker, findi
     comment.body?.includes(findingMarker));
   const withFindings = summaries.some((comment) => comment.body?.includes(`${marker}:with-findings -->`));
   const withoutFindings = summaries.some((comment) => comment.body?.includes(`${marker}:without-findings -->`));
+  if ((withFindings || withoutFindings) && !diagnostic.review_agent_calls) {
+    return blocked('Upstream review agents did not run');
+  }
   if (withFindings && !withoutFindings && findings.length) {
     return { outcome: 'completed with findings', reason: 'Current-run summary and exact-commit inline findings verified' };
   }

--- a/.github/scripts/claude-review-outcome.cjs
+++ b/.github/scripts/claude-review-outcome.cjs
@@ -22,11 +22,20 @@ function diagnostics(messages) {
   const denials = Array.isArray(result?.permission_denials) ? result.permission_denials : [];
   const calls = Array.isArray(messages) ? messages.flatMap((message) => message.type === 'assistant' && Array.isArray(message.message?.content)
     ? message.message.content.filter((item) => item.type === 'tool_use') : []) : [];
+  const deniedIds = new Set(denials.map((denial) => denial.tool_use_id));
+  const completedIds = new Set(Array.isArray(messages) ? messages.flatMap((message) => message.type === 'user' && Array.isArray(message.message?.content)
+    ? message.message.content.filter((item) => item.type === 'tool_result' && item.is_error !== true && !deniedIds.has(item.tool_use_id)).map((item) => item.tool_use_id) : []) : []);
   const pluginCalls = calls.filter((call) => call.name === 'Skill' && call.input?.skill === 'code-review:code-review');
+  const successfulPlugins = pluginCalls.filter((call) => typeof call.id === 'string' && completedIds.has(call.id));
+  const agentCalls = calls.filter((call) => ['Agent', 'Task'].includes(call.name));
   return {
     plugin_calls: pluginCalls.length,
-    plugin_comment_argument_seen: pluginCalls.some((call) => typeof call.input?.args === 'string' && /(?:^|\s)--comment(?:\s|$)/.test(call.input.args)),
-    review_agent_calls: calls.filter((call) => ['Agent', 'Task'].includes(call.name)).length,
+    plugin_successes: successfulPlugins.length,
+    plugin_comment_argument_seen: successfulPlugins.some((call) => typeof call.input?.args === 'string' && /(?:^|\s)--comment(?:\s|$)/.test(call.input.args)),
+    review_agent_calls: agentCalls.length,
+    // A background launch acknowledgment does not prove that the agent finished.
+    review_agent_successes: agentCalls.filter((call) => call.input?.run_in_background !== true &&
+      typeof call.id === 'string' && completedIds.has(call.id)).length,
     sdk_success: result?.subtype === 'success' && result?.is_error === false,
     reported_outcome: reportedOutcomes.has(result?.structured_output?.outcome) ? result.structured_output.outcome : 'unreported',
     reported_reason: reportedReasons.has(result?.structured_output?.reason) ? result.structured_output.reason : 'unreported',
@@ -63,7 +72,7 @@ function classify({ diagnostic, sha, currentSha, comments, inline, marker, findi
   const blocked = (reason) => ({ outcome: 'blocked/failed', reason });
   if (sha !== currentSha) return blocked('PR head changed during review');
   if (actionOutcome !== 'success' || !diagnostic.sdk_success) return blocked('Claude did not complete successfully');
-  if (!diagnostic.plugin_calls || !diagnostic.plugin_comment_argument_seen) {
+  if (!diagnostic.plugin_calls || !diagnostic.plugin_successes || !diagnostic.plugin_comment_argument_seen) {
     return blocked('Upstream review plugin was not invoked with --comment');
   }
   const fresh = (comment) => comment.user?.login === 'github-actions[bot]' &&
@@ -73,7 +82,7 @@ function classify({ diagnostic, sha, currentSha, comments, inline, marker, findi
     comment.body?.includes(findingMarker));
   const withFindings = summaries.some((comment) => comment.body?.includes(`${marker}:with-findings -->`));
   const withoutFindings = summaries.some((comment) => comment.body?.includes(`${marker}:without-findings -->`));
-  if ((withFindings || withoutFindings) && !diagnostic.review_agent_calls) {
+  if ((withFindings || withoutFindings) && (!diagnostic.review_agent_calls || !diagnostic.review_agent_successes)) {
     return blocked('Upstream review agents did not run');
   }
   if (withFindings && !withoutFindings && findings.length) {

--- a/.github/scripts/claude-review-outcome.cjs
+++ b/.github/scripts/claude-review-outcome.cjs
@@ -7,6 +7,8 @@ const knownTools = new Set([
   'TaskGet', 'TaskStop', 'SendMessage', 'EnterPlanMode', 'ExitPlanMode',
   'mcp__github_inline_comment__create_inline_comment',
 ]);
+const reportedOutcomes = new Set(['completed-with-findings', 'completed-without-findings', 'skipped', 'blocked']);
+const reportedReasons = new Set(['reviewed', 'draft', 'closed', 'trivial', 'already-reviewed', 'permission-denied', 'other']);
 const commands = [
   'gh pr view', 'gh pr diff', 'gh pr list', 'gh pr comment',
   'gh issue view', 'gh issue list', 'gh search', 'gh api',
@@ -20,6 +22,8 @@ function diagnostics(messages) {
   const denials = Array.isArray(result?.permission_denials) ? result.permission_denials : [];
   return {
     sdk_success: result?.subtype === 'success' && result?.is_error === false,
+    reported_outcome: reportedOutcomes.has(result?.structured_output?.outcome) ? result.structured_output.outcome : 'unreported',
+    reported_reason: reportedReasons.has(result?.structured_output?.reason) ? result.structured_output.reason : 'unreported',
     permission_denials_count: denials.length,
     denied_operations: [...new Set(denials.flatMap((denial) => {
       const tool = knownTools.has(denial.tool_name) ? denial.tool_name : 'other-tool';
@@ -102,6 +106,7 @@ async function main() {
   fs.writeFileSync(`${env.RUNNER_TEMP}/claude-review-outcome.json`, JSON.stringify(safe, null, 2));
   fs.appendFileSync(env.GITHUB_STEP_SUMMARY,
     `### Claude review: ${safe.outcome}\n\nCommit: \`${sha}\`\n\n${safe.reason}.\n\n` +
+    `Reviewer report: ${safe.reported_outcome} (${safe.reported_reason}).\n\n` +
     `Permission denials: ${safe.permission_denials_count}. ` +
     `Operations: ${safe.denied_operations.join(', ') || 'none'}.\n`);
   console.log(JSON.stringify(safe));

--- a/.github/scripts/claude-review-outcome.cjs
+++ b/.github/scripts/claude-review-outcome.cjs
@@ -35,7 +35,7 @@ function classify({ diagnostic, sha, currentSha, comments, inline, marker, start
   if (sha !== currentSha) return blocked('PR head changed during review');
   if (actionOutcome !== 'success' || !diagnostic.sdk_success) return blocked('Claude did not complete successfully');
   if (diagnostic.permission_denials_count) return blocked('Claude tool permission denied');
-  const fresh = (comment) => comment.user?.login === 'claude[bot]' &&
+  const fresh = (comment) => comment.user?.login === 'github-actions[bot]' &&
     Date.parse(comment.created_at) >= Date.parse(started);
   const summaries = comments.filter(fresh);
   const findings = inline.filter((comment) => fresh(comment) && comment.commit_id === sha);

--- a/.github/scripts/claude-review-outcome.cjs
+++ b/.github/scripts/claude-review-outcome.cjs
@@ -8,7 +8,7 @@ const knownTools = new Set([
   'mcp__github_inline_comment__create_inline_comment',
 ]);
 const reportedOutcomes = new Set(['completed-with-findings', 'completed-without-findings', 'skipped', 'blocked']);
-const reportedReasons = new Set(['reviewed', 'draft', 'closed', 'trivial', 'already-reviewed', 'permission-denied', 'other']);
+const reportedReasons = new Set(['reviewed', 'draft', 'closed', 'trivial', 'already-reviewed', 'permission-denied', 'diff-unavailable', 'plugin-unavailable', 'subagent-unavailable', 'provider-limit', 'publication-failed', 'policy-conflict', 'other']);
 const commands = [
   'gh pr view', 'gh pr diff', 'gh pr list', 'gh pr comment',
   'gh issue view', 'gh issue list', 'gh search', 'gh api',

--- a/.github/scripts/claude-review-outcome.cjs
+++ b/.github/scripts/claude-review-outcome.cjs
@@ -50,6 +50,15 @@ function diagnostics(messages) {
   };
 }
 
+function priorReviewSkip({ sha, currentSha, comments, started }) {
+  const priorReview = comments.some((comment) => comment.user?.login === 'github-actions[bot]' &&
+    Date.parse(comment.created_at) < Date.parse(started) &&
+    /<!-- deputy-claude-review:[a-f0-9]{40}:\d+:\d+:(?:with|without)-findings -->/.test(comment.body || ''));
+  return sha === currentSha && priorReview
+    ? { outcome: 'intentionally skipped', reason: 'Upstream policy skips a prior Claude review; this run did not review the current head' }
+    : undefined;
+}
+
 function classify({ diagnostic, sha, currentSha, comments, inline, marker, findingMarker, started, actionOutcome, draft = false, state = 'open' }) {
   const blocked = (reason) => ({ outcome: 'blocked/failed', reason });
   if (sha !== currentSha) return blocked('PR head changed during review');
@@ -80,11 +89,9 @@ function classify({ diagnostic, sha, currentSha, comments, inline, marker, findi
     if (diagnostic.reported_reason === 'trivial') {
       return skipped('Upstream plugin classified the change as trivial; this run did not review the current head');
     }
-    const priorReview = comments.some((comment) => comment.user?.login === 'github-actions[bot]' &&
-      Date.parse(comment.created_at) < Date.parse(started) &&
-      /<!-- deputy-claude-review:[a-f0-9]{40}:\d+:\d+:(?:with|without)-findings -->/.test(comment.body || ''));
-    if (diagnostic.reported_reason === 'already-reviewed' && priorReview) {
-      return skipped('Upstream plugin found a prior Claude review; this run did not review the current head');
+    const priorSkip = priorReviewSkip({ sha, currentSha, comments, started });
+    if (diagnostic.reported_reason === 'already-reviewed' && priorSkip) {
+      return priorSkip;
     }
   }
   return blocked('No consistent current-run exact-commit review evidence');
@@ -93,12 +100,15 @@ function classify({ diagnostic, sha, currentSha, comments, inline, marker, findi
 async function main() {
   const env = process.env;
   const sha = env.REVIEW_SHA;
+  const preflight = env.REVIEW_PREFLIGHT === 'true';
   if (!/^[a-f0-9]{40}$/.test(sha || '')) throw new Error('Invalid review SHA');
   let diagnostic = diagnostics([]);
   let result = { outcome: 'blocked/failed', reason: 'Claude execution evidence unavailable' };
   try {
-    const execution = env.EXECUTION_FILE || `${env.RUNNER_TEMP}/claude-execution-output.json`;
-    diagnostic = diagnostics(JSON.parse(fs.readFileSync(execution, 'utf8')));
+    if (!preflight) {
+      const execution = env.EXECUTION_FILE || `${env.RUNNER_TEMP}/claude-execution-output.json`;
+      diagnostic = diagnostics(JSON.parse(fs.readFileSync(execution, 'utf8')));
+    }
     result.reason = 'GitHub review evidence unavailable';
     async function get(path) {
       const response = await fetch(`https://api.github.com/repos/${env.GITHUB_REPOSITORY}/${path}`, {
@@ -117,9 +127,18 @@ async function main() {
     }
     const [pr, comments, inline] = await Promise.all([
       get(`pulls/${env.PR_NUMBER}`), pages(`issues/${env.PR_NUMBER}/comments`),
-      pages(`pulls/${env.PR_NUMBER}/comments`),
+      preflight ? [] : pages(`pulls/${env.PR_NUMBER}/comments`),
     ]);
-    result = classify({ diagnostic, sha, currentSha: pr.head.sha, comments, inline,
+    if (preflight) {
+      if (sha !== pr.head.sha) {
+        result = { outcome: 'blocked/failed', reason: 'PR head changed before review' };
+      } else {
+        const skip = priorReviewSkip({ sha, currentSha: pr.head.sha, comments, started: env.REVIEW_STARTED });
+        fs.appendFileSync(env.GITHUB_OUTPUT, `should_review=${!skip}\n`);
+        if (!skip) return;
+        result = skip;
+      }
+    } else result = classify({ diagnostic, sha, currentSha: pr.head.sha, comments, inline,
       marker: `<!-- deputy-claude-review:${sha}:${env.GITHUB_RUN_ID}:${env.GITHUB_RUN_ATTEMPT}`,
       findingMarker: `[Review run](https://github.com/${env.GITHUB_REPOSITORY}/actions/runs/${env.GITHUB_RUN_ID}/attempts/${env.GITHUB_RUN_ATTEMPT})`,
       started: env.REVIEW_STARTED, actionOutcome: env.ACTION_OUTCOME, draft: pr.draft, state: pr.state });
@@ -127,7 +146,7 @@ async function main() {
     // Errors can include server responses, file contents, or token-bearing URLs.
     // Keep the public failure categorical; never print the caught value.
   }
-  const safe = { ...result, target_sha: sha, ...diagnostic };
+  const safe = { ...result, target_sha: sha, stage: preflight ? 'eligibility' : 'review', ...diagnostic };
   fs.writeFileSync(`${env.RUNNER_TEMP}/claude-review-outcome.json`, JSON.stringify(safe, null, 2));
   fs.appendFileSync(env.GITHUB_STEP_SUMMARY,
     `### Claude review: ${safe.outcome}\n\nCommit: \`${sha}\`\n\n${safe.reason}.\n\n` +
@@ -138,7 +157,7 @@ async function main() {
   if (safe.outcome === 'blocked/failed') process.exitCode = 1;
 }
 
-module.exports = { diagnostics, classify };
+module.exports = { diagnostics, classify, priorReviewSkip };
 if (require.main === module) main().catch(() => {
   console.error('Claude review outcome verification failed');
   process.exitCode = 1;

--- a/.github/scripts/claude-review-outcome.cjs
+++ b/.github/scripts/claude-review-outcome.cjs
@@ -9,6 +9,7 @@ const knownTools = new Set([
 ]);
 const reportedOutcomes = new Set(['completed-with-findings', 'completed-without-findings', 'skipped', 'blocked']);
 const reportedReasons = new Set(['reviewed', 'draft', 'closed', 'trivial', 'already-reviewed', 'permission-denied', 'diff-unavailable', 'plugin-unavailable', 'subagent-unavailable', 'provider-limit', 'publication-failed', 'policy-conflict', 'other']);
+const eligibilities = new Set(['eligible', 'draft', 'closed', 'prior-comment', 'trivial', 'plugin-unavailable', 'input-unavailable', 'other']);
 const commands = [
   'gh pr view', 'gh pr diff', 'gh pr list', 'gh pr comment',
   'gh issue view', 'gh issue list', 'gh search', 'gh api',
@@ -20,7 +21,14 @@ function diagnostics(messages) {
   const result = Array.isArray(messages)
     ? messages.findLast((message) => message.type === 'result') : undefined;
   const denials = Array.isArray(result?.permission_denials) ? result.permission_denials : [];
+  const calls = Array.isArray(messages) ? messages.flatMap((message) => message.type === 'assistant' && Array.isArray(message.message?.content)
+    ? message.message.content.filter((item) => item.type === 'tool_use') : []) : [];
+  const pluginCalls = calls.filter((call) => call.name === 'Skill' && call.input?.skill === 'code-review:code-review');
   return {
+    plugin_calls: pluginCalls.length,
+    plugin_comment_argument_seen: pluginCalls.some((call) => typeof call.input?.args === 'string' && /(?:^|\s)--comment(?:\s|$)/.test(call.input.args)),
+    review_agent_calls: calls.filter((call) => ['Agent', 'Task'].includes(call.name)).length,
+    reported_eligibility: eligibilities.has(result?.structured_output?.eligibility) ? result.structured_output.eligibility : 'unreported',
     sdk_success: result?.subtype === 'success' && result?.is_error === false,
     reported_outcome: reportedOutcomes.has(result?.structured_output?.outcome) ? result.structured_output.outcome : 'unreported',
     reported_reason: reportedReasons.has(result?.structured_output?.reason) ? result.structured_output.reason : 'unreported',

--- a/.github/scripts/claude-review-outcome.cjs
+++ b/.github/scripts/claude-review-outcome.cjs
@@ -10,7 +10,7 @@ const commands = [
   'gh pr view', 'gh pr diff', 'gh pr list', 'gh pr comment',
   'gh issue view', 'gh issue list', 'gh search', 'gh api',
   'git diff', 'git show', 'git log', 'git rev-parse',
-  'cat', 'ls', 'find', 'sed', 'head', 'tail', 'wc', 'rg', 'grep', 'pwd',
+  'cat', 'ls', 'find', 'sed', 'head', 'tail', 'wc', 'rg', 'grep', 'pwd', 'cd', 'echo', 'printf',
 ];
 
 function diagnostics(messages) {
@@ -20,15 +20,21 @@ function diagnostics(messages) {
   return {
     sdk_success: result?.subtype === 'success' && result?.is_error === false,
     permission_denials_count: denials.length,
-    denied_operations: [...new Set(denials.map((denial) => {
+    denied_operations: [...new Set(denials.flatMap((denial) => {
       const tool = knownTools.has(denial.tool_name) ? denial.tool_name : 'other-tool';
       if (tool === 'Skill') return denial.tool_input?.skill === 'code-review:code-review'
         ? 'Skill(code-review:code-review)' : 'Skill(other-skill)';
       if (tool !== 'Bash') return tool;
       const command = denial.tool_input?.command;
-      const prefix = typeof command === 'string' && commands.find((candidate) =>
-        command === candidate || command.startsWith(candidate + ' '));
-      return prefix ? `Bash(${prefix})` : 'Bash(other-command)';
+      if (typeof command !== 'string') return ['Bash(other-command)'];
+      // This is a safe diagnostic projection, not a shell parser or permission rule.
+      const operations = command.split(/&&|\|\||[;|]/).slice(0, 8).map((part) => {
+        const text = part.trim();
+        const prefix = commands.find((candidate) => text === candidate || text.startsWith(candidate + ' '));
+        return prefix ? `Bash(${prefix})` : 'Bash(other-command)';
+      });
+      if (/[<>]/.test(command)) operations.push('Bash(shell-redirection)');
+      return operations;
     }))].sort(),
   };
 }
@@ -39,7 +45,7 @@ function classify({ diagnostic, sha, currentSha, comments, inline, marker, start
   if (actionOutcome !== 'success' || !diagnostic.sdk_success) return blocked('Claude did not complete successfully');
   if (diagnostic.permission_denials_count) return blocked('Claude tool permission denied');
   const fresh = (comment) => comment.user?.login === 'github-actions[bot]' &&
-    Date.parse(comment.created_at) >= Date.parse(started);
+    Date.parse(comment.created_at) >= Date.parse(started) - 5000;
   const summaries = comments.filter(fresh);
   const findings = inline.filter((comment) => fresh(comment) && comment.commit_id === sha &&
     comment.body?.includes(`${marker}:finding -->`));
@@ -59,10 +65,11 @@ async function main() {
   const sha = env.REVIEW_SHA;
   if (!/^[a-f0-9]{40}$/.test(sha || '')) throw new Error('Invalid review SHA');
   let diagnostic = diagnostics([]);
-  let result = { outcome: 'blocked/failed', reason: 'Review evidence unavailable' };
+  let result = { outcome: 'blocked/failed', reason: 'Claude execution evidence unavailable' };
   try {
     const execution = env.EXECUTION_FILE || `${env.RUNNER_TEMP}/claude-execution-output.json`;
     diagnostic = diagnostics(JSON.parse(fs.readFileSync(execution, 'utf8')));
+    result.reason = 'GitHub review evidence unavailable';
     async function get(path) {
       const response = await fetch(`https://api.github.com/repos/${env.GITHUB_REPOSITORY}/${path}`, {
         headers: { Authorization: `Bearer ${env.GH_TOKEN}`, Accept: 'application/vnd.github+json' },

--- a/.github/scripts/claude-review-outcome.cjs
+++ b/.github/scripts/claude-review-outcome.cjs
@@ -59,16 +59,21 @@ function diagnostics(messages) {
   };
 }
 
-function priorReviewSkip({ sha, currentSha, comments, started }) {
-  const priorReview = comments.some((comment) => comment.user?.login === 'github-actions[bot]' &&
-    Date.parse(comment.created_at) < Date.parse(started) &&
-    /<!-- deputy-claude-review:[a-f0-9]{40}:\d+:\d+:(?:with|without)-findings -->/.test(comment.body || ''));
+function priorReviewSkip({ sha, currentSha, comments, runId, runAttempt }) {
+  if (!/^\d+$/.test(runId || '') || !/^\d+$/.test(runAttempt || '')) return undefined;
+  const priorReview = comments.some((comment) => {
+    if (comment.user?.login !== 'github-actions[bot]') return false;
+    const markers = [...(comment.body || '').matchAll(/<!-- deputy-claude-review:[a-f0-9]{40}:(\d+):(\d+):(?:with|without)-findings -->/g)];
+    // A previous run can publish after this run starts. Identity, not timestamps,
+    // separates an upstream prior-comment skip from this run's own publication.
+    return markers.length > 0 && !markers.some((match) => match[1] === runId && match[2] === runAttempt);
+  });
   return sha === currentSha && priorReview
     ? { outcome: 'intentionally skipped', reason: 'Upstream policy skips a prior Claude review comment; this run did not review the current head or validate the earlier run' }
     : undefined;
 }
 
-function classify({ diagnostic, sha, currentSha, comments, inline, marker, findingMarker, started, actionOutcome, draft = false, state = 'open' }) {
+function classify({ diagnostic, sha, currentSha, comments, inline, marker, findingMarker, started, actionOutcome, draft = false, state = 'open', runId, runAttempt }) {
   const blocked = (reason) => ({ outcome: 'blocked/failed', reason });
   if (sha !== currentSha) return blocked('PR head changed during review');
   if (actionOutcome !== 'success' || !diagnostic.sdk_success) return blocked('Claude did not complete successfully');
@@ -104,7 +109,7 @@ function classify({ diagnostic, sha, currentSha, comments, inline, marker, findi
     if (diagnostic.reported_reason === 'trivial') {
       return skipped('Upstream plugin classified the change as trivial; this run did not review the current head');
     }
-    const priorSkip = priorReviewSkip({ sha, currentSha, comments, started });
+    const priorSkip = priorReviewSkip({ sha, currentSha, comments, runId, runAttempt });
     if (diagnostic.reported_reason === 'already-reviewed' && priorSkip) {
       return priorSkip;
     }
@@ -148,7 +153,7 @@ async function main() {
       if (sha !== pr.head.sha) {
         result = { outcome: 'blocked/failed', reason: 'PR head changed before review' };
       } else {
-        const skip = priorReviewSkip({ sha, currentSha: pr.head.sha, comments, started: env.REVIEW_STARTED });
+        const skip = priorReviewSkip({ sha, currentSha: pr.head.sha, comments, runId: env.GITHUB_RUN_ID, runAttempt: env.GITHUB_RUN_ATTEMPT });
         fs.appendFileSync(env.GITHUB_OUTPUT, `should_review=${!skip}\n`);
         if (!skip) return;
         result = skip;
@@ -156,7 +161,8 @@ async function main() {
     } else result = classify({ diagnostic, sha, currentSha: pr.head.sha, comments, inline,
       marker: `<!-- deputy-claude-review:${sha}:${env.GITHUB_RUN_ID}:${env.GITHUB_RUN_ATTEMPT}`,
       findingMarker: `[Review run](https://github.com/${env.GITHUB_REPOSITORY}/actions/runs/${env.GITHUB_RUN_ID}/attempts/${env.GITHUB_RUN_ATTEMPT})`,
-      started: env.REVIEW_STARTED, actionOutcome: env.ACTION_OUTCOME, draft: pr.draft, state: pr.state });
+      started: env.REVIEW_STARTED, actionOutcome: env.ACTION_OUTCOME, draft: pr.draft, state: pr.state,
+      runId: env.GITHUB_RUN_ID, runAttempt: env.GITHUB_RUN_ATTEMPT });
   } catch {
     // Errors can include server responses, file contents, or token-bearing URLs.
     // Keep the public failure categorical; never print the caught value.

--- a/.github/scripts/claude-review-outcome.cjs
+++ b/.github/scripts/claude-review-outcome.cjs
@@ -63,6 +63,9 @@ function classify({ diagnostic, sha, currentSha, comments, inline, marker, findi
   const blocked = (reason) => ({ outcome: 'blocked/failed', reason });
   if (sha !== currentSha) return blocked('PR head changed during review');
   if (actionOutcome !== 'success' || !diagnostic.sdk_success) return blocked('Claude did not complete successfully');
+  if (!diagnostic.plugin_calls || !diagnostic.plugin_comment_argument_seen) {
+    return blocked('Upstream review plugin was not invoked with --comment');
+  }
   const fresh = (comment) => comment.user?.login === 'github-actions[bot]' &&
     Date.parse(comment.created_at) >= Date.parse(started) - 5000;
   const summaries = comments.filter(fresh);

--- a/.github/scripts/claude-review-outcome.cjs
+++ b/.github/scripts/claude-review-outcome.cjs
@@ -9,7 +9,6 @@ const knownTools = new Set([
 ]);
 const reportedOutcomes = new Set(['completed-with-findings', 'completed-without-findings', 'skipped', 'blocked']);
 const reportedReasons = new Set(['reviewed', 'draft', 'closed', 'trivial', 'already-reviewed', 'permission-denied', 'diff-unavailable', 'plugin-unavailable', 'subagent-unavailable', 'provider-limit', 'publication-failed', 'policy-conflict', 'other']);
-const eligibilities = new Set(['eligible', 'draft', 'closed', 'prior-comment', 'trivial', 'plugin-unavailable', 'input-unavailable', 'other']);
 const commands = [
   'gh pr view', 'gh pr diff', 'gh pr list', 'gh pr comment',
   'gh issue view', 'gh issue list', 'gh search', 'gh api',
@@ -28,7 +27,6 @@ function diagnostics(messages) {
     plugin_calls: pluginCalls.length,
     plugin_comment_argument_seen: pluginCalls.some((call) => typeof call.input?.args === 'string' && /(?:^|\s)--comment(?:\s|$)/.test(call.input.args)),
     review_agent_calls: calls.filter((call) => ['Agent', 'Task'].includes(call.name)).length,
-    reported_eligibility: eligibilities.has(result?.structured_output?.eligibility) ? result.structured_output.eligibility : 'unreported',
     sdk_success: result?.subtype === 'success' && result?.is_error === false,
     reported_outcome: reportedOutcomes.has(result?.structured_output?.outcome) ? result.structured_output.outcome : 'unreported',
     reported_reason: reportedReasons.has(result?.structured_output?.reason) ? result.structured_output.reason : 'unreported',
@@ -52,7 +50,7 @@ function diagnostics(messages) {
   };
 }
 
-function classify({ diagnostic, sha, currentSha, comments, inline, marker, findingMarker, started, actionOutcome }) {
+function classify({ diagnostic, sha, currentSha, comments, inline, marker, findingMarker, started, actionOutcome, draft = false, state = 'open' }) {
   const blocked = (reason) => ({ outcome: 'blocked/failed', reason });
   if (sha !== currentSha) return blocked('PR head changed during review');
   if (actionOutcome !== 'success' || !diagnostic.sdk_success) return blocked('Claude did not complete successfully');
@@ -70,6 +68,25 @@ function classify({ diagnostic, sha, currentSha, comments, inline, marker, findi
     return { outcome: 'completed without findings', reason: 'Current-run exact-commit clean summary verified' };
   }
   if (diagnostic.permission_denials_count) return blocked('Denied tools and no verified review evidence');
+  if (!withFindings && !withoutFindings && !findings.length &&
+      diagnostic.plugin_calls > 0 && diagnostic.reported_outcome === 'skipped') {
+    const skipped = (reason) => ({ outcome: 'intentionally skipped', reason });
+    if (diagnostic.reported_reason === 'draft' && draft) {
+      return skipped('PR is now a draft; this run did not review the current head');
+    }
+    if (diagnostic.reported_reason === 'closed' && state === 'closed') {
+      return skipped('PR is now closed; this run did not review the current head');
+    }
+    if (diagnostic.reported_reason === 'trivial') {
+      return skipped('Upstream plugin classified the change as trivial; this run did not review the current head');
+    }
+    const priorReview = comments.some((comment) => comment.user?.login === 'github-actions[bot]' &&
+      Date.parse(comment.created_at) < Date.parse(started) &&
+      /<!-- deputy-claude-review:[a-f0-9]{40}:\d+:\d+:(?:with|without)-findings -->/.test(comment.body || ''));
+    if (diagnostic.reported_reason === 'already-reviewed' && priorReview) {
+      return skipped('Upstream plugin found a prior Claude review; this run did not review the current head');
+    }
+  }
   return blocked('No consistent current-run exact-commit review evidence');
 }
 
@@ -105,12 +122,12 @@ async function main() {
     result = classify({ diagnostic, sha, currentSha: pr.head.sha, comments, inline,
       marker: `<!-- deputy-claude-review:${sha}:${env.GITHUB_RUN_ID}:${env.GITHUB_RUN_ATTEMPT}`,
       findingMarker: `[Review run](https://github.com/${env.GITHUB_REPOSITORY}/actions/runs/${env.GITHUB_RUN_ID}/attempts/${env.GITHUB_RUN_ATTEMPT})`,
-      started: env.REVIEW_STARTED, actionOutcome: env.ACTION_OUTCOME });
+      started: env.REVIEW_STARTED, actionOutcome: env.ACTION_OUTCOME, draft: pr.draft, state: pr.state });
   } catch {
     // Errors can include server responses, file contents, or token-bearing URLs.
     // Keep the public failure categorical; never print the caught value.
   }
-  const safe = { ...result, reviewed_sha: sha, ...diagnostic };
+  const safe = { ...result, target_sha: sha, ...diagnostic };
   fs.writeFileSync(`${env.RUNNER_TEMP}/claude-review-outcome.json`, JSON.stringify(safe, null, 2));
   fs.appendFileSync(env.GITHUB_STEP_SUMMARY,
     `### Claude review: ${safe.outcome}\n\nCommit: \`${sha}\`\n\n${safe.reason}.\n\n` +

--- a/.github/scripts/claude-review-outcome.cjs
+++ b/.github/scripts/claude-review-outcome.cjs
@@ -10,6 +10,7 @@ const commands = [
   'gh pr view', 'gh pr diff', 'gh pr list', 'gh pr comment',
   'gh issue view', 'gh issue list', 'gh search', 'gh api',
   'git diff', 'git show', 'git log', 'git rev-parse',
+  'cat', 'ls', 'find', 'sed', 'head', 'tail', 'wc', 'rg', 'grep', 'pwd',
 ];
 
 function diagnostics(messages) {
@@ -21,6 +22,8 @@ function diagnostics(messages) {
     permission_denials_count: denials.length,
     denied_operations: [...new Set(denials.map((denial) => {
       const tool = knownTools.has(denial.tool_name) ? denial.tool_name : 'other-tool';
+      if (tool === 'Skill') return denial.tool_input?.skill === 'code-review:code-review'
+        ? 'Skill(code-review:code-review)' : 'Skill(other-skill)';
       if (tool !== 'Bash') return tool;
       const command = denial.tool_input?.command;
       const prefix = typeof command === 'string' && commands.find((candidate) =>
@@ -38,7 +41,8 @@ function classify({ diagnostic, sha, currentSha, comments, inline, marker, start
   const fresh = (comment) => comment.user?.login === 'github-actions[bot]' &&
     Date.parse(comment.created_at) >= Date.parse(started);
   const summaries = comments.filter(fresh);
-  const findings = inline.filter((comment) => fresh(comment) && comment.commit_id === sha);
+  const findings = inline.filter((comment) => fresh(comment) && comment.commit_id === sha &&
+    comment.body?.includes(`${marker}:finding -->`));
   const withFindings = summaries.some((comment) => comment.body?.includes(`${marker}:with-findings -->`));
   const withoutFindings = summaries.some((comment) => comment.body?.includes(`${marker}:without-findings -->`));
   if (withFindings && !withoutFindings && findings.length) {

--- a/.github/scripts/claude-review-outcome.cjs
+++ b/.github/scripts/claude-review-outcome.cjs
@@ -64,7 +64,7 @@ function priorReviewSkip({ sha, currentSha, comments, started }) {
     Date.parse(comment.created_at) < Date.parse(started) &&
     /<!-- deputy-claude-review:[a-f0-9]{40}:\d+:\d+:(?:with|without)-findings -->/.test(comment.body || ''));
   return sha === currentSha && priorReview
-    ? { outcome: 'intentionally skipped', reason: 'Upstream policy skips a prior Claude review; this run did not review the current head' }
+    ? { outcome: 'intentionally skipped', reason: 'Upstream policy skips a prior Claude review comment; this run did not review the current head or validate the earlier run' }
     : undefined;
 }
 

--- a/.github/scripts/claude-review-outcome.cjs
+++ b/.github/scripts/claude-review-outcome.cjs
@@ -3,7 +3,8 @@ const fs = require('node:fs');
 
 const knownTools = new Set([
   'Agent', 'Task', 'TaskOutput', 'TaskCreate', 'TaskUpdate', 'TaskList',
-  'TodoWrite', 'Skill', 'Read', 'Glob', 'Grep', 'Bash',
+  'TodoWrite', 'Skill', 'Read', 'Glob', 'Grep', 'Bash', 'ToolSearch',
+  'TaskGet', 'TaskStop', 'SendMessage', 'EnterPlanMode', 'ExitPlanMode',
   'mcp__github_inline_comment__create_inline_comment',
 ]);
 const commands = [
@@ -39,16 +40,15 @@ function diagnostics(messages) {
   };
 }
 
-function classify({ diagnostic, sha, currentSha, comments, inline, marker, started, actionOutcome }) {
+function classify({ diagnostic, sha, currentSha, comments, inline, marker, findingMarker, started, actionOutcome }) {
   const blocked = (reason) => ({ outcome: 'blocked/failed', reason });
   if (sha !== currentSha) return blocked('PR head changed during review');
   if (actionOutcome !== 'success' || !diagnostic.sdk_success) return blocked('Claude did not complete successfully');
-  if (diagnostic.permission_denials_count) return blocked('Claude tool permission denied');
   const fresh = (comment) => comment.user?.login === 'github-actions[bot]' &&
     Date.parse(comment.created_at) >= Date.parse(started) - 5000;
   const summaries = comments.filter(fresh);
   const findings = inline.filter((comment) => fresh(comment) && comment.commit_id === sha &&
-    comment.body?.includes(`${marker}:finding -->`));
+    comment.body?.includes(findingMarker));
   const withFindings = summaries.some((comment) => comment.body?.includes(`${marker}:with-findings -->`));
   const withoutFindings = summaries.some((comment) => comment.body?.includes(`${marker}:without-findings -->`));
   if (withFindings && !withoutFindings && findings.length) {
@@ -57,6 +57,7 @@ function classify({ diagnostic, sha, currentSha, comments, inline, marker, start
   if (withoutFindings && !withFindings && !findings.length) {
     return { outcome: 'completed without findings', reason: 'Current-run exact-commit clean summary verified' };
   }
+  if (diagnostic.permission_denials_count) return blocked('Denied tools and no verified review evidence');
   return blocked('No consistent current-run exact-commit review evidence');
 }
 
@@ -91,6 +92,7 @@ async function main() {
     ]);
     result = classify({ diagnostic, sha, currentSha: pr.head.sha, comments, inline,
       marker: `<!-- deputy-claude-review:${sha}:${env.GITHUB_RUN_ID}:${env.GITHUB_RUN_ATTEMPT}`,
+      findingMarker: `[Review run](https://github.com/${env.GITHUB_REPOSITORY}/actions/runs/${env.GITHUB_RUN_ID}/attempts/${env.GITHUB_RUN_ATTEMPT})`,
       started: env.REVIEW_STARTED, actionOutcome: env.ACTION_OUTCOME });
   } catch {
     // Errors can include server responses, file contents, or token-bearing URLs.

--- a/.github/scripts/claude-review-outcome.test.cjs
+++ b/.github/scripts/claude-review-outcome.test.cjs
@@ -11,8 +11,11 @@ const findingMarker = "[Review run](https://github.com/example/deputy/actions/ru
 const comment = (outcome) => ({ user: { login: 'github-actions[bot]' },
   created_at: '2026-09-06T12:01:00Z', body: `${marker}:${outcome} -->` });
 const context = () => ({ diagnostic: diagnostics([{ type: 'assistant', message: { content: [
-  { type: 'tool_use', name: 'Skill', input: { skill: 'code-review:code-review', args: 'example/deputy/pull/131 --comment' } },
-  { type: 'tool_use', name: 'Agent', input: { prompt: 'Review the current PR diff' } },
+  { type: 'tool_use', id: 'skill-1', name: 'Skill', input: { skill: 'code-review:code-review', args: 'example/deputy/pull/131 --comment' } },
+  { type: 'tool_use', id: 'agent-1', name: 'Agent', input: { prompt: 'Review the current PR diff' } },
+] } }, { type: 'user', message: { content: [
+  { type: 'tool_result', tool_use_id: 'skill-1', content: 'Plugin instructions' },
+  { type: 'tool_result', tool_use_id: 'agent-1', content: 'Review result' },
 ] } }, { type: 'result', subtype: 'success',
   is_error: false, permission_denials: [] }]), sha, currentSha: sha, comments: [], inline: [],
   marker, findingMarker, started: '2026-09-06T12:00:00Z', actionOutcome: 'success' });
@@ -23,7 +26,7 @@ test('SDK success alone cannot claim a clean review', () => {
 });
 
 test('upstream skips remain distinct from current-head completion', () => {
-  const diagnostic = { ...context().diagnostic, plugin_calls: 1, review_agent_calls: 0,
+  const diagnostic = { ...context().diagnostic, plugin_calls: 1, review_agent_calls: 0, review_agent_successes: 0,
     reported_outcome: 'skipped', reported_reason: 'already-reviewed' };
   const priorReview = { ...comment('without-findings'), created_at: '2026-09-05T12:00:00Z',
     body: `<!-- deputy-claude-review:${'b'.repeat(40)}:122:1:without-findings -->` };
@@ -100,6 +103,8 @@ test('clean and findings outcomes require current-run bot evidence', () => {
   assert.equal(classify({ ...clean, diagnostic: { ...clean.diagnostic, plugin_calls: 0 } }).outcome, 'blocked/failed');
   assert.equal(classify({ ...clean, diagnostic: { ...clean.diagnostic, plugin_comment_argument_seen: false } }).outcome, 'blocked/failed');
   assert.equal(classify({ ...clean, diagnostic: { ...clean.diagnostic, review_agent_calls: 0 } }).outcome, 'blocked/failed');
+  assert.equal(classify({ ...clean, diagnostic: { ...clean.diagnostic, review_agent_successes: 0 } }).outcome, 'blocked/failed');
+  assert.equal(classify({ ...clean, diagnostic: { ...clean.diagnostic, plugin_successes: 0 } }).outcome, 'blocked/failed');
   assert.equal(classify({ ...clean, comments: [{ ...clean.comments[0], created_at: '2026-09-06T11:59:58Z' }] }).outcome, 'completed without findings');
   const findings = { ...context(), comments: [comment('with-findings')],
     inline: [{ ...comment('finding'), body: findingMarker, commit_id: sha }] };
@@ -121,8 +126,11 @@ test('clean and findings outcomes require current-run bot evidence', () => {
 test('diagnostics never emit free-form names, command arguments, or SDK text', () => {
   const secret = 'CANARY_PRIVATE_VALUE';
   const diagnostic = diagnostics([{ type: 'assistant', message: { content: [
-    { type: 'tool_use', name: 'Skill', input: { skill: 'code-review:code-review', args: `${secret} --comment` } },
-    { type: 'tool_use', name: 'Agent', input: { prompt: secret } },
+    { type: 'tool_use', id: 'skill-1', name: 'Skill', input: { skill: 'code-review:code-review', args: `${secret} --comment` } },
+    { type: 'tool_use', id: 'agent-1', name: 'Agent', input: { prompt: secret } },
+  ] } }, { type: 'user', message: { content: [
+    { type: 'tool_result', tool_use_id: 'skill-1', content: secret },
+    { type: 'tool_result', tool_use_id: 'agent-1', content: secret },
   ] } }, { type: 'result', subtype: 'success', is_error: false,
     result: secret, structured_output: { outcome: secret, reason: secret }, permission_denials: [
       { tool_name: 'Bash', tool_input: { command: `gh pr comment 123 --body ${secret} | head -10 > ${secret}` } },
@@ -132,9 +140,39 @@ test('diagnostics never emit free-form names, command arguments, or SDK text', (
     ] }]);
   assert.equal(JSON.stringify(diagnostic).includes(secret), false);
   assert.equal(diagnostic.plugin_calls, 1);
+  assert.equal(diagnostic.plugin_successes, 1);
   assert.equal(diagnostic.plugin_comment_argument_seen, true);
   assert.equal(diagnostic.review_agent_calls, 1);
+  assert.equal(diagnostic.review_agent_successes, 1);
   assert.deepEqual(diagnostic.denied_operations, ['Bash(gh pr comment)', 'Bash(head)', 'Bash(other-command)', 'Bash(shell-redirection)', 'Skill(other-skill)', 'other-tool']);
   assert.equal(classify({ ...context(), diagnostic }).outcome, 'blocked/failed');
   assert.equal(classify({ ...context(), diagnostic, comments: [comment('without-findings')] }).outcome, 'completed without findings');
+});
+
+test('denied and failed tool attempts do not count as upstream execution', () => {
+  for (const name of ['Skill', 'Agent', 'Task']) {
+    const call = { type: 'tool_use', id: 'attempt-1', name,
+      input: name === 'Skill' ? { skill: 'code-review:code-review', args: '--comment' } : {} };
+    const attempt = [{ type: 'assistant', message: { content: [call] } }];
+    const successResult = { type: 'result', subtype: 'success', is_error: false, permission_denials: [] };
+    const failed = { type: 'user', message: { content: [{ type: 'tool_result', tool_use_id: call.id, is_error: true }] } };
+    const successful = { type: 'user', message: { content: [{ type: 'tool_result', tool_use_id: call.id, is_error: false }] } };
+    for (const messages of [
+      [...attempt, successResult], [...attempt, failed, successResult],
+      [...attempt, successful, { ...successResult, permission_denials: [{ tool_name: name, tool_use_id: call.id }] }],
+    ]) {
+      const diagnostic = diagnostics(messages);
+      assert.equal(diagnostic.plugin_successes, 0);
+      assert.equal(diagnostic.review_agent_successes, 0);
+      assert.equal(diagnostic.plugin_comment_argument_seen, false);
+    }
+    const diagnostic = diagnostics([...attempt, successful, successResult]);
+    assert.equal(name === 'Skill' ? diagnostic.plugin_successes : diagnostic.review_agent_successes, 1);
+    if (name !== 'Skill') {
+      const background = diagnostics([{ type: 'assistant', message: { content: [
+        { ...call, input: { run_in_background: true } },
+      ] } }, successful, successResult]);
+      assert.equal(background.review_agent_successes, 0);
+    }
+  }
 });

--- a/.github/scripts/claude-review-outcome.test.cjs
+++ b/.github/scripts/claude-review-outcome.test.cjs
@@ -37,7 +37,7 @@ test('clean and findings outcomes require current-run bot evidence', () => {
 test('diagnostics never emit free-form names, command arguments, or SDK text', () => {
   const secret = 'CANARY_PRIVATE_VALUE';
   const diagnostic = diagnostics([{ type: 'result', subtype: 'success', is_error: false,
-    result: secret, permission_denials: [
+    result: secret, structured_output: { outcome: secret, reason: secret }, permission_denials: [
       { tool_name: 'Bash', tool_input: { command: `gh pr comment 123 --body ${secret} | head -10 > ${secret}` } },
       { tool_name: secret, tool_input: { command: secret } },
       { tool_name: 'Skill', tool_input: { skill: secret } },

--- a/.github/scripts/claude-review-outcome.test.cjs
+++ b/.github/scripts/claude-review-outcome.test.cjs
@@ -17,6 +17,7 @@ test('SDK success alone cannot claim a clean review', () => {
 test('clean and findings outcomes require current-run bot evidence', () => {
   const clean = { ...context(), comments: [comment('without-findings')] };
   assert.equal(classify(clean).outcome, 'completed without findings');
+  assert.equal(classify({ ...clean, comments: [{ ...clean.comments[0], created_at: '2026-09-06T11:59:58Z' }] }).outcome, 'completed without findings');
   const findings = { ...context(), comments: [comment('with-findings')],
     inline: [{ ...comment('finding'), commit_id: sha }] };
   assert.equal(classify(findings).outcome, 'completed with findings');
@@ -36,12 +37,12 @@ test('diagnostics never emit free-form names, command arguments, or SDK text', (
   const secret = 'CANARY_PRIVATE_VALUE';
   const diagnostic = diagnostics([{ type: 'result', subtype: 'success', is_error: false,
     result: secret, permission_denials: [
-      { tool_name: 'Bash', tool_input: { command: `gh pr comment 123 --body ${secret}` } },
+      { tool_name: 'Bash', tool_input: { command: `gh pr comment 123 --body ${secret} | head -10 > ${secret}` } },
       { tool_name: secret, tool_input: { command: secret } },
       { tool_name: 'Skill', tool_input: { skill: secret } },
       { tool_name: 'Bash', tool_input: { command: `env ${secret}` } },
     ] }]);
   assert.equal(JSON.stringify(diagnostic).includes(secret), false);
-  assert.deepEqual(diagnostic.denied_operations, ['Bash(gh pr comment)', 'Bash(other-command)', 'Skill(other-skill)', 'other-tool']);
+  assert.deepEqual(diagnostic.denied_operations, ['Bash(gh pr comment)', 'Bash(head)', 'Bash(other-command)', 'Bash(shell-redirection)', 'Skill(other-skill)', 'other-tool']);
   assert.equal(classify({ ...context(), diagnostic, comments: [comment('without-findings')] }).outcome, 'blocked/failed');
 });

--- a/.github/scripts/claude-review-outcome.test.cjs
+++ b/.github/scripts/claude-review-outcome.test.cjs
@@ -18,7 +18,7 @@ const context = () => ({ diagnostic: diagnostics([{ type: 'assistant', message: 
   { type: 'tool_result', tool_use_id: 'agent-1', content: 'Review result' },
 ] } }, { type: 'result', subtype: 'success',
   is_error: false, permission_denials: [] }]), sha, currentSha: sha, comments: [], inline: [],
-  marker, findingMarker, started: '2026-09-06T12:00:00Z', actionOutcome: 'success' });
+  marker, findingMarker, started: '2026-09-06T12:00:00Z', actionOutcome: 'success', runId: '123', runAttempt: '1' });
 
 test('SDK success alone cannot claim a clean review', () => {
   assert.equal(classify(context()).outcome, 'blocked/failed');
@@ -35,6 +35,12 @@ test('upstream skips remain distinct from current-head completion', () => {
   assert.equal(priorReviewSkip({ ...prior, currentSha: 'b'.repeat(40) }), undefined);
   assert.equal(priorReviewSkip({ ...prior, comments: [] }), undefined);
   assert.equal(priorReviewSkip({ ...prior, comments: [{ ...priorReview, user: { login: 'someone' } }] }), undefined);
+  const raced = { ...prior, comments: [{ ...priorReview, created_at: '2026-09-06T12:01:00Z' }] };
+  assert.equal(priorReviewSkip(raced).outcome, 'intentionally skipped');
+  assert.equal(classify(raced).outcome, 'intentionally skipped');
+  assert.equal(priorReviewSkip({ ...prior, runId: '122', runAttempt: '2' }).outcome, 'intentionally skipped');
+  assert.equal(priorReviewSkip({ ...prior, runId: '122', runAttempt: '1' }), undefined);
+  assert.equal(priorReviewSkip({ ...prior, runId: undefined }), undefined);
   assert.equal(classify(prior).outcome, 'intentionally skipped');
   assert.match(classify(prior).reason, /this run did not review the current head/);
   for (const replacement of [
@@ -43,7 +49,7 @@ test('upstream skips remain distinct from current-head completion', () => {
     { diagnostic: { ...diagnostic, plugin_calls: 0 } },
     { diagnostic: { ...diagnostic, permission_denials_count: 1 } },
     { comments: [{ ...priorReview, user: { login: 'someone' } }] },
-    { comments: [{ ...priorReview, created_at: '2026-09-06T12:01:00Z' }] },
+    { runId: '122', runAttempt: '1' },
     { comments: [{ ...priorReview, body: 'An unrelated older bot comment' }] },
   ]) assert.equal(classify({ ...prior, ...replacement }).outcome, 'blocked/failed');
   for (const [reason, evidence] of [['draft', { draft: true }], ['closed', { state: 'closed' }], ['trivial', {}]]) {
@@ -63,7 +69,8 @@ test('preflight skips SDK only with prior-review evidence and fails closed on AP
         ? { head: { sha: process.env.TEST_CURRENT_SHA } }
         : JSON.parse(process.env.TEST_COMMENTS),
     });`);
-    const prior = { ...comment('without-findings'), created_at: '2026-09-05T12:00:00Z' };
+    const prior = { ...comment('without-findings'), created_at: '2026-09-05T12:00:00Z',
+      body: `<!-- deputy-claude-review:${sha}:122:1:without-findings -->` };
     for (const [scenario, overrides, expected] of [
       ['prior', {}, 'intentionally skipped'],
       ['new', { TEST_COMMENTS: '[]' }, undefined],
@@ -76,6 +83,7 @@ test('preflight skips SDK only with prior-review evidence and fails closed on AP
       const result = spawnSync(process.execPath, ['--require', preload, path.join(__dirname, 'claude-review-outcome.cjs')], {
         encoding: 'utf8', env: { ...process.env, REVIEW_PREFLIGHT: 'true', REVIEW_SHA: sha,
           REVIEW_STARTED: context().started, PR_NUMBER: '131', GITHUB_REPOSITORY: 'example/deputy',
+          GITHUB_RUN_ID: '123', GITHUB_RUN_ATTEMPT: '1',
           GITHUB_OUTPUT: output, GITHUB_STEP_SUMMARY: path.join(runDirectory, 'summary'), RUNNER_TEMP: runDirectory,
           TEST_CURRENT_SHA: sha, TEST_COMMENTS: JSON.stringify([prior]), ...overrides },
       });

--- a/.github/scripts/claude-review-outcome.test.cjs
+++ b/.github/scripts/claude-review-outcome.test.cjs
@@ -1,0 +1,46 @@
+const { test } = require('node:test');
+const assert = require('node:assert/strict');
+const { diagnostics, classify } = require('./claude-review-outcome.cjs');
+const sha = 'a'.repeat(40);
+const marker = `<!-- deputy-claude-review:${sha}:123:1`;
+const comment = (outcome) => ({ user: { login: 'claude[bot]' },
+  created_at: '2026-09-06T12:01:00Z', body: `${marker}:${outcome} -->` });
+const context = () => ({ diagnostic: diagnostics([{ type: 'result', subtype: 'success',
+  is_error: false, permission_denials: [] }]), sha, currentSha: sha, comments: [], inline: [],
+  marker, started: '2026-09-06T12:00:00Z', actionOutcome: 'success' });
+
+test('SDK success alone cannot claim a clean review', () => {
+  assert.equal(classify(context()).outcome, 'blocked/failed');
+  assert.equal(diagnostics([]).sdk_success, false);
+});
+
+test('clean and findings outcomes require current-run bot evidence', () => {
+  const clean = { ...context(), comments: [comment('without-findings')] };
+  assert.equal(classify(clean).outcome, 'completed without findings');
+  const findings = { ...context(), comments: [comment('with-findings')],
+    inline: [{ ...comment('with-findings'), commit_id: sha }] };
+  assert.equal(classify(findings).outcome, 'completed with findings');
+  assert.equal(classify({ ...findings, inline: [] }).outcome, 'blocked/failed');
+  assert.equal(classify({ ...findings, inline: [{ ...findings.inline[0], commit_id: 'b'.repeat(40) }] }).outcome, 'blocked/failed');
+  for (const replacement of [
+    { user: { login: 'someone' } }, { created_at: '2026-09-05T00:00:00Z' },
+    { body: '<!-- deputy-claude-review:old -->' },
+  ]) assert.equal(classify({ ...clean, comments: [{ ...clean.comments[0], ...replacement }] }).outcome, 'blocked/failed');
+  assert.equal(classify({ ...clean, currentSha: 'b'.repeat(40) }).outcome, 'blocked/failed');
+  assert.equal(classify({ ...clean, actionOutcome: 'failure' }).outcome, 'blocked/failed');
+  assert.equal(classify({ ...clean, inline: findings.inline }).outcome, 'blocked/failed');
+});
+
+test('diagnostics never emit free-form names, command arguments, or SDK text', () => {
+  const secret = 'CANARY_PRIVATE_VALUE';
+  const diagnostic = diagnostics([{ type: 'result', subtype: 'success', is_error: false,
+    result: secret, permission_denials: [
+      { tool_name: 'Bash', tool_input: { command: `gh pr comment 123 --body ${secret}` } },
+      { tool_name: secret, tool_input: { command: secret } },
+      { tool_name: 'Skill', tool_input: { skill: secret } },
+      { tool_name: 'Bash', tool_input: { command: `env ${secret}` } },
+    ] }]);
+  assert.equal(JSON.stringify(diagnostic).includes(secret), false);
+  assert.deepEqual(diagnostic.denied_operations, ['Bash(gh pr comment)', 'Bash(other-command)', 'Skill', 'other-tool']);
+  assert.equal(classify({ ...context(), diagnostic, comments: [comment('without-findings')] }).outcome, 'blocked/failed');
+});

--- a/.github/scripts/claude-review-outcome.test.cjs
+++ b/.github/scripts/claude-review-outcome.test.cjs
@@ -1,6 +1,10 @@
 const { test } = require('node:test');
 const assert = require('node:assert/strict');
-const { diagnostics, classify } = require('./claude-review-outcome.cjs');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+const { spawnSync } = require('node:child_process');
+const { diagnostics, classify, priorReviewSkip } = require('./claude-review-outcome.cjs');
 const sha = 'a'.repeat(40);
 const marker = `<!-- deputy-claude-review:${sha}:123:1`;
 const findingMarker = "[Review run](https://github.com/example/deputy/actions/runs/123/attempts/1)";
@@ -21,6 +25,10 @@ test('upstream skips remain distinct from current-head completion', () => {
   const priorReview = { ...comment('without-findings'), created_at: '2026-09-05T12:00:00Z',
     body: `<!-- deputy-claude-review:${'b'.repeat(40)}:122:1:without-findings -->` };
   const prior = { ...context(), diagnostic, comments: [priorReview] };
+  assert.equal(priorReviewSkip(prior).outcome, 'intentionally skipped');
+  assert.equal(priorReviewSkip({ ...prior, currentSha: 'b'.repeat(40) }), undefined);
+  assert.equal(priorReviewSkip({ ...prior, comments: [] }), undefined);
+  assert.equal(priorReviewSkip({ ...prior, comments: [{ ...priorReview, user: { login: 'someone' } }] }), undefined);
   assert.equal(classify(prior).outcome, 'intentionally skipped');
   assert.match(classify(prior).reason, /this run did not review the current head/);
   for (const replacement of [
@@ -36,6 +44,50 @@ test('upstream skips remain distinct from current-head completion', () => {
     const skipped = { ...context(), ...evidence, diagnostic: { ...diagnostic, reported_reason: reason } };
     assert.equal(classify(skipped).outcome, 'intentionally skipped');
     if (reason !== 'trivial') assert.equal(classify({ ...skipped, draft: false, state: 'open' }).outcome, 'blocked/failed');
+  }
+});
+
+test('preflight skips SDK only with prior-review evidence and fails closed on API errors', () => {
+  const directory = fs.mkdtempSync(path.join(os.tmpdir(), 'deputy-review-preflight-'));
+  try {
+    const preload = path.join(directory, 'fetch.cjs');
+    fs.writeFileSync(preload, `global.fetch = async (url) => ({
+      ok: process.env.TEST_API_FAIL !== 'true',
+      json: async () => url.endsWith('/pulls/131')
+        ? { head: { sha: process.env.TEST_CURRENT_SHA } }
+        : JSON.parse(process.env.TEST_COMMENTS),
+    });`);
+    const prior = { ...comment('without-findings'), created_at: '2026-09-05T12:00:00Z' };
+    for (const [scenario, overrides, expected] of [
+      ['prior', {}, 'intentionally skipped'],
+      ['new', { TEST_COMMENTS: '[]' }, undefined],
+      ['changed', { TEST_CURRENT_SHA: 'b'.repeat(40) }, 'blocked/failed'],
+      ['api-error', { TEST_API_FAIL: 'true' }, 'blocked/failed'],
+    ]) {
+      const runDirectory = path.join(directory, scenario);
+      fs.mkdirSync(runDirectory);
+      const output = path.join(runDirectory, 'output');
+      const result = spawnSync(process.execPath, ['--require', preload, path.join(__dirname, 'claude-review-outcome.cjs')], {
+        encoding: 'utf8', env: { ...process.env, REVIEW_PREFLIGHT: 'true', REVIEW_SHA: sha,
+          REVIEW_STARTED: context().started, PR_NUMBER: '131', GITHUB_REPOSITORY: 'example/deputy',
+          GITHUB_OUTPUT: output, GITHUB_STEP_SUMMARY: path.join(runDirectory, 'summary'), RUNNER_TEMP: runDirectory,
+          TEST_CURRENT_SHA: sha, TEST_COMMENTS: JSON.stringify([prior]), ...overrides },
+      });
+      assert.equal(result.status, expected === 'blocked/failed' ? 1 : 0);
+      const artifact = path.join(runDirectory, 'claude-review-outcome.json');
+      if (expected) {
+        const outcome = JSON.parse(fs.readFileSync(artifact, 'utf8'));
+        assert.equal(outcome.outcome, expected);
+        assert.equal(outcome.stage, 'eligibility');
+        assert.equal(outcome.sdk_success, false);
+        assert.equal(fs.existsSync(output) && fs.readFileSync(output, 'utf8').includes('should_review=true'), false);
+      } else {
+        assert.equal(fs.readFileSync(output, 'utf8'), 'should_review=true\n');
+        assert.equal(fs.existsSync(artifact), false);
+      }
+    }
+  } finally {
+    fs.rmSync(directory, { recursive: true, force: true });
   }
 });
 

--- a/.github/scripts/claude-review-outcome.test.cjs
+++ b/.github/scripts/claude-review-outcome.test.cjs
@@ -10,7 +10,9 @@ const marker = `<!-- deputy-claude-review:${sha}:123:1`;
 const findingMarker = "[Review run](https://github.com/example/deputy/actions/runs/123/attempts/1)";
 const comment = (outcome) => ({ user: { login: 'github-actions[bot]' },
   created_at: '2026-09-06T12:01:00Z', body: `${marker}:${outcome} -->` });
-const context = () => ({ diagnostic: diagnostics([{ type: 'result', subtype: 'success',
+const context = () => ({ diagnostic: diagnostics([{ type: 'assistant', message: { content: [
+  { type: 'tool_use', name: 'Skill', input: { skill: 'code-review:code-review', args: 'example/deputy/pull/131 --comment' } },
+] } }, { type: 'result', subtype: 'success',
   is_error: false, permission_denials: [] }]), sha, currentSha: sha, comments: [], inline: [],
   marker, findingMarker, started: '2026-09-06T12:00:00Z', actionOutcome: 'success' });
 
@@ -94,10 +96,13 @@ test('preflight skips SDK only with prior-review evidence and fails closed on AP
 test('clean and findings outcomes require current-run bot evidence', () => {
   const clean = { ...context(), comments: [comment('without-findings')] };
   assert.equal(classify(clean).outcome, 'completed without findings');
+  assert.equal(classify({ ...clean, diagnostic: { ...clean.diagnostic, plugin_calls: 0 } }).outcome, 'blocked/failed');
+  assert.equal(classify({ ...clean, diagnostic: { ...clean.diagnostic, plugin_comment_argument_seen: false } }).outcome, 'blocked/failed');
   assert.equal(classify({ ...clean, comments: [{ ...clean.comments[0], created_at: '2026-09-06T11:59:58Z' }] }).outcome, 'completed without findings');
   const findings = { ...context(), comments: [comment('with-findings')],
     inline: [{ ...comment('finding'), body: findingMarker, commit_id: sha }] };
   assert.equal(classify(findings).outcome, 'completed with findings');
+  assert.equal(classify({ ...findings, diagnostic: { ...findings.diagnostic, plugin_calls: 0 } }).outcome, 'blocked/failed');
   assert.equal(classify({ ...findings, inline: [] }).outcome, 'blocked/failed');
   assert.equal(classify({ ...findings, inline: [{ ...findings.inline[0], body: 'Unrelated concurrent bot finding' }] }).outcome, 'blocked/failed');
   assert.equal(classify({ ...findings, inline: [{ ...findings.inline[0], commit_id: 'b'.repeat(40) }] }).outcome, 'blocked/failed');

--- a/.github/scripts/claude-review-outcome.test.cjs
+++ b/.github/scripts/claude-review-outcome.test.cjs
@@ -3,11 +3,12 @@ const assert = require('node:assert/strict');
 const { diagnostics, classify } = require('./claude-review-outcome.cjs');
 const sha = 'a'.repeat(40);
 const marker = `<!-- deputy-claude-review:${sha}:123:1`;
+const findingMarker = "[Review run](https://github.com/example/deputy/actions/runs/123/attempts/1)";
 const comment = (outcome) => ({ user: { login: 'github-actions[bot]' },
   created_at: '2026-09-06T12:01:00Z', body: `${marker}:${outcome} -->` });
 const context = () => ({ diagnostic: diagnostics([{ type: 'result', subtype: 'success',
   is_error: false, permission_denials: [] }]), sha, currentSha: sha, comments: [], inline: [],
-  marker, started: '2026-09-06T12:00:00Z', actionOutcome: 'success' });
+  marker, findingMarker, started: '2026-09-06T12:00:00Z', actionOutcome: 'success' });
 
 test('SDK success alone cannot claim a clean review', () => {
   assert.equal(classify(context()).outcome, 'blocked/failed');
@@ -19,7 +20,7 @@ test('clean and findings outcomes require current-run bot evidence', () => {
   assert.equal(classify(clean).outcome, 'completed without findings');
   assert.equal(classify({ ...clean, comments: [{ ...clean.comments[0], created_at: '2026-09-06T11:59:58Z' }] }).outcome, 'completed without findings');
   const findings = { ...context(), comments: [comment('with-findings')],
-    inline: [{ ...comment('finding'), commit_id: sha }] };
+    inline: [{ ...comment('finding'), body: findingMarker, commit_id: sha }] };
   assert.equal(classify(findings).outcome, 'completed with findings');
   assert.equal(classify({ ...findings, inline: [] }).outcome, 'blocked/failed');
   assert.equal(classify({ ...findings, inline: [{ ...findings.inline[0], body: 'Unrelated concurrent bot finding' }] }).outcome, 'blocked/failed');
@@ -44,5 +45,6 @@ test('diagnostics never emit free-form names, command arguments, or SDK text', (
     ] }]);
   assert.equal(JSON.stringify(diagnostic).includes(secret), false);
   assert.deepEqual(diagnostic.denied_operations, ['Bash(gh pr comment)', 'Bash(head)', 'Bash(other-command)', 'Bash(shell-redirection)', 'Skill(other-skill)', 'other-tool']);
-  assert.equal(classify({ ...context(), diagnostic, comments: [comment('without-findings')] }).outcome, 'blocked/failed');
+  assert.equal(classify({ ...context(), diagnostic }).outcome, 'blocked/failed');
+  assert.equal(classify({ ...context(), diagnostic, comments: [comment('without-findings')] }).outcome, 'completed without findings');
 });

--- a/.github/scripts/claude-review-outcome.test.cjs
+++ b/.github/scripts/claude-review-outcome.test.cjs
@@ -18,9 +18,10 @@ test('clean and findings outcomes require current-run bot evidence', () => {
   const clean = { ...context(), comments: [comment('without-findings')] };
   assert.equal(classify(clean).outcome, 'completed without findings');
   const findings = { ...context(), comments: [comment('with-findings')],
-    inline: [{ ...comment('with-findings'), commit_id: sha }] };
+    inline: [{ ...comment('finding'), commit_id: sha }] };
   assert.equal(classify(findings).outcome, 'completed with findings');
   assert.equal(classify({ ...findings, inline: [] }).outcome, 'blocked/failed');
+  assert.equal(classify({ ...findings, inline: [{ ...findings.inline[0], body: 'Unrelated concurrent bot finding' }] }).outcome, 'blocked/failed');
   assert.equal(classify({ ...findings, inline: [{ ...findings.inline[0], commit_id: 'b'.repeat(40) }] }).outcome, 'blocked/failed');
   for (const replacement of [
     { user: { login: 'someone' } }, { created_at: '2026-09-05T00:00:00Z' },
@@ -41,6 +42,6 @@ test('diagnostics never emit free-form names, command arguments, or SDK text', (
       { tool_name: 'Bash', tool_input: { command: `env ${secret}` } },
     ] }]);
   assert.equal(JSON.stringify(diagnostic).includes(secret), false);
-  assert.deepEqual(diagnostic.denied_operations, ['Bash(gh pr comment)', 'Bash(other-command)', 'Skill', 'other-tool']);
+  assert.deepEqual(diagnostic.denied_operations, ['Bash(gh pr comment)', 'Bash(other-command)', 'Skill(other-skill)', 'other-tool']);
   assert.equal(classify({ ...context(), diagnostic, comments: [comment('without-findings')] }).outcome, 'blocked/failed');
 });

--- a/.github/scripts/claude-review-outcome.test.cjs
+++ b/.github/scripts/claude-review-outcome.test.cjs
@@ -3,7 +3,7 @@ const assert = require('node:assert/strict');
 const { diagnostics, classify } = require('./claude-review-outcome.cjs');
 const sha = 'a'.repeat(40);
 const marker = `<!-- deputy-claude-review:${sha}:123:1`;
-const comment = (outcome) => ({ user: { login: 'claude[bot]' },
+const comment = (outcome) => ({ user: { login: 'github-actions[bot]' },
   created_at: '2026-09-06T12:01:00Z', body: `${marker}:${outcome} -->` });
 const context = () => ({ diagnostic: diagnostics([{ type: 'result', subtype: 'success',
   is_error: false, permission_denials: [] }]), sha, currentSha: sha, comments: [], inline: [],

--- a/.github/scripts/claude-review-outcome.test.cjs
+++ b/.github/scripts/claude-review-outcome.test.cjs
@@ -12,6 +12,7 @@ const comment = (outcome) => ({ user: { login: 'github-actions[bot]' },
   created_at: '2026-09-06T12:01:00Z', body: `${marker}:${outcome} -->` });
 const context = () => ({ diagnostic: diagnostics([{ type: 'assistant', message: { content: [
   { type: 'tool_use', name: 'Skill', input: { skill: 'code-review:code-review', args: 'example/deputy/pull/131 --comment' } },
+  { type: 'tool_use', name: 'Agent', input: { prompt: 'Review the current PR diff' } },
 ] } }, { type: 'result', subtype: 'success',
   is_error: false, permission_denials: [] }]), sha, currentSha: sha, comments: [], inline: [],
   marker, findingMarker, started: '2026-09-06T12:00:00Z', actionOutcome: 'success' });
@@ -22,7 +23,7 @@ test('SDK success alone cannot claim a clean review', () => {
 });
 
 test('upstream skips remain distinct from current-head completion', () => {
-  const diagnostic = { ...context().diagnostic, plugin_calls: 1,
+  const diagnostic = { ...context().diagnostic, plugin_calls: 1, review_agent_calls: 0,
     reported_outcome: 'skipped', reported_reason: 'already-reviewed' };
   const priorReview = { ...comment('without-findings'), created_at: '2026-09-05T12:00:00Z',
     body: `<!-- deputy-claude-review:${'b'.repeat(40)}:122:1:without-findings -->` };
@@ -98,11 +99,13 @@ test('clean and findings outcomes require current-run bot evidence', () => {
   assert.equal(classify(clean).outcome, 'completed without findings');
   assert.equal(classify({ ...clean, diagnostic: { ...clean.diagnostic, plugin_calls: 0 } }).outcome, 'blocked/failed');
   assert.equal(classify({ ...clean, diagnostic: { ...clean.diagnostic, plugin_comment_argument_seen: false } }).outcome, 'blocked/failed');
+  assert.equal(classify({ ...clean, diagnostic: { ...clean.diagnostic, review_agent_calls: 0 } }).outcome, 'blocked/failed');
   assert.equal(classify({ ...clean, comments: [{ ...clean.comments[0], created_at: '2026-09-06T11:59:58Z' }] }).outcome, 'completed without findings');
   const findings = { ...context(), comments: [comment('with-findings')],
     inline: [{ ...comment('finding'), body: findingMarker, commit_id: sha }] };
   assert.equal(classify(findings).outcome, 'completed with findings');
   assert.equal(classify({ ...findings, diagnostic: { ...findings.diagnostic, plugin_calls: 0 } }).outcome, 'blocked/failed');
+  assert.equal(classify({ ...findings, diagnostic: { ...findings.diagnostic, review_agent_calls: 0 } }).outcome, 'blocked/failed');
   assert.equal(classify({ ...findings, inline: [] }).outcome, 'blocked/failed');
   assert.equal(classify({ ...findings, inline: [{ ...findings.inline[0], body: 'Unrelated concurrent bot finding' }] }).outcome, 'blocked/failed');
   assert.equal(classify({ ...findings, inline: [{ ...findings.inline[0], commit_id: 'b'.repeat(40) }] }).outcome, 'blocked/failed');

--- a/.github/scripts/claude-review-outcome.test.cjs
+++ b/.github/scripts/claude-review-outcome.test.cjs
@@ -15,6 +15,30 @@ test('SDK success alone cannot claim a clean review', () => {
   assert.equal(diagnostics([]).sdk_success, false);
 });
 
+test('upstream skips remain distinct from current-head completion', () => {
+  const diagnostic = { ...context().diagnostic, plugin_calls: 1,
+    reported_outcome: 'skipped', reported_reason: 'already-reviewed' };
+  const priorReview = { ...comment('without-findings'), created_at: '2026-09-05T12:00:00Z',
+    body: `<!-- deputy-claude-review:${'b'.repeat(40)}:122:1:without-findings -->` };
+  const prior = { ...context(), diagnostic, comments: [priorReview] };
+  assert.equal(classify(prior).outcome, 'intentionally skipped');
+  assert.match(classify(prior).reason, /this run did not review the current head/);
+  for (const replacement of [
+    { comments: [] }, { currentSha: 'b'.repeat(40) }, { actionOutcome: 'failure' },
+    { diagnostic: { ...diagnostic, sdk_success: false } },
+    { diagnostic: { ...diagnostic, plugin_calls: 0 } },
+    { diagnostic: { ...diagnostic, permission_denials_count: 1 } },
+    { comments: [{ ...priorReview, user: { login: 'someone' } }] },
+    { comments: [{ ...priorReview, created_at: '2026-09-06T12:01:00Z' }] },
+    { comments: [{ ...priorReview, body: 'An unrelated older bot comment' }] },
+  ]) assert.equal(classify({ ...prior, ...replacement }).outcome, 'blocked/failed');
+  for (const [reason, evidence] of [['draft', { draft: true }], ['closed', { state: 'closed' }], ['trivial', {}]]) {
+    const skipped = { ...context(), ...evidence, diagnostic: { ...diagnostic, reported_reason: reason } };
+    assert.equal(classify(skipped).outcome, 'intentionally skipped');
+    if (reason !== 'trivial') assert.equal(classify({ ...skipped, draft: false, state: 'open' }).outcome, 'blocked/failed');
+  }
+});
+
 test('clean and findings outcomes require current-run bot evidence', () => {
   const clean = { ...context(), comments: [comment('without-findings')] };
   assert.equal(classify(clean).outcome, 'completed without findings');
@@ -36,7 +60,10 @@ test('clean and findings outcomes require current-run bot evidence', () => {
 
 test('diagnostics never emit free-form names, command arguments, or SDK text', () => {
   const secret = 'CANARY_PRIVATE_VALUE';
-  const diagnostic = diagnostics([{ type: 'result', subtype: 'success', is_error: false,
+  const diagnostic = diagnostics([{ type: 'assistant', message: { content: [
+    { type: 'tool_use', name: 'Skill', input: { skill: 'code-review:code-review', args: `${secret} --comment` } },
+    { type: 'tool_use', name: 'Agent', input: { prompt: secret } },
+  ] } }, { type: 'result', subtype: 'success', is_error: false,
     result: secret, structured_output: { outcome: secret, reason: secret }, permission_denials: [
       { tool_name: 'Bash', tool_input: { command: `gh pr comment 123 --body ${secret} | head -10 > ${secret}` } },
       { tool_name: secret, tool_input: { command: secret } },
@@ -44,6 +71,9 @@ test('diagnostics never emit free-form names, command arguments, or SDK text', (
       { tool_name: 'Bash', tool_input: { command: `env ${secret}` } },
     ] }]);
   assert.equal(JSON.stringify(diagnostic).includes(secret), false);
+  assert.equal(diagnostic.plugin_calls, 1);
+  assert.equal(diagnostic.plugin_comment_argument_seen, true);
+  assert.equal(diagnostic.review_agent_calls, 1);
   assert.deepEqual(diagnostic.denied_operations, ['Bash(gh pr comment)', 'Bash(head)', 'Bash(other-command)', 'Bash(shell-redirection)', 'Skill(other-skill)', 'other-tool']);
   assert.equal(classify({ ...context(), diagnostic }).outcome, 'blocked/failed');
   assert.equal(classify({ ...context(), diagnostic, comments: [comment('without-findings')] }).outcome, 'completed without findings');

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -80,7 +80,9 @@ jobs:
             closed, trivial, or already-reviewed. Do not post a completion marker
             or claim this run reviewed the current head when it intentionally skips.
             Use the upstream plugin via Skill(code-review:code-review), including its
-            review agents. Use gh pr view/diff and Read/Glob/Grep for inspection;
+            review agents. Run agent calls synchronously (parallel calls are fine);
+            do not use run_in_background. Wait for their returned review results.
+            Use gh pr view/diff and Read/Glob/Grep for inspection;
             gh api and arbitrary shell commands are not enabled. A complete diff is
             already available at ${{ runner.temp }}/deputy-review-input/diff; use Read to
             inspect it. Tell every review agent this path and tool policy. Do not

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -30,20 +30,25 @@ jobs:
       - name: Test review evidence verifier
         run: node --test .github/scripts/claude-review-outcome.test.cjs
 
-      - name: Record review start
+      - name: Freeze verifier and record review start
         id: start
-        run: echo "time=$(date -u +%Y-%m-%dT%H:%M:%SZ)" >> "$GITHUB_OUTPUT"
+        run: |
+          install -m 0444 .github/scripts/claude-review-outcome.cjs "$RUNNER_TEMP/claude-review-verifier.cjs"
+          echo "digest=$(sha256sum "$RUNNER_TEMP/claude-review-verifier.cjs" | cut -d ' ' -f 1)" >> "$GITHUB_OUTPUT"
+          echo "time=$(date -u +%Y-%m-%dT%H:%M:%SZ)" >> "$GITHUB_OUTPUT"
 
       - name: Run Claude Code Review
         id: claude-review
         uses: anthropics/claude-code-action@v1
         with:
           # Supported scoped GitHub token auth also permits reviewing workflow PRs.
-          # https://github.com/anthropics/claude-code-action/blob/main/docs/custom-app.md
+          # https://github.com/anthropics/claude-code-action/blob/main/action.yml
           github_token: ${{ github.token }}
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           plugin_marketplaces: 'https://github.com/anthropics/claude-code.git'
           plugins: 'code-review@claude-code-plugins'
+          claude_args: >-
+            --allowedTools "Skill(code-review:code-review),Agent,Task,TaskOutput,TodoWrite,TaskCreate,TaskUpdate,TaskList,Read,Glob,Grep,Bash(gh pr view:*),Bash(gh pr diff:*),Bash(gh pr list:*),Bash(gh pr comment:*),Bash(gh issue view:*),Bash(gh issue list:*),Bash(gh search:*),mcp__github_inline_comment__create_inline_comment"
           show_full_output: false
           display_report: false
           prompt: |
@@ -51,6 +56,11 @@ jobs:
 
             Review exactly commit ${{ github.event.pull_request.head.sha }}.
             Prior Claude comments on older commits do not satisfy this review.
+            Use the upstream plugin via Skill(code-review:code-review), including its
+            review agents. Use gh pr view/diff and Read/Glob/Grep for inspection;
+            gh api and arbitrary shell commands are not enabled.
+            Every inline finding must include this provenance marker in its body:
+            <!-- deputy-claude-review:${{ github.event.pull_request.head.sha }}:${{ github.run_id }}:${{ github.run_attempt }}:finding -->
             After the upstream plugin completes, post a summary with gh pr comment.
             Include exactly one of these markers according to the plugin's findings:
             <!-- deputy-claude-review:${{ github.event.pull_request.head.sha }}:${{ github.run_id }}:${{ github.run_attempt }}:with-findings -->
@@ -68,7 +78,14 @@ jobs:
           REVIEW_STARTED: ${{ steps.start.outputs.time }}
           EXECUTION_FILE: ${{ steps.claude-review.outputs.execution_file }}
           ACTION_OUTCOME: ${{ steps.claude-review.outcome }}
-        run: node .github/scripts/claude-review-outcome.cjs
+          VERIFIER_DIGEST: ${{ steps.start.outputs.digest }}
+        run: |
+          if ! printf '%s  %s\n' "$VERIFIER_DIGEST" "$RUNNER_TEMP/claude-review-verifier.cjs" | sha256sum --check --status; then
+            echo '### Claude review: blocked/failed' >> "$GITHUB_STEP_SUMMARY"
+            echo 'The frozen verification control is missing or changed.' >> "$GITHUB_STEP_SUMMARY"
+            exit 1
+          fi
+          node "$RUNNER_TEMP/claude-review-verifier.cjs"
 
       - name: Upload sanitized review outcome
         if: always()

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -3,18 +3,17 @@ name: Claude Code Review
 on:
   pull_request:
     types: [opened, synchronize, ready_for_review, reopened]
-    # Optional: Only run on specific file changes
-    # paths:
-    #   - "src/**/*.ts"
-    #   - "src/**/*.tsx"
-    #   - "src/**/*.js"
-    #   - "src/**/*.jsx"
+
+concurrency:
+  group: claude-review-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
 
 jobs:
   claude-review:
     # Fork pull_request runs cannot supply the credentials/OIDC this action needs.
-    if: github.event.pull_request.head.repo.full_name == github.repository
+    if: github.event.pull_request.head.repo.full_name == github.repository && !github.event.pull_request.draft
     runs-on: ubuntu-latest
+    timeout-minutes: 25
     permissions:
       contents: read
       pull-requests: read
@@ -25,7 +24,13 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
         with:
+          ref: ${{ github.event.pull_request.head.sha }}
           fetch-depth: 1
+          persist-credentials: false
+
+      - name: Record review start
+        id: start
+        run: echo "time=$(date -u +%Y-%m-%dT%H:%M:%SZ)" >> "$GITHUB_OUTPUT"
 
       - name: Run Claude Code Review
         id: claude-review
@@ -34,9 +39,53 @@ jobs:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           plugin_marketplaces: 'https://github.com/anthropics/claude-code.git'
           plugins: 'code-review@claude-code-plugins'
-          prompt: '/code-review:code-review ${{ github.repository }}/pull/${{ github.event.pull_request.number }}'
-          # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
-          # or https://code.claude.com/docs/en/cli-reference for available options
+          show_full_output: false
+          display_report: false
+          prompt: |
+            /code-review:code-review ${{ github.repository }}/pull/${{ github.event.pull_request.number }} --comment
+
+            Review exactly commit ${{ github.event.pull_request.head.sha }}.
+            Prior Claude comments on older commits do not satisfy this review.
+            After the upstream plugin completes, post a summary with gh pr comment.
+            Include exactly one of these markers according to the plugin's findings:
+            <!-- deputy-claude-review:${{ github.event.pull_request.head.sha }}:${{ github.run_id }}:${{ github.run_attempt }}:with-findings -->
+            <!-- deputy-claude-review:${{ github.event.pull_request.head.sha }}:${{ github.run_id }}:${{ github.run_attempt }}:without-findings -->
+            Include the full reviewed commit SHA visibly in the summary.
+            Only report completion after reviewing the diff; if blocked, explain the
+            blocker and do not use a completion marker. Do not modify repository files.
+
+      - name: Verify review outcome and sanitize diagnostics
+        if: always()
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          REVIEW_SHA: ${{ github.event.pull_request.head.sha }}
+          REVIEW_STARTED: ${{ steps.start.outputs.time }}
+          EXECUTION_FILE: ${{ steps.claude-review.outputs.execution_file }}
+          ACTION_OUTCOME: ${{ steps.claude-review.outcome }}
+        run: node .github/scripts/claude-review-outcome.cjs
+
+      - name: Upload sanitized review outcome
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: claude-review-outcome-${{ github.run_id }}-${{ github.run_attempt }}
+          path: ${{ runner.temp }}/claude-review-outcome.json
+          retention-days: 14
+          if-no-files-found: warn
+
+  draft-review-notice:
+    if: github.event.pull_request.head.repo.full_name == github.repository && github.event.pull_request.draft
+    runs-on: ubuntu-latest
+    permissions: {}
+    steps:
+      - name: Explain intentional draft skip
+        run: |
+          cat >> "$GITHUB_STEP_SUMMARY" <<'EOF'
+          ### Claude review: intentionally skipped
+
+          This PR is a draft. Mark it ready for review to start automatic Claude review.
+          EOF
 
   fork-review-notice:
     if: github.event.pull_request.head.repo.full_name != github.repository
@@ -46,7 +95,7 @@ jobs:
       - name: Explain unsupported automatic fork review
         run: |
           cat >> "$GITHUB_STEP_SUMMARY" <<'EOF'
-          ### Claude review skipped for a fork pull request
+          ### Claude review: intentionally skipped (fork pull request)
 
           Automatic Claude review requires credentials unavailable to fork PR workflows.
           A maintainer must review this PR manually. Other configured CI checks still run.

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -55,24 +55,37 @@ jobs:
           claude_args: >-
             --add-dir '${{ runner.temp }}/deputy-review-input'
             --allowedTools "Skill(code-review:code-review),Agent,Task,TaskOutput,TodoWrite,TaskCreate,TaskUpdate,TaskList,Read,Glob,Grep,Bash(gh pr view:*),Bash(gh pr diff:*),Bash(gh pr list:*),Bash(gh pr comment:*),Bash(gh issue view:*),Bash(gh issue list:*),Bash(gh search:*),Bash(wc:*),mcp__github_inline_comment__create_inline_comment"
-            --json-schema '{"type":"object","properties":{"outcome":{"type":"string","enum":["completed-with-findings","completed-without-findings","skipped","blocked"]},"reason":{"type":"string","enum":["reviewed","draft","closed","trivial","already-reviewed","permission-denied","diff-unavailable","plugin-unavailable","subagent-unavailable","provider-limit","publication-failed","policy-conflict","other"]},"eligibility":{"type":"string","enum":["eligible","draft","closed","prior-comment","trivial","plugin-unavailable","input-unavailable","other"]}},"required":["outcome","reason","eligibility"],"additionalProperties":false}'
+            --json-schema '{"type":"object","properties":{"outcome":{"type":"string","enum":["completed-with-findings","completed-without-findings","skipped","blocked"]},"reason":{"type":"string","enum":["reviewed","draft","closed","trivial","already-reviewed","permission-denied","diff-unavailable","plugin-unavailable","subagent-unavailable","provider-limit","publication-failed","policy-conflict","other"]}},"required":["outcome","reason"],"additionalProperties":false}'
           show_full_output: false
           display_report: false
           prompt: |
-            This is a read-only diagnostic of the upstream plugin's eligibility
-            policy, not a code review. Do not post comments and do not launch any
-            agents or execute the review procedure.
-            First call Bash with wc -l ${{ runner.temp }}/deputy-review-input/diff.
-            Load Skill with skill="code-review:code-review" and
-            args="${{ github.repository }}/pull/${{ github.event.pull_request.number }} --comment"
-            only to inspect its instructions. Do not perform its review steps.
-            Inspect PR metadata and prior comments with gh pr view. Determine the
-            first eligibility rule that would stop the upstream plugin, or report
-            eligibility=eligible if none does. Distinguish a prior-comment guard
-            from a missing plugin, unreadable diff, draft, closed PR, or trivial PR.
-            Return outcome=skipped because this is diagnostic-only, and the most
-            specific reason plus eligibility. Use already-reviewed for the
-            prior-comment guard; do not claim a review completed.
+            Invoke the installed code-review:code-review Skill for
+            ${{ github.repository }}/pull/${{ github.event.pull_request.number }}
+            with the --comment argument. Follow that upstream review procedure.
+
+            Review exactly commit ${{ github.event.pull_request.head.sha }}.
+            Preserve the upstream plugin's eligibility and intentional-skip rules.
+            If it skips, return outcome skipped with the specific reason: draft,
+            closed, trivial, or already-reviewed. Do not post a completion marker
+            or claim this run reviewed the current head when it intentionally skips.
+            Use the upstream plugin via Skill(code-review:code-review), including its
+            review agents. Use gh pr view/diff and Read/Glob/Grep for inspection;
+            gh api and arbitrary shell commands are not enabled. A complete diff is
+            already available at ${{ runner.temp }}/deputy-review-input/diff; use Read to
+            inspect it. Tell every review agent this path and tool policy. Do not
+            use shell pipes, redirection, or shell commands to read or buffer files.
+            Every inline finding must include this visible provenance link in its body
+            (the upstream inline-comment sanitizer removes HTML comments):
+            [Review run](https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}/attempts/${{ github.run_attempt }})
+            After the upstream plugin completes a review, post a summary with gh pr comment.
+            Include exactly one of these markers according to the plugin's findings:
+            <!-- deputy-claude-review:${{ github.event.pull_request.head.sha }}:${{ github.run_id }}:${{ github.run_attempt }}:with-findings -->
+            <!-- deputy-claude-review:${{ github.event.pull_request.head.sha }}:${{ github.run_id }}:${{ github.run_attempt }}:without-findings -->
+            Include the full reviewed commit SHA visibly in the summary.
+            Only report completion after reviewing the diff; if blocked, explain the
+            blocker and do not use a completion marker. Return the structured outcome
+            and the most specific available reason after posting the result. Use other
+            only when none of the reason categories apply. Do not modify repository files.
 
       - name: Verify review outcome and sanitize diagnostics
         if: ${{ !cancelled() }}

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -32,7 +32,11 @@ jobs:
 
       - name: Freeze verifier and record review start
         id: start
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
         run: |
+          gh pr diff "$PR_NUMBER" --repo "$GITHUB_REPOSITORY" > "$RUNNER_TEMP/deputy-review.diff"
           install -m 0444 .github/scripts/claude-review-outcome.cjs "$RUNNER_TEMP/claude-review-verifier.cjs"
           echo "digest=$(sha256sum "$RUNNER_TEMP/claude-review-verifier.cjs" | cut -d ' ' -f 1)" >> "$GITHUB_OUTPUT"
           echo "time=$(date -u +%Y-%m-%dT%H:%M:%SZ)" >> "$GITHUB_OUTPUT"
@@ -52,13 +56,18 @@ jobs:
           show_full_output: false
           display_report: false
           prompt: |
-            /code-review:code-review ${{ github.repository }}/pull/${{ github.event.pull_request.number }} --comment
+            Invoke the installed code-review:code-review Skill for
+            ${{ github.repository }}/pull/${{ github.event.pull_request.number }}
+            with the --comment argument. Follow that upstream review procedure.
 
             Review exactly commit ${{ github.event.pull_request.head.sha }}.
             Prior Claude comments on older commits do not satisfy this review.
             Use the upstream plugin via Skill(code-review:code-review), including its
             review agents. Use gh pr view/diff and Read/Glob/Grep for inspection;
-            gh api and arbitrary shell commands are not enabled.
+            gh api and arbitrary shell commands are not enabled. A complete diff is
+            already available at ${{ runner.temp }}/deputy-review.diff; use Read to
+            inspect it. Tell every review agent this path and tool policy. Do not
+            use shell pipes, redirection, or shell commands to read or buffer files.
             Every inline finding must include this provenance marker in its body:
             <!-- deputy-claude-review:${{ github.event.pull_request.head.sha }}:${{ github.run_id }}:${{ github.run_attempt }}:finding -->
             After the upstream plugin completes, post a summary with gh pr comment.

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -42,7 +42,18 @@ jobs:
           echo "digest=$(sha256sum "$RUNNER_TEMP/claude-review-verifier.cjs" | cut -d ' ' -f 1)" >> "$GITHUB_OUTPUT"
           echo "time=$(date -u +%Y-%m-%dT%H:%M:%SZ)" >> "$GITHUB_OUTPUT"
 
+      - name: Check upstream prior-review eligibility
+        id: eligibility
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          REVIEW_SHA: ${{ github.event.pull_request.head.sha }}
+          REVIEW_STARTED: ${{ steps.start.outputs.time }}
+          REVIEW_PREFLIGHT: 'true'
+        run: node "$RUNNER_TEMP/claude-review-verifier.cjs"
+
       - name: Run Claude Code Review
+        if: steps.eligibility.outputs.should_review == 'true'
         id: claude-review
         uses: anthropics/claude-code-action@v1
         with:
@@ -88,7 +99,7 @@ jobs:
             only when none of the reason categories apply. Do not modify repository files.
 
       - name: Verify review outcome and sanitize diagnostics
-        if: ${{ !cancelled() }}
+        if: ${{ !cancelled() && steps.eligibility.outputs.should_review == 'true' }}
         env:
           GH_TOKEN: ${{ github.token }}
           PR_NUMBER: ${{ github.event.pull_request.number }}

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -55,37 +55,24 @@ jobs:
           claude_args: >-
             --add-dir '${{ runner.temp }}/deputy-review-input'
             --allowedTools "Skill(code-review:code-review),Agent,Task,TaskOutput,TodoWrite,TaskCreate,TaskUpdate,TaskList,Read,Glob,Grep,Bash(gh pr view:*),Bash(gh pr diff:*),Bash(gh pr list:*),Bash(gh pr comment:*),Bash(gh issue view:*),Bash(gh issue list:*),Bash(gh search:*),Bash(wc:*),mcp__github_inline_comment__create_inline_comment"
-            --json-schema '{"type":"object","properties":{"outcome":{"type":"string","enum":["completed-with-findings","completed-without-findings","skipped","blocked"]},"reason":{"type":"string","enum":["reviewed","draft","closed","trivial","already-reviewed","permission-denied","diff-unavailable","plugin-unavailable","subagent-unavailable","provider-limit","publication-failed","policy-conflict","other"]}},"required":["outcome","reason"],"additionalProperties":false}'
+            --json-schema '{"type":"object","properties":{"outcome":{"type":"string","enum":["completed-with-findings","completed-without-findings","skipped","blocked"]},"reason":{"type":"string","enum":["reviewed","draft","closed","trivial","already-reviewed","permission-denied","diff-unavailable","plugin-unavailable","subagent-unavailable","provider-limit","publication-failed","policy-conflict","other"]},"eligibility":{"type":"string","enum":["eligible","draft","closed","prior-comment","trivial","plugin-unavailable","input-unavailable","other"]}},"required":["outcome","reason","eligibility"],"additionalProperties":false}'
           show_full_output: false
           display_report: false
           prompt: |
-            Invoke the installed code-review:code-review Skill for
-            ${{ github.repository }}/pull/${{ github.event.pull_request.number }}
-            with the --comment argument. Follow that upstream review procedure.
-
-            Review exactly commit ${{ github.event.pull_request.head.sha }}.
-            This workflow selected the ready PR for a fresh review. Override the
-            plugin's trivial/already-commented skip shortcuts: previous comments,
-            including the bot's older-head review, do not satisfy this run. Only a
-            PR that is now closed or a draft may be intentionally skipped.
-            Use the upstream plugin via Skill(code-review:code-review), including its
-            review agents. Use gh pr view/diff and Read/Glob/Grep for inspection;
-            gh api and arbitrary shell commands are not enabled. A complete diff is
-            already available at ${{ runner.temp }}/deputy-review-input/diff; use Read to
-            inspect it. Tell every review agent this path and tool policy. Do not
-            use shell pipes, redirection, or shell commands to read or buffer files.
-            Every inline finding must include this visible provenance link in its body
-            (the upstream inline-comment sanitizer removes HTML comments):
-            [Review run](https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}/attempts/${{ github.run_attempt }})
-            After the upstream plugin completes, post a summary with gh pr comment.
-            Include exactly one of these markers according to the plugin's findings:
-            <!-- deputy-claude-review:${{ github.event.pull_request.head.sha }}:${{ github.run_id }}:${{ github.run_attempt }}:with-findings -->
-            <!-- deputy-claude-review:${{ github.event.pull_request.head.sha }}:${{ github.run_id }}:${{ github.run_attempt }}:without-findings -->
-            Include the full reviewed commit SHA visibly in the summary.
-            Only report completion after reviewing the diff; if blocked, explain the
-            blocker and do not use a completion marker. Return the structured outcome
-            and the most specific available reason after posting the result. Use other
-            only when none of the reason categories apply. Do not modify repository files.
+            This is a read-only diagnostic of the upstream plugin's eligibility
+            policy, not a code review. Do not post comments and do not launch any
+            agents or execute the review procedure.
+            First call Bash with wc -l ${{ runner.temp }}/deputy-review-input/diff.
+            Load Skill with skill="code-review:code-review" and
+            args="${{ github.repository }}/pull/${{ github.event.pull_request.number }} --comment"
+            only to inspect its instructions. Do not perform its review steps.
+            Inspect PR metadata and prior comments with gh pr view. Determine the
+            first eligibility rule that would stop the upstream plugin, or report
+            eligibility=eligible if none does. Distinguish a prior-comment guard
+            from a missing plugin, unreadable diff, draft, closed PR, or trivial PR.
+            Return outcome=skipped because this is diagnostic-only, and the most
+            specific reason plus eligibility. Use already-reviewed for the
+            prior-comment guard; do not claim a review completed.
 
       - name: Verify review outcome and sanitize diagnostics
         if: ${{ !cancelled() }}

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -52,7 +52,8 @@ jobs:
           plugin_marketplaces: 'https://github.com/anthropics/claude-code.git'
           plugins: 'code-review@claude-code-plugins'
           claude_args: >-
-            --allowedTools "Skill(code-review:code-review),Agent,Task,TaskOutput,TodoWrite,TaskCreate,TaskUpdate,TaskList,Read,Glob,Grep,Bash(gh pr view:*),Bash(gh pr diff:*),Bash(gh pr list:*),Bash(gh pr comment:*),Bash(gh issue view:*),Bash(gh issue list:*),Bash(gh search:*),mcp__github_inline_comment__create_inline_comment"
+            --allowedTools "Skill(code-review:code-review),Agent,Task,TaskOutput,TodoWrite,TaskCreate,TaskUpdate,TaskList,Read,Glob,Grep,Bash(gh pr view:*),Bash(gh pr diff:*),Bash(gh pr list:*),Bash(gh pr comment:*),Bash(gh issue view:*),Bash(gh issue list:*),Bash(gh search:*),Bash(wc:*),mcp__github_inline_comment__create_inline_comment"
+            --json-schema '{"type":"object","properties":{"outcome":{"type":"string","enum":["completed-with-findings","completed-without-findings","skipped","blocked"]},"reason":{"type":"string","enum":["reviewed","draft","closed","trivial","already-reviewed","permission-denied","other"]}},"required":["outcome","reason"],"additionalProperties":false}'
           show_full_output: false
           display_report: false
           prompt: |
@@ -61,7 +62,10 @@ jobs:
             with the --comment argument. Follow that upstream review procedure.
 
             Review exactly commit ${{ github.event.pull_request.head.sha }}.
-            Prior Claude comments on older commits do not satisfy this review.
+            This workflow selected the ready PR for a fresh review. Override the
+            plugin's trivial/already-commented skip shortcuts: previous comments,
+            including the bot's older-head review, do not satisfy this run. Only a
+            PR that is now closed or a draft may be intentionally skipped.
             Use the upstream plugin via Skill(code-review:code-review), including its
             review agents. Use gh pr view/diff and Read/Glob/Grep for inspection;
             gh api and arbitrary shell commands are not enabled. A complete diff is
@@ -77,7 +81,8 @@ jobs:
             <!-- deputy-claude-review:${{ github.event.pull_request.head.sha }}:${{ github.run_id }}:${{ github.run_attempt }}:without-findings -->
             Include the full reviewed commit SHA visibly in the summary.
             Only report completion after reviewing the diff; if blocked, explain the
-            blocker and do not use a completion marker. Do not modify repository files.
+            blocker and do not use a completion marker. Return the structured outcome
+            and reason after posting the result. Do not modify repository files.
 
       - name: Verify review outcome and sanitize diagnostics
         if: ${{ !cancelled() }}

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -36,7 +36,8 @@ jobs:
           GH_TOKEN: ${{ github.token }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
         run: |
-          gh pr diff "$PR_NUMBER" --repo "$GITHUB_REPOSITORY" > "$RUNNER_TEMP/deputy-review.diff"
+          mkdir -p "$RUNNER_TEMP/deputy-review-input"
+          gh pr diff "$PR_NUMBER" --repo "$GITHUB_REPOSITORY" > "$RUNNER_TEMP/deputy-review-input/diff"
           install -m 0444 .github/scripts/claude-review-outcome.cjs "$RUNNER_TEMP/claude-review-verifier.cjs"
           echo "digest=$(sha256sum "$RUNNER_TEMP/claude-review-verifier.cjs" | cut -d ' ' -f 1)" >> "$GITHUB_OUTPUT"
           echo "time=$(date -u +%Y-%m-%dT%H:%M:%SZ)" >> "$GITHUB_OUTPUT"
@@ -52,8 +53,9 @@ jobs:
           plugin_marketplaces: 'https://github.com/anthropics/claude-code.git'
           plugins: 'code-review@claude-code-plugins'
           claude_args: >-
+            --add-dir '${{ runner.temp }}/deputy-review-input'
             --allowedTools "Skill(code-review:code-review),Agent,Task,TaskOutput,TodoWrite,TaskCreate,TaskUpdate,TaskList,Read,Glob,Grep,Bash(gh pr view:*),Bash(gh pr diff:*),Bash(gh pr list:*),Bash(gh pr comment:*),Bash(gh issue view:*),Bash(gh issue list:*),Bash(gh search:*),Bash(wc:*),mcp__github_inline_comment__create_inline_comment"
-            --json-schema '{"type":"object","properties":{"outcome":{"type":"string","enum":["completed-with-findings","completed-without-findings","skipped","blocked"]},"reason":{"type":"string","enum":["reviewed","draft","closed","trivial","already-reviewed","permission-denied","other"]}},"required":["outcome","reason"],"additionalProperties":false}'
+            --json-schema '{"type":"object","properties":{"outcome":{"type":"string","enum":["completed-with-findings","completed-without-findings","skipped","blocked"]},"reason":{"type":"string","enum":["reviewed","draft","closed","trivial","already-reviewed","permission-denied","diff-unavailable","plugin-unavailable","subagent-unavailable","provider-limit","publication-failed","policy-conflict","other"]}},"required":["outcome","reason"],"additionalProperties":false}'
           show_full_output: false
           display_report: false
           prompt: |
@@ -69,7 +71,7 @@ jobs:
             Use the upstream plugin via Skill(code-review:code-review), including its
             review agents. Use gh pr view/diff and Read/Glob/Grep for inspection;
             gh api and arbitrary shell commands are not enabled. A complete diff is
-            already available at ${{ runner.temp }}/deputy-review.diff; use Read to
+            already available at ${{ runner.temp }}/deputy-review-input/diff; use Read to
             inspect it. Tell every review agent this path and tool policy. Do not
             use shell pipes, redirection, or shell commands to read or buffer files.
             Every inline finding must include this visible provenance link in its body
@@ -82,7 +84,8 @@ jobs:
             Include the full reviewed commit SHA visibly in the summary.
             Only report completion after reviewing the diff; if blocked, explain the
             blocker and do not use a completion marker. Return the structured outcome
-            and reason after posting the result. Do not modify repository files.
+            and the most specific available reason after posting the result. Use other
+            only when none of the reason categories apply. Do not modify repository files.
 
       - name: Verify review outcome and sanitize diagnostics
         if: ${{ !cancelled() }}

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -68,8 +68,9 @@ jobs:
             already available at ${{ runner.temp }}/deputy-review.diff; use Read to
             inspect it. Tell every review agent this path and tool policy. Do not
             use shell pipes, redirection, or shell commands to read or buffer files.
-            Every inline finding must include this provenance marker in its body:
-            <!-- deputy-claude-review:${{ github.event.pull_request.head.sha }}:${{ github.run_id }}:${{ github.run_attempt }}:finding -->
+            Every inline finding must include this visible provenance link in its body
+            (the upstream inline-comment sanitizer removes HTML comments):
+            [Review run](https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}/attempts/${{ github.run_attempt }})
             After the upstream plugin completes, post a summary with gh pr comment.
             Include exactly one of these markers according to the plugin's findings:
             <!-- deputy-claude-review:${{ github.event.pull_request.head.sha }}:${{ github.run_id }}:${{ github.run_attempt }}:with-findings -->
@@ -79,7 +80,7 @@ jobs:
             blocker and do not use a completion marker. Do not modify repository files.
 
       - name: Verify review outcome and sanitize diagnostics
-        if: always()
+        if: ${{ !cancelled() }}
         env:
           GH_TOKEN: ${{ github.token }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
@@ -97,7 +98,7 @@ jobs:
           node "$RUNNER_TEMP/claude-review-verifier.cjs"
 
       - name: Upload sanitized review outcome
-        if: always()
+        if: ${{ !cancelled() }}
         uses: actions/upload-artifact@v4
         with:
           name: claude-review-outcome-${{ github.run_id }}-${{ github.run_attempt }}

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -2,7 +2,7 @@ name: Claude Code Review
 
 on:
   pull_request:
-    types: [opened, synchronize, ready_for_review, reopened]
+    types: [opened, synchronize, ready_for_review, reopened, converted_to_draft]
 
 concurrency:
   group: claude-review-${{ github.event.pull_request.number }}
@@ -10,15 +10,14 @@ concurrency:
 
 jobs:
   claude-review:
-    # Fork pull_request runs cannot supply the credentials/OIDC this action needs.
+    # Repository-owned PRs only; never expose reviewer credentials to forks.
     if: github.event.pull_request.head.repo.full_name == github.repository && !github.event.pull_request.draft
     runs-on: ubuntu-latest
     timeout-minutes: 25
     permissions:
       contents: read
-      pull-requests: read
+      pull-requests: write
       issues: read
-      id-token: write
 
     steps:
       - name: Checkout repository
@@ -28,6 +27,9 @@ jobs:
           fetch-depth: 1
           persist-credentials: false
 
+      - name: Test review evidence verifier
+        run: node --test .github/scripts/claude-review-outcome.test.cjs
+
       - name: Record review start
         id: start
         run: echo "time=$(date -u +%Y-%m-%dT%H:%M:%SZ)" >> "$GITHUB_OUTPUT"
@@ -36,6 +38,9 @@ jobs:
         id: claude-review
         uses: anthropics/claude-code-action@v1
         with:
+          # Supported scoped GitHub token auth also permits reviewing workflow PRs.
+          # https://github.com/anthropics/claude-code-action/blob/main/docs/custom-app.md
+          github_token: ${{ github.token }}
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           plugin_marketplaces: 'https://github.com/anthropics/claude-code.git'
           plugins: 'code-review@claude-code-plugins'

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -641,9 +641,10 @@ The same-repository job passes the action its supported `github_token` input wit
 OIDC or an App token. Reviews post as `github-actions[bot]`.
 Draft PRs explicitly skip automatic review until ready. Ready reviews check out the
 exact PR head and require a current-run `github-actions[bot]` summary tied to that SHA; findings
-also require exact-commit inline comments carrying the same run marker. Missing
-evidence or denied tools fail
-the review job. The only uploaded diagnostic is `claude-review-outcome.json`: fixed
+also require exact-commit inline comments linking the same workflow run and attempt
+(the upstream sanitizer strips HTML comments from inline bodies). Missing evidence
+fails the review job; recovered tool denials remain visible diagnostics when
+completion is verified. Cancelled runs remain cancelled. The only uploaded diagnostic is `claude-review-outcome.json`: fixed
 outcome/reason values, the reviewed SHA, a denial count, and allowlisted operation
 names. Never upload the raw SDK execution file or enable full-output logging.
 The verifier is copied out of the model workspace before review and its digest is

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -655,9 +655,11 @@ also require exact-commit inline comments linking the same workflow run and atte
 fails the review job; recovered tool denials remain visible diagnostics when
 completion is verified. Cancelled runs remain cancelled. The only uploaded diagnostic is `claude-review-outcome.json`: fixed
 outcome/reason values, the target SHA, a denial count, allowlisted operation
-names, plugin/agent invocation counts, whether the plugin received `--comment`,
+names, plugin/agent attempt and success counts, whether the successful plugin received `--comment`,
 and the reviewer's enum-only outcome/reason report. The report never substitutes
 for verified completion evidence. Never upload the raw SDK execution file or enable full-output logging.
+Completed outcomes require a successful plugin invocation with `--comment` and
+agent execution, matched to non-error SDK tool results and excluding denied calls.
 The verifier is copied out of the model workspace before review and its digest is
 checked before execution. This protects against model-workspace changes; it is not
 an immutable security boundary against repository writers, who can also edit the

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -636,8 +636,11 @@ notice has no token permissions, checkout, or secrets. Keep this workflow on
 restrictions. This policy applies to automatic review, not the separate
 mention-triggered Claude workflow.
 
+The same-repository job passes the action its supported `github_token` input with
+`contents: read`, `issues: read`, and `pull-requests: write`; it does not request
+OIDC or an App token. Reviews post as `github-actions[bot]`.
 Draft PRs explicitly skip automatic review until ready. Ready reviews check out the
-exact PR head and require a current-run Claude summary tied to that SHA; findings
+exact PR head and require a current-run `github-actions[bot]` summary tied to that SHA; findings
 also require exact-commit inline comments. Missing evidence or denied tools fail
 the review job. The only uploaded diagnostic is `claude-review-outcome.json`: fixed
 outcome/reason values, the reviewed SHA, a denial count, and allowlisted operation

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -645,8 +645,9 @@ also require exact-commit inline comments linking the same workflow run and atte
 (the upstream sanitizer strips HTML comments from inline bodies). Missing evidence
 fails the review job; recovered tool denials remain visible diagnostics when
 completion is verified. Cancelled runs remain cancelled. The only uploaded diagnostic is `claude-review-outcome.json`: fixed
-outcome/reason values, the reviewed SHA, a denial count, and allowlisted operation
-names. Never upload the raw SDK execution file or enable full-output logging.
+outcome/reason values, the reviewed SHA, a denial count, allowlisted operation
+names, and the reviewer's enum-only outcome/reason report. The report never
+substitutes for verified GitHub evidence. Never upload the raw SDK execution file or enable full-output logging.
 The verifier is copied out of the model workspace before review and its digest is
 checked before execution. This protects against model-workspace changes; it is not
 an immutable security boundary against repository writers, who can also edit the

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -646,7 +646,9 @@ or a PR with a prior Claude review comment. Closed/draft state and prior bot rev
 are checked against GitHub. A skip explicitly states that this run did not review
 the current head; an older review never counts as current-run completion.
 Before starting the SDK, the workflow checks for a prior bot review comment with
-the established provenance marker. That confirmed upstream skip needs no model
+the established provenance marker from a different run or attempt. A prior run
+can publish while this run starts; the current run's own marker never qualifies.
+That confirmed upstream skip needs no model
 call and emits an eligibility-stage result. PRs without that evidence invoke the
 existing plugin normally; GitHub eligibility lookup failures fail the job.
 This eligibility decision follows the upstream comment-presence rule. It does

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -641,10 +641,16 @@ The same-repository job passes the action its supported `github_token` input wit
 OIDC or an App token. Reviews post as `github-actions[bot]`.
 Draft PRs explicitly skip automatic review until ready. Ready reviews check out the
 exact PR head and require a current-run `github-actions[bot]` summary tied to that SHA; findings
-also require exact-commit inline comments. Missing evidence or denied tools fail
+also require exact-commit inline comments carrying the same run marker. Missing
+evidence or denied tools fail
 the review job. The only uploaded diagnostic is `claude-review-outcome.json`: fixed
 outcome/reason values, the reviewed SHA, a denial count, and allowlisted operation
 names. Never upload the raw SDK execution file or enable full-output logging.
+The verifier is copied out of the model workspace before review and its digest is
+checked before execution. This protects against model-workspace changes; it is not
+an immutable security boundary against repository writers, who can also edit the
+workflow. This workflow trusts same-repository writers, and the action retains its
+actor write-access check. Fork contributions remain excluded.
 Run workflow evidence tests with `node --test .github/scripts/claude-review-outcome.test.cjs`.
 
 See `dev/runtime-modules.md` for internal module boundaries and the documented

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -645,6 +645,10 @@ denial-free invocation can explicitly skip a trivial change, a now-closed/draft 
 or a PR with a prior Claude review. Closed/draft state and prior bot review summaries
 are checked against GitHub. A skip explicitly states that this run did not review
 the current head; an older review never counts as current-run completion.
+Before starting the SDK, the workflow checks for a prior bot review summary with
+the established provenance marker. That confirmed upstream skip needs no model
+call and emits an eligibility-stage result. PRs without that evidence invoke the
+existing plugin normally; GitHub eligibility lookup failures fail the job.
 Completed reviews require a current-run `github-actions[bot]` summary tied to that SHA; findings
 also require exact-commit inline comments linking the same workflow run and attempt
 (the upstream sanitizer strips HTML comments from inline bodies). Missing evidence

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -642,13 +642,16 @@ OIDC or an App token. Reviews post as `github-actions[bot]`.
 Draft PRs explicitly skip automatic review until ready. Ready reviews check out the
 exact PR head and preserve the upstream plugin's skip policy. Its successful,
 denial-free invocation can explicitly skip a trivial change, a now-closed/draft PR,
-or a PR with a prior Claude review. Closed/draft state and prior bot review summaries
+or a PR with a prior Claude review comment. Closed/draft state and prior bot review comments
 are checked against GitHub. A skip explicitly states that this run did not review
 the current head; an older review never counts as current-run completion.
-Before starting the SDK, the workflow checks for a prior bot review summary with
+Before starting the SDK, the workflow checks for a prior bot review comment with
 the established provenance marker. That confirmed upstream skip needs no model
 call and emits an eligibility-stage result. PRs without that evidence invoke the
 existing plugin normally; GitHub eligibility lookup failures fail the job.
+This eligibility decision follows the upstream comment-presence rule. It does
+not validate the earlier run's conclusion or certify it as a completed review.
+Current-run completion remains subject to all SDK and GitHub evidence checks.
 Completed reviews require a current-run `github-actions[bot]` summary tied to that SHA; findings
 also require exact-commit inline comments linking the same workflow run and attempt
 (the upstream sanitizer strips HTML comments from inline bodies). Missing evidence

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -636,5 +636,13 @@ notice has no token permissions, checkout, or secrets. Keep this workflow on
 restrictions. This policy applies to automatic review, not the separate
 mention-triggered Claude workflow.
 
+Draft PRs explicitly skip automatic review until ready. Ready reviews check out the
+exact PR head and require a current-run Claude summary tied to that SHA; findings
+also require exact-commit inline comments. Missing evidence or denied tools fail
+the review job. The only uploaded diagnostic is `claude-review-outcome.json`: fixed
+outcome/reason values, the reviewed SHA, a denial count, and allowlisted operation
+names. Never upload the raw SDK execution file or enable full-output logging.
+Run workflow evidence tests with `node --test .github/scripts/claude-review-outcome.test.cjs`.
+
 See `dev/runtime-modules.md` for internal module boundaries and the documented
 size exception for the public Agent facade.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -640,14 +640,20 @@ The same-repository job passes the action its supported `github_token` input wit
 `contents: read`, `issues: read`, and `pull-requests: write`; it does not request
 OIDC or an App token. Reviews post as `github-actions[bot]`.
 Draft PRs explicitly skip automatic review until ready. Ready reviews check out the
-exact PR head and require a current-run `github-actions[bot]` summary tied to that SHA; findings
+exact PR head and preserve the upstream plugin's skip policy. Its successful,
+denial-free invocation can explicitly skip a trivial change, a now-closed/draft PR,
+or a PR with a prior Claude review. Closed/draft state and prior bot review summaries
+are checked against GitHub. A skip explicitly states that this run did not review
+the current head; an older review never counts as current-run completion.
+Completed reviews require a current-run `github-actions[bot]` summary tied to that SHA; findings
 also require exact-commit inline comments linking the same workflow run and attempt
 (the upstream sanitizer strips HTML comments from inline bodies). Missing evidence
 fails the review job; recovered tool denials remain visible diagnostics when
 completion is verified. Cancelled runs remain cancelled. The only uploaded diagnostic is `claude-review-outcome.json`: fixed
-outcome/reason values, the reviewed SHA, a denial count, allowlisted operation
-names, and the reviewer's enum-only outcome/reason report. The report never
-substitutes for verified GitHub evidence. Never upload the raw SDK execution file or enable full-output logging.
+outcome/reason values, the target SHA, a denial count, allowlisted operation
+names, plugin/agent invocation counts, whether the plugin received `--comment`,
+and the reviewer's enum-only outcome/reason report. The report never substitutes
+for verified completion evidence. Never upload the raw SDK execution file or enable full-output logging.
 The verifier is copied out of the model workspace before review and its digest is
 checked before execution. This protects against model-workspace changes; it is not
 an immutable security boundary against repository writers, who can also edit the


### PR DESCRIPTION
Closes #110

A green Claude action no longer implies a completed review. Completed reviews require a successful upstream plugin run and fresh GitHub Actions bot evidence tied to the exact PR head, run, and attempt; findings additionally require matching inline comments. Missing evidence or a changed head fails the job. Recovered tool denials remain visible diagnostics. Drafts, forks, and the upstream plugin's eligibility decisions produce explicit intentional skips that state this run did not review the current head. A prior review never substitutes for current-run completion.

The workflow invokes the existing upstream `code-review:code-review` Skill with `--comment`, enables only its agent/read/PR-comment tools, and supplies a complete diff for read-only inspection. It uses the action's documented [`github_token` input](https://github.com/anthropics/claude-code-action/blob/main/action.yml) with `contents: read`, `issues: read`, and `pull-requests: write`, following the [scoped workflow-token guidance](https://github.com/anthropics/claude-code-action/blob/main/docs/security.md). It requests no OIDC token and never executes fork code with reviewer credentials.

Only a sanitized outcome artifact is uploaded: fixed outcome/reason values, target SHA, denial count, allowlisted operation categories, plugin/agent attempt and success counts, and enum-only reviewer reports. Completion requires successful upstream Skill and agent calls matched to non-error SDK tool results, excluding denied calls and background-launch acknowledgments. Raw SDK output, tool arguments, and repository content remain off public logs/artifacts. Verification control is frozen before the model starts and checked by digest afterwards. Repository writers remain trusted because they can edit the workflow itself; #133 tracks a base-controlled verifier after bootstrap.

Diagnosis: [run 34073561723](https://github.com/JamesHWade/deputy/actions/runs/34073561723) reproduced a successful action that never entered the SDK because App/OIDC workflow validation rejected a workflow differing from main. After switching to supported scoped-token authentication, [run 34073702546](https://github.com/JamesHWade/deputy/actions/runs/34073702546) completed the SDK with 13 denied tool calls, including `Skill` and shell inspection operations. Both were correctly reported as blocked. [Run 34074436227](https://github.com/JamesHWade/deputy/actions/runs/34074436227) then produced an [actual exact-head review](https://github.com/JamesHWade/deputy/pull/131#issuecomment-5563980727) with two findings, which are fixed: recovered denials no longer override proven completion, and cancelled runs remain cancelled. The original historical runs' specific denials cannot be recovered because their raw execution files were not retained.

The last file-read denial was a `wc` access outside the working directory, resolved by passing only the dedicated precomputed-diff directory through `--add-dir`. The subsequent [bounded eligibility probe](https://github.com/JamesHWade/deputy/actions/runs/34076604495) confirmed the upstream plugin skipped because a prior Claude review comment was present: one Skill invocation with `--comment`, no review agents, and zero permission denials. A deterministic preflight now checks that bot-comment provenance and records the known skip before starting the SDK. PRs without prior evidence invoke the full existing upstream plugin; lookup errors fail closed. Eligibility follows the upstream comment-presence policy, independently of the earlier run's conclusion. It certifies neither the earlier review nor the current head. In particular, the earlier e20aa33 run's failed verification remains a failed verification; the later skip does not relabel it.

Validation: six Node regression tests cover false-green SDK results, required successful upstream tool execution, exact-commit/run evidence, concurrent unrelated findings, clock skew, validated skips and startup races, preflight process outputs/failures, and secret-canary redaction; YAML parsing, Air, and Jarl pass. Full package suite: 4,623 passing assertions; R CMD check: 0 errors, 0 warnings, 0 notes. The [final production run at 20e124c](https://github.com/JamesHWade/deputy/actions/runs/34079679775) succeeded with the explicit eligibility outcome: intentionally skipped because a prior Claude review comment exists; this run did not review the current head or validate the earlier run. The earlier exact-commit review and the final intentional skip are distinct observed outcomes. The strengthened successful-tool matching follows the [documented tool-result contract](https://platform.claude.com/docs/en/agents-and-tools/tool-use/handle-tool-calls) and is covered by fixtures; the original review's raw SDK transcript was not retained, so it cannot be replayed through that later guard.

All checks are green at `20e124c`, including all three platform package checks, coverage and Codecov, pkgdown, formatting, the executable smoke test, and the explicit Claude eligibility outcome. Codex completed its review of this exact head; no review threads remain unresolved.
