### PR TITLE
Stabilize isolated-hook coverage tests

### DIFF
--- a/tests/testthat/test-agent-hooks-integration.R
+++ b/tests/testthat/test-agent-hooks-integration.R
@@ -107,7 +107,8 @@ test_that("Agent preserves isolated hook failure details", {
   agent <- Agent$new(chat = create_mock_chat())
   agent$add_hook(HookMatcher(
     event = "PreToolUse",
-    timeout = 5,
+    # Allow instrumented process startup; this test checks error preservation.
+    timeout = 60,
     callback = function(...) stop("isolated hook failed")
   ))
 
@@ -124,6 +125,29 @@ test_that("Agent preserves isolated hook failure details", {
     "isolated hook failed",
     fixed = TRUE
   )
+})
+
+test_that("Agent denies execution when an isolated hook times out", {
+  agent <- Agent$new(chat = create_mock_chat())
+  agent$add_hook(HookMatcher(
+    event = "PreToolUse",
+    timeout = 0.1,
+    callback = function(...) {
+      Sys.sleep(60)
+      HookResultPreToolUse(permission = "allow")
+    }
+  ))
+
+  result <- suppressMessages(agent$hooks$fire(
+    "PreToolUse",
+    tool_name = "read_file",
+    tool_input = list(path = "DESCRIPTION"),
+    context = list()
+  ))
+
+  expect_equal(result$permission, "deny")
+  expect_match(result$reason, "timed out", fixed = TRUE)
+  expect_match(agent$hooks$last_errors()[[1]]$error, "timed out", fixed = TRUE)
 })
 
 test_that("Hook denial takes precedence over permission allow", {

--- a/tests/testthat/test-agent-hooks-integration.R
+++ b/tests/testthat/test-agent-hooks-integration.R
@@ -133,7 +133,7 @@ test_that("Agent denies execution when an isolated hook times out", {
     event = "PreToolUse",
     timeout = 0.1,
     callback = function(...) {
-      Sys.sleep(60)
+      Sys.sleep(1)
       HookResultPreToolUse(permission = "allow")
     }
   ))


### PR DESCRIPTION
Closes #136.

The isolated-hook error-preservation test intermittently hit its five-second deadline during coverage runs, reporting `callr timed out` instead of the callback's original error. Give that test 60 seconds for instrumented process startup while retaining its error assertions. A separate real-process regression requires a slow hook to time out and deny execution; runtime timeout defaults and enforcement are unchanged.

Validation: all 5,103 test assertions passed, including the focused hook tests. The full suite also passed under covr instrumentation. Air, Jarl, pkgdown, R CMD check (zero errors, warnings or notes), and `git diff --check` passed. The ordinary full suite emitted its two existing invalid-path warnings.

This is the first layer of the follow-up and MCP work. Subsequent changes will be submitted as native GitHub stacked PRs.
