### PR TITLE
Preserve native conversation history across compaction

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -356,6 +356,14 @@ fallback Chats never select the task provider or inherit executable tools and
 callbacks. Installing a compacted window preserves prior usage and completed
 tool effects. Manual `compact()` remains synchronous. Evaluation cases and the
 future history-retrieval comparison are described in `dev/compaction-evaluation.md`.
+`Agent$get_turns()` and `turns()` expose the complete selected conversation;
+`get_context_turns()` exposes the compacted model input. Accepted compaction
+retains removed turns as a portable in-memory prefix, without executable tool
+references. `set_turns()` replaces both views and clears the installed summary.
+Snapshot schema 3 preserves the prefix and context separately. Hosts still own
+durable storage and branch identity; native shinychat history can use its normal
+Chat protocol without disabling compaction. See ADR-0017. Context/usage logic
+must inspect the wrapped Chat or `get_context_turns()`, not `get_turns()`.
 Compaction projects ellmer Content objects to public evidence before offloading,
 and bounds potential rendered expansion as well as serialized size. Generated
 summaries preserve up to eight direct recovery references; larger sets use one

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -37,11 +37,15 @@ A single exchange within a run — one model response and any tool calls it requ
 _Avoid_: step, iteration, round
 
 **Conversation snapshot**:
-The serialized contents of an Agent's conversation, written to and read from disk by `save_session()` and `load_session()`. Concerns what was said, not who is saying it.
+The serialized contents of an Agent's selected conversation and model context,
+written to and read from disk by `save_session()` and `load_session()`. Concerns
+what was said, not who is saying it. The host owns durable storage and branches.
 _Avoid_: session, session file, saved session, conversation state
 
 **Compaction**:
-Replacing older turns with a summary to reduce context size, preserving the thread of the conversation while discarding its detail.
+Replacing older turns in model context with a summary to reduce input size.
+The complete selected conversation remains available through `get_turns()`;
+`get_context_turns()` exposes only the current model context.
 _Avoid_: truncation, pruning, summarization
 
 **Checkpoint**:

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,11 @@
 # deputy (development version)
 
+* `Agent$get_turns()` and `turns()` retain the complete selected conversation
+  across compaction, so shinychat native history keeps later replies. Use
+  `get_context_turns()` to inspect the bounded model context. Snapshot schema 3
+  preserves both views; earlier development snapshot schemas are rejected
+  (#146).
+
 * `RSession` provides conversation-scoped trusted R workers with persistent
   variables, ordered console and plot results, queued calls, cancellation and
   explicit state-loss recovery. Native rich tool results now obey separate

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,11 @@
 # deputy (development version)
 
+* The Shiny chat example shows summarization progress and an expandable accepted
+  summary without changing the transcript. Its notice follows the selected
+  conversation and clears busy status after failed or cancelled runs. Chat
+  methods now accept dynamic dots (`!!!`), including shinychat's native input
+  forwarding, and the example no longer registers overlapping tool bundles.
+
 * `Agent$get_turns()` and `turns()` retain the complete selected conversation
   across compaction, so shinychat native history keeps later replies. Use
   `get_context_turns()` to inspect the bounded model context. Snapshot schema 3

--- a/R/agent-approval.R
+++ b/R/agent-approval.R
@@ -40,6 +40,7 @@ deputy_agent_approval_methods <- function(self = NULL, private = NULL) {
       }
       session <- private$build_session_payload()
       session$turns <- approval_record_turns(session$turns)
+      session$compacted_turns <- approval_record_turns(session$compacted_turns)
       session$metadata$saved_at <- as.numeric(session$metadata$saved_at)
       policy <- approval_policy_record(self$permissions)
       record <- list(
@@ -493,6 +494,10 @@ approval_resume <- function(
   session$turns <- approval_replay_turns(
     session$turns,
     private$.chat$get_tools()
+  )
+  session$compacted_turns <- approval_replay_turns(
+    session$compacted_turns,
+    tools = list()
   )
   private$restore_session_payload(session, source = path)
   record$status <- "resuming"

--- a/R/agent-context.R
+++ b/R/agent-context.R
@@ -206,9 +206,12 @@ retire_compaction_catalogs <- function(
     references <- c(
       references,
       compaction_tool_result_references(owner$get_system_prompt()),
-      compaction_embedded_references(lapply(owner$get_turns(), function(turn) {
-        turn@contents
-      }))
+      compaction_embedded_references(lapply(
+        owner$get_context_turns(),
+        function(turn) {
+          turn@contents
+        }
+      ))
     )
   }
   retained <- vapply(references, parse_tool_result_reference, character(1))
@@ -736,6 +739,10 @@ deputy_agent_context_methods <- function(self = NULL, private = NULL) {
       old_prompt <- private$.chat$get_system_prompt()
       old_tools <- if (needs_reader) private$.chat$get_tools()
       had_reader <- private$.tool_result_reader_registered
+      compacted_turns <- c(
+        private$.compacted_turns,
+        portable_session_turns(plan$turns_to_compact)
+      )
       tryCatch(
         {
           private$.chat$set_system_prompt(new_system)
@@ -753,6 +760,7 @@ deputy_agent_context_methods <- function(self = NULL, private = NULL) {
           rlang::cnd_signal(error)
         }
       )
+      private$.compacted_turns <- compacted_turns
       private$.compaction_summary <- summary
       if (!is.null(private$.compaction_artifacts)) {
         private$.compaction_artifacts$installed <- TRUE

--- a/R/agent-session.R
+++ b/R/agent-session.R
@@ -4,8 +4,9 @@ deputy_agent_session_methods <- function(self = NULL, private = NULL) {
   list(
     build_session_payload = function() {
       list(
-        schema_version = 2L,
+        schema_version = 3L,
         turns = portable_session_turns(private$.chat$get_turns()),
+        compacted_turns = portable_session_turns(private$.compacted_turns),
         system_prompt = private$.chat$get_system_prompt(),
         compaction_summary = private$.compaction_summary,
         tool_result_envelopes = collect_tool_result_envelopes(
@@ -48,15 +49,16 @@ deputy_agent_session_methods <- function(self = NULL, private = NULL) {
         )
       }
 
-      if (!identical(session$schema_version, 2L)) {
+      if (!identical(session$schema_version, 3L)) {
         abort_session_load(
-          "Unsupported session schema - expected version 2",
+          "Unsupported session schema - expected version 3",
           path = source
         )
       }
 
       required_fields <- c(
         "turns",
+        "compacted_turns",
         "system_prompt",
         "compaction_summary",
         "tool_result_envelopes",
@@ -89,6 +91,25 @@ deputy_agent_session_methods <- function(self = NULL, private = NULL) {
           path = source
         )
       }
+      if (
+        !is.list(session$compacted_turns) ||
+          !all(vapply(
+            session$compacted_turns,
+            function(turn) {
+              S7::S7_inherits(turn, ellmer::UserTurn) ||
+                S7::S7_inherits(turn, ellmer::AssistantTurn)
+            },
+            logical(1)
+          ))
+      ) {
+        abort_session_load(
+          "Invalid session file - compacted_turns must be a list of conversation turns",
+          path = source
+        )
+      }
+      restored_compacted_turns <- portable_session_turns(
+        session$compacted_turns
+      )
       if (
         !is.null(session$system_prompt) &&
           (!is.character(session$system_prompt) ||
@@ -232,6 +253,7 @@ deputy_agent_session_methods <- function(self = NULL, private = NULL) {
       private$last_run_context <- clone_run_context(restored_run_context)
       private$appended_hook_context_hashes <- restored_hashes
       private$.compaction_summary <- session$compaction_summary
+      private$.compacted_turns <- restored_compacted_turns
     }
   )
 }

--- a/R/agent.R
+++ b/R/agent.R
@@ -611,10 +611,32 @@ Agent <- R6::R6Class(
       invisible(self)
     },
 
-    #' @description Return conversation turns, as in ellmer Chat.
+    #' @description Return the complete selected conversation, as in ellmer
+    #'   Chat. Compaction removes turns from model context, not from this
+    #'   transcript. Hosts can persist this view through their normal history
+    #'   API. Retained turns remain in memory until the conversation is replaced.
     #' @param include_system_prompt Include the system prompt as a turn.
     #' @return A list of ellmer turns.
     get_turns = function(include_system_prompt = FALSE) {
+      turns <- c(private$.compacted_turns, private$.chat$get_turns())
+      if (isTRUE(include_system_prompt)) {
+        context <- self$get_context_turns(include_system_prompt = TRUE)
+        system <- Filter(
+          function(turn) inherits(turn, "ellmer::SystemTurn"),
+          context
+        )
+        turns <- c(system, turns)
+      }
+      turns
+    },
+
+    #' @description Return only the current model context. Unlike `get_turns()`
+    #'   and `turns()`, this view shrinks when compaction succeeds. Use it when
+    #'   inspecting or transferring the bounded input for a model request.
+    #' @param include_system_prompt Include the current system prompt, including
+    #'   any installed compaction summary, as a turn.
+    #' @return A list of ellmer turns.
+    get_context_turns = function(include_system_prompt = FALSE) {
       if (
         "include_system_prompt" %in% names(formals(private$.chat$get_turns))
       ) {
@@ -625,20 +647,33 @@ Agent <- R6::R6Class(
       private$.chat$get_turns()
     },
 
-    #' @description Replace conversation turns, as in ellmer Chat. During a
-    #'   run, already accrued usage remains charged after history replacement.
+    #' @description Replace the selected conversation and its model context,
+    #'   as in ellmer Chat. Clears the retained compacted prefix and summary,
+    #'   so host branch restoration cannot carry another branch's history.
+    #'   During a run, already accrued usage remains charged after replacement.
     #' @param value A list of ellmer turns.
     #' @return Invisible self.
     set_turns = function(value) {
       usage <- if (isTRUE(private$run_active)) private$current_run_usage()
-      private$.chat$set_turns(value)
-      preserve_run_usage(self, usage)
+      previous_turns <- private$.chat$get_turns()
       prompt <- private$.chat$get_system_prompt()
       prompt_without_compaction <- private$system_prompt_without_compaction()
-      if (!identical(prompt, prompt_without_compaction)) {
-        private$.chat$set_system_prompt(prompt_without_compaction)
-      }
+      tryCatch(
+        {
+          private$.chat$set_turns(value)
+          if (!identical(prompt, prompt_without_compaction)) {
+            private$.chat$set_system_prompt(prompt_without_compaction)
+          }
+        },
+        error = function(error) {
+          try(private$.chat$set_turns(previous_turns), silent = TRUE)
+          try(private$.chat$set_system_prompt(prompt), silent = TRUE)
+          rlang::cnd_signal(error)
+        }
+      )
+      preserve_run_usage(self, usage)
       private$.compaction_summary <- NULL
+      private$.compacted_turns <- list()
       invisible(self)
     },
 
@@ -833,11 +868,11 @@ Agent <- R6::R6Class(
     },
 
     #' @description
-    #' Get the conversation history.
+    #' Get the complete selected conversation, including compacted turns.
     #'
     #' @return A list of Turn objects
     turns = function() {
-      private$.chat$get_turns()
+      self$get_turns()
     },
 
     #' @description
@@ -846,7 +881,12 @@ Agent <- R6::R6Class(
     #' @param role Role to filter by ("assistant", "user", or "system")
     #' @return A Turn object or NULL
     last_turn = function(role = c("assistant", "user", "system")) {
-      private$.chat$last_turn(role = match.arg(role))
+      role <- match.arg(role)
+      turns <- Filter(
+        function(turn) identical(turn@role, role),
+        self$get_turns(include_system_prompt = identical(role, "system"))
+      )
+      if (length(turns)) tail(turns, 1L)[[1L]] else NULL
     },
 
     #' @description
@@ -1024,6 +1064,7 @@ Agent <- R6::R6Class(
     #' - Conversation turns
     #' - System prompt
     #' - The cumulative compaction summary
+    #' - Retained compacted turns for the complete selected conversation
     #' - Portable copies of offloaded tool results
     #' - Effective run context
     #' - File checkpoint state, when enabled
@@ -1062,6 +1103,9 @@ Agent <- R6::R6Class(
     #' context; protected identity conflicts fail the load. Compaction summaries
     #' and integrity-checked tool-result envelopes are restored as conversational
     #' state under the receiving Agent's session identity.
+    #' Schema 3 preserves both the selected conversation and model context.
+    #' Earlier development schemas are rejected; native host history remains
+    #' independently readable through that host's restore API.
     load_session = function(path) {
       if (isTRUE(private$run_active)) {
         cli::cli_abort(
@@ -1792,6 +1836,7 @@ Agent <- R6::R6Class(
       consecutive_tool_cycles = 0L,
       .last_compaction = NULL,
       .compaction_summary = NULL,
+      .compacted_turns = list(),
       .compaction_catalog_registry = NULL,
       .compaction_artifacts = NULL,
       .tool_result_reader_registered = FALSE,

--- a/R/agent.R
+++ b/R/agent.R
@@ -882,9 +882,13 @@ Agent <- R6::R6Class(
     #' @return A Turn object or NULL
     last_turn = function(role = c("assistant", "user", "system")) {
       role <- match.arg(role)
+      current <- private$.chat$last_turn(role = role)
+      if (!is.null(current)) {
+        return(current)
+      }
       turns <- Filter(
         function(turn) identical(turn@role, role),
-        self$get_turns(include_system_prompt = identical(role, "system"))
+        private$.compacted_turns
       )
       if (length(turns)) tail(turns, 1L)[[1L]] else NULL
     },

--- a/R/agent.R
+++ b/R/agent.R
@@ -379,7 +379,7 @@ Agent <- R6::R6Class(
         run_context
       )
       governed_run <- private$start_governed_stream(
-        messages = list(...),
+        messages = rlang::list2(...),
         limits = self$usage_limits,
         run_context = effective_run_context,
         stream = "content"
@@ -405,7 +405,7 @@ Agent <- R6::R6Class(
       run_context = list()
     ) {
       tool_mode <- match.arg(tool_mode)
-      messages <- list(...)
+      messages <- rlang::list2(...)
       effective_run_context <- merge_run_context(
         private$.run_context,
         run_context
@@ -481,7 +481,7 @@ Agent <- R6::R6Class(
         run_context
       )
       governed_run <- private$start_governed_stream(
-        messages = list(...),
+        messages = rlang::list2(...),
         limits = self$usage_limits,
         run_context = effective_run_context,
         stream = "content",
@@ -520,7 +520,7 @@ Agent <- R6::R6Class(
         run_context
       )
       governed_run <- private$start_governed_stream(
-        messages = list(...),
+        messages = rlang::list2(...),
         limits = self$usage_limits,
         run_context = effective_run_context,
         stream = stream,
@@ -562,7 +562,7 @@ Agent <- R6::R6Class(
         run_context
       )
       private$start_governed_stream(
-        messages = list(...),
+        messages = rlang::list2(...),
         limits = self$usage_limits,
         run_context = effective_run_context,
         tool_mode = tool_mode,

--- a/dev/adr/0003-shinychat-owns-conversation-persistence.md
+++ b/dev/adr/0003-shinychat-owns-conversation-persistence.md
@@ -11,9 +11,10 @@ is available.
 
 ## Why
 
-An Agent's compacted context and session snapshot are not a complete conversation
-archive. A host must retain original evidence independently if later runs need
-to recover it. Coupling this boundary to an unreleased shinychat API would block
+An Agent's compacted model context is not a complete conversation archive.
+ADR-0017 separates it from the retained selected transcript and includes both in
+explicit snapshots. A host owns durable retention and authorized retrieval of
+original evidence. Coupling this boundary to an unreleased shinychat API would block
 headless workers and history-recovery work that already runs with caller-owned
 records and released ellmer APIs.
 
@@ -32,8 +33,8 @@ It does not introduce a Deputy conversation database or copy shinychat's tree.
 - Retrieved history supplies evidence. Current host policy supplies execution
   authority; conversation text and saved metadata cannot restore permissions.
 - `Agent$save_session()` and `load_session()` remain supported execution
-  snapshots. Removed turns are recoverable only if the host retained them
-  independently. Session IDs and host conversation IDs require explicit mapping.
+  snapshots. Schema 3 retains compacted turns alongside working context; the host owns
+  the snapshot lifecycle and durable history. Session IDs and host conversation IDs require explicit mapping.
 - Branch restoration and hosted resume must be proved against the chosen host's
   history producer. The recovery fixture alone does not establish durable
   storage, branch editing or restart behavior for a production host.
@@ -41,7 +42,7 @@ It does not introduce a Deputy conversation database or copy shinychat's tree.
 ## Optional shinychat integration
 
 Await the upstream outcome tracked in #66 and
-[`dev/shinychat-history-consumer.md`](../shinychat-history-consumer.md). Only the
+[`dev/shinychat-history-consumer.md`](../shinychat-history-consumer.md). Only the headless
 adapter is gated on a supported, released public R contract and focused
 integration tests under ADR-0004. Use public APIs; do not depend on private tree
 fields or store helpers. A future adapter must preserve the same authorization,
@@ -50,3 +51,7 @@ revision and bounded-read behavior as other host-supplied history.
 Implementation and evaluation under #112 can proceed independently. Live-model
 quality conclusions still require authorized repeated trials; removing the
 shinychat prerequisite does not supply that evidence.
+
+Native Chat-protocol history does not need the headless adapter. ADR-0017 fixes
+#146 by retaining the complete selected conversation in `Agent$get_turns()`
+while model context remains compacted. shinychat still owns its store and tree.

--- a/dev/adr/0017-conversation-and-model-context.md
+++ b/dev/adr/0017-conversation-and-model-context.md
@@ -63,7 +63,11 @@ exchanges. Tests require all 54 turns after save/switch/restore, smaller provide
 requests, unchanged tool-effect counts, native branch editing and navigation,
 fresh-session restoration, and workspace-scope isolation. Runtime-only tests
 cover both views, empty context, cloning, replacement, snapshot validation, and
-saved native plot evidence without executable tool references.
+saved native plot evidence without executable tool references. A durable approval
+regression compacts an already completed effect, pauses a later effect, restores
+display evidence without consuming approval, then explicitly resumes once.
+Approval records encode both turn lists as portable ellmer records and replay
+the compacted prefix without executable tools.
 
 The native store integration is optional: tests skip it when the installed
 shinychat lacks its public history exports. Core transcript behavior is covered

--- a/dev/adr/0017-conversation-and-model-context.md
+++ b/dev/adr/0017-conversation-and-model-context.md
@@ -1,0 +1,70 @@
+# Preserve the selected conversation independently of model context
+
+Accepted for implementation 2026-09-09; issue #146.
+
+## Problem
+
+An Agent implements ellmer's Chat interface for hosts including shinychat.
+Previously its `get_turns()` forwarded the wrapped Chat's working context.
+Compaction could shrink a 46-turn conversation to four turns. shinychat's native
+history appends new turns after the length of its selected branch, so later
+completed replies could remain visible while never reaching durable history.
+An explicit history save used the same view and did not repair the omission.
+
+## Decision
+
+`Agent$get_turns()` and `turns()` return the complete selected conversation.
+`get_context_turns()` returns the current model context, which may shrink.
+Providers, context estimation, usage, compaction, and run accounting continue to
+use the wrapped Chat. Retention does not add old turns to provider requests.
+
+When compaction successfully replaces a context prefix with a summary, Deputy
+retains that prefix in memory. It uses the accepted compaction plan rather than
+trying to rediscover newly completed turns from the current context length.
+Failed or cancelled compaction does not add a prefix. Repeated compaction appends
+only newly removed turns; the retained suffix is never copied into the prefix.
+Archived tool requests retain their public evidence and display metadata but
+lose executable tool references. Completed tools are never replayed by retention.
+
+`set_turns()` replaces the selected conversation and working context together,
+clearing the former prefix and summary. This supports host branch selection,
+new conversations, and native history restoration through the existing public
+Chat protocol. Clones have independent prefixes and context. `last_turn()` reads
+the complete selected conversation, including after all model turns compact.
+
+Snapshot schema 3 stores `compacted_turns` and working `turns` separately. The
+loader validates retained turns before changing live state and restores both
+views only after successful installation. As with previous development schema
+changes, older schemas are rejected rather than presented as complete history.
+Existing native host history remains owned and readable by that host. Restore
+it through the host and write a new snapshot when upgrading.
+
+## Ownership and limits
+
+ADR-0003's host-owned storage boundary remains. This is one in-memory selected
+path, not a conversation database, branch tree, identity service, or retrieval
+API. Hosts own persistence and access control. A host may persist snapshots
+explicitly; Deputy does not open a history store or call private shinychat APIs.
+Headless shinychat branching remains a separate upstream question under #66.
+
+Retaining history uses memory proportional to the selected conversation and
+increases snapshot size. `ContextPolicy(max_tokens)` bounds model input, not
+history memory. Applications choose conversation lifetime and storage limits.
+Restoring a transcript or snapshot does not restore permissions, grant approval,
+or resume live tools. Internal recovery-catalog retirement continues to follow
+live model references; retaining the display transcript does not pin superseded
+internal catalogs indefinitely.
+
+## Verification
+
+A real ellmer HTTP fixture and shinychat's native file store reproduce the old
+loss with 46 initial turns, repeated automatic compaction, and two later tool
+exchanges. Tests require all 54 turns after save/switch/restore, smaller provider
+requests, unchanged tool-effect counts, native branch editing and navigation,
+fresh-session restoration, and workspace-scope isolation. Runtime-only tests
+cover both views, empty context, cloning, replacement, snapshot validation, and
+saved native plot evidence without executable tool references.
+
+The native store integration is optional: tests skip it when the installed
+shinychat lacks its public history exports. Core transcript behavior is covered
+on released ellmer 0.5.0 without that development-only host feature.

--- a/dev/shinychat-history-consumer.md
+++ b/dev/shinychat-history-consumer.md
@@ -12,6 +12,21 @@ an earlier correction through bounded search/read tools. Continue this work with
 caller-owned records. Only the shinychat adapter waits for a public, released
 contract; Deputy implementation and evaluation do not depend on that outcome.
 
+## Native history and compaction (#146)
+
+Native `chat_server()` history can coexist with Deputy compaction through its
+existing Chat protocol. `Agent$get_turns()` now retains the complete selected
+conversation; `get_context_turns()` exposes the smaller model context. The
+runtime does not copy shinychat's store or call private helpers. A deterministic
+integration test uses the exported `chat_server()`, `history_options()`, and
+`FileConversationStore`, plus native UI inputs for switching and branching.
+
+The former host workaround of setting `max_tokens = NULL` with native history
+can be removed when upgrading to this implementation. Hosts restoring Deputy
+snapshots must account for schema 3; older development snapshots are rejected.
+Native host history can be restored independently and then checkpointed anew.
+This fixes native persistence, not the separate headless API request below.
+
 ## What already works
 
 At shinychat development commit

--- a/inst/examples/history-recovery/evaluation.R
+++ b/inst/examples/history-recovery/evaluation.R
@@ -140,7 +140,7 @@ history_budget <- function(
     input <- list(
       prompt = prompt,
       system_prompt = agent$get_system_prompt(),
-      turns = lapply(agent$get_turns(), function(turn) {
+      turns = lapply(agent$get_context_turns(), function(turn) {
         cli::ansi_strip(format(turn))
       })
     )
@@ -498,13 +498,13 @@ history_prepare <- function(
   }
   list(
     fixture = fixture,
-    turns = agent$get_turns(),
+    turns = agent$get_context_turns(),
     system_prompt = agent$get_system_prompt(),
     summaries = compactions,
     summary_id = digest::digest(
       list(
         system_prompt = agent$get_system_prompt(),
-        turns = lapply(agent$get_turns(), format)
+        turns = lapply(agent$get_context_turns(), format)
       ),
       algo = "sha256"
     )

--- a/inst/examples/shiny-chat/app.R
+++ b/inst/examples/shiny-chat/app.R
@@ -2,7 +2,10 @@ library(shiny)
 library(deputy)
 library(shinychat)
 
+source("compaction-notice.R", local = TRUE)
+
 ui <- bslib::page_fluid(
+  compaction_notice_ui("compaction"),
   chat_ui("chat", fill = TRUE)
 )
 
@@ -16,7 +19,7 @@ server <- function(input, output, session) {
   # Deputy adds permissions and hooks on top of the ellmer chat
   agent <- Agent$new(
     chat = chat,
-    tools = c(tools_file(), tools_data()),
+    tools = c(tools_file(), list(tool_read_csv)),
     permissions = Permissions(
       file_read = TRUE,
       file_write = FALSE,
@@ -28,7 +31,8 @@ server <- function(input, output, session) {
 
   # Agent is a drop-in ellmer chat. shinychat owns input, attachments,
   # cancellation, and history while Deputy governs every run.
-  chat_server("chat", agent)
+  chat_module <- chat_server("chat", agent)
+  compaction_notice_server("compaction", agent, chat_module, session)
 }
 
 shinyApp(ui, server)

--- a/inst/examples/shiny-chat/compaction-notice.R
+++ b/inst/examples/shiny-chat/compaction-notice.R
@@ -1,0 +1,106 @@
+# Host-owned presentation: these hooks observe compaction without adding turns.
+compaction_notice_ui <- function(id) {
+  shiny::uiOutput(
+    id,
+    class = "small text-body-secondary mb-2",
+    style = "display: block; max-width: 42rem; margin: 0.75rem auto;"
+  )
+}
+
+compaction_notice_server <- function(id, agent, chat_module, session) {
+  notice <- shiny::reactiveVal(NULL)
+  conversation_id <- function() {
+    shiny::isolate(chat_module$history$conversation_id())
+  }
+
+  agent$add_hook(deputy::HookMatcher(
+    event = "PreCompact",
+    callback = function(...) {
+      current <- shiny::isolate(notice())
+      if (!identical(current$conversation_id, conversation_id())) {
+        current <- NULL
+      }
+      notice(list(
+        conversation_id = conversation_id(),
+        busy = TRUE,
+        summary = current$summary
+      ))
+      NULL
+    }
+  ))
+  agent$add_hook(deputy::HookMatcher(
+    event = "PostCompact",
+    callback = function(result, ...) {
+      notice(list(
+        conversation_id = conversation_id(),
+        busy = FALSE,
+        summary = result$summary
+      ))
+      NULL
+    }
+  ))
+  agent$add_hook(deputy::HookMatcher(
+    event = "Stop",
+    callback = function(...) {
+      current <- shiny::isolate(notice())
+      if (!is.null(current)) {
+        current$busy <- FALSE
+        notice(current)
+      }
+      NULL
+    }
+  ))
+
+  # Native history restores the full transcript, not this summary context.
+  # Clear even when navigating branches within the same conversation.
+  chat_module$history$on_restore(function(...) notice(NULL))
+
+  session$output[[id]] <- shiny::renderUI({
+    current <- notice()
+    if (
+      is.null(current) ||
+        (!isTRUE(current$busy) && is.null(current$summary)) ||
+        !identical(
+          current$conversation_id,
+          chat_module$history$conversation_id()
+        )
+    ) {
+      return(NULL)
+    }
+    shiny::tagList(
+      shiny::tags$p(
+        role = "status",
+        `aria-live` = "polite",
+        class = "mb-1",
+        if (isTRUE(current$busy)) {
+          "Summarizing earlier messages…"
+        } else if (!is.null(current$summary)) {
+          paste(
+            "Earlier messages summarized for the assistant.",
+            "Your full conversation is still available."
+          )
+        }
+      ),
+      if (!is.null(current$summary)) {
+        shiny::tags$details(
+          shiny::tags$summary("View summary"),
+          shiny::tags$p(
+            class = "mt-2 mb-2",
+            paste(
+              "The assistant uses this summary alongside recent messages.",
+              "Some earlier details may be omitted."
+            )
+          ),
+          shiny::tags$div(
+            style = paste(
+              "white-space: pre-wrap; overflow-wrap: anywhere;",
+              "max-height: 16rem; overflow-y: auto;"
+            ),
+            current$summary
+          )
+        )
+      }
+    )
+  })
+  invisible(NULL)
+}

--- a/man/Agent.Rd
+++ b/man/Agent.Rd
@@ -132,6 +132,7 @@ agent$add_hook(HookMatcher(
     \item \href{#method-Agent-resolve_tool_result}{\code{Agent$resolve_tool_result()}}
     \item \href{#method-Agent-add_turn}{\code{Agent$add_turn()}}
     \item \href{#method-Agent-get_turns}{\code{Agent$get_turns()}}
+    \item \href{#method-Agent-get_context_turns}{\code{Agent$get_context_turns()}}
     \item \href{#method-Agent-set_turns}{\code{Agent$set_turns()}}
     \item \href{#method-Agent-get_system_prompt}{\code{Agent$get_system_prompt()}}
     \item \href{#method-Agent-set_system_prompt}{\code{Agent$set_system_prompt()}}
@@ -644,7 +645,10 @@ their replacement; saved sessions retain their catalog snapshots.
 \if{html}{\out{<a id="method-Agent-get_turns"></a>}}
 \if{latex}{\out{\hypertarget{method-Agent-get_turns}{}}}
 \subsection{\code{Agent$get_turns()}}{
-  Return conversation turns, as in ellmer Chat.
+  Return the complete selected conversation, as in ellmer
+Chat. Compaction removes turns from model context, not from this
+transcript. Hosts can persist this view through their normal history
+API. Retained turns remain in memory until the conversation is replaced.
   \subsection{Usage}{
     \if{html}{\out{<div class="r">}}
     \preformatted{Agent$get_turns(include_system_prompt = FALSE)}
@@ -663,11 +667,38 @@ their replacement; saved sessions retain their catalog snapshots.
 }
 
 \if{html}{\out{<hr>}}
+\if{html}{\out{<a id="method-Agent-get_context_turns"></a>}}
+\if{latex}{\out{\hypertarget{method-Agent-get_context_turns}{}}}
+\subsection{\code{Agent$get_context_turns()}}{
+  Return only the current model context. Unlike \code{get_turns()}
+and \code{turns()}, this view shrinks when compaction succeeds. Use it when
+inspecting or transferring the bounded input for a model request.
+  \subsection{Usage}{
+    \if{html}{\out{<div class="r">}}
+    \preformatted{Agent$get_context_turns(include_system_prompt = FALSE)}
+    \if{html}{\out{</div>}}
+  }
+  \subsection{Arguments}{
+    \if{html}{\out{<div class="arguments">}}
+    \describe{
+      \item{\code{include_system_prompt}}{Include the current system prompt, including
+any installed compaction summary, as a turn.}
+    }
+    \if{html}{\out{</div>}}
+  }
+  \subsection{Returns}{
+    A list of ellmer turns.
+  }
+}
+
+\if{html}{\out{<hr>}}
 \if{html}{\out{<a id="method-Agent-set_turns"></a>}}
 \if{latex}{\out{\hypertarget{method-Agent-set_turns}{}}}
 \subsection{\code{Agent$set_turns()}}{
-  Replace conversation turns, as in ellmer Chat. During a
-run, already accrued usage remains charged after history replacement.
+  Replace the selected conversation and its model context,
+as in ellmer Chat. Clears the retained compacted prefix and summary,
+so host branch restoration cannot carry another branch's history.
+During a run, already accrued usage remains charged after replacement.
   \subsection{Usage}{
     \if{html}{\out{<div class="r">}}
     \preformatted{Agent$set_turns(value)}
@@ -1043,7 +1074,7 @@ agent$add_hook(HookMatcher(
 \if{html}{\out{<a id="method-Agent-turns"></a>}}
 \if{latex}{\out{\hypertarget{method-Agent-turns}{}}}
 \subsection{\code{Agent$turns()}}{
-  Get the conversation history.
+  Get the complete selected conversation, including compacted turns.
   \subsection{Usage}{
     \if{html}{\out{<div class="r">}}
     \preformatted{Agent$turns()}
@@ -1232,6 +1263,7 @@ owned connections and discard server session state.
 \item Conversation turns
 \item System prompt
 \item The cumulative compaction summary
+\item Retained compacted turns for the complete selected conversation
 \item Portable copies of offloaded tool results
 \item Effective run context
 \item File checkpoint state, when enabled
@@ -1267,6 +1299,9 @@ validated before conversation state changes and merged with constructor
 context; protected identity conflicts fail the load. Compaction summaries
 and integrity-checked tool-result envelopes are restored as conversational
 state under the receiving Agent's session identity.
+Schema 3 preserves both the selected conversation and model context.
+Earlier development schemas are rejected; native host history remains
+independently readable through that host's restore API.
   }
   \subsection{Returns}{
     Invisible self

--- a/man/LeadAgent.Rd
+++ b/man/LeadAgent.Rd
@@ -44,6 +44,7 @@ sub-agents based on registered AgentDefinitions.
   <li><span class="pkg-link" data-pkg="deputy" data-topic="Agent" data-id="checkpoint"><a href='../../deputy/html/Agent.html#method-Agent-checkpoint'><code>Agent$checkpoint()</code></a></span></li>
   <li><span class="pkg-link" data-pkg="deputy" data-topic="Agent" data-id="compact"><a href='../../deputy/html/Agent.html#method-Agent-compact'><code>Agent$compact()</code></a></span></li>
   <li><span class="pkg-link" data-pkg="deputy" data-topic="Agent" data-id="cost"><a href='../../deputy/html/Agent.html#method-Agent-cost'><code>Agent$cost()</code></a></span></li>
+  <li><span class="pkg-link" data-pkg="deputy" data-topic="Agent" data-id="get_context_turns"><a href='../../deputy/html/Agent.html#method-Agent-get_context_turns'><code>Agent$get_context_turns()</code></a></span></li>
   <li><span class="pkg-link" data-pkg="deputy" data-topic="Agent" data-id="get_cost"><a href='../../deputy/html/Agent.html#method-Agent-get_cost'><code>Agent$get_cost()</code></a></span></li>
   <li><span class="pkg-link" data-pkg="deputy" data-topic="Agent" data-id="get_model"><a href='../../deputy/html/Agent.html#method-Agent-get_model'><code>Agent$get_model()</code></a></span></li>
   <li><span class="pkg-link" data-pkg="deputy" data-topic="Agent" data-id="get_model_object"><a href='../../deputy/html/Agent.html#method-Agent-get_model_object'><code>Agent$get_model_object()</code></a></span></li>

--- a/tests/testthat/helper-runtime.R
+++ b/tests/testthat/helper-runtime.R
@@ -215,7 +215,7 @@ collect_async_stream <- function(stream) {
   result
 }
 
-resolve_async_value <- function(promise, timeout = 1) {
+resolve_async_value <- function(promise, max_polls = 100L) {
   result <- NULL
   stream_error <- NULL
   done <- FALSE
@@ -230,8 +230,7 @@ resolve_async_value <- function(promise, timeout = 1) {
       done <<- TRUE
     })
 
-  deadline <- Sys.time() + timeout
-  while (Sys.time() < deadline) {
+  for (i in seq_len(max_polls)) {
     if (done) {
       break
     }

--- a/tests/testthat/helper-runtime.R
+++ b/tests/testthat/helper-runtime.R
@@ -215,7 +215,7 @@ collect_async_stream <- function(stream) {
   result
 }
 
-resolve_async_value <- function(promise) {
+resolve_async_value <- function(promise, timeout = 1) {
   result <- NULL
   stream_error <- NULL
   done <- FALSE
@@ -230,7 +230,8 @@ resolve_async_value <- function(promise) {
       done <<- TRUE
     })
 
-  for (i in seq_len(100)) {
+  deadline <- Sys.time() + timeout
+  while (Sys.time() < deadline) {
     if (done) {
       break
     }

--- a/tests/testthat/test-agent-context-integration.R
+++ b/tests/testthat/test-agent-context-integration.R
@@ -443,7 +443,7 @@ test_that("manual save and load preserve run context", {
     product = "tempest",
     research_run_id = "research-123"
   )
-  expect_identical(payload$schema_version, 2L)
+  expect_identical(payload$schema_version, 3L)
   expect_identical(payload$run_context, expected)
 
   restored_chat <- create_mock_chat()
@@ -536,8 +536,9 @@ test_that("unsafe restored context is rejected before conversation mutation", {
     path <- file.path(root, paste0(case_name, ".rds"))
     saveRDS(
       list(
-        schema_version = 2L,
+        schema_version = 3L,
         turns = unsafe_turns,
+        compacted_turns = list(),
         system_prompt = "Unsafe prompt",
         compaction_summary = NULL,
         tool_result_envelopes = list(),

--- a/tests/testthat/test-agent.R
+++ b/tests/testthat/test-agent.R
@@ -193,12 +193,13 @@ test_that("Agent save_session creates file", {
 
   # Check session contents
   session <- readRDS(session_file)
-  expect_identical(session$schema_version, 2L)
+  expect_identical(session$schema_version, 3L)
   expect_named(
     session,
     c(
       "schema_version",
       "turns",
+      "compacted_turns",
       "system_prompt",
       "compaction_summary",
       "tool_result_envelopes",
@@ -294,8 +295,9 @@ test_that("Agent load_session validates payload before mutating conversation", {
 
   saveRDS(
     list(
-      schema_version = 2L,
+      schema_version = 3L,
       turns = list(create_mock_user_turn("new turn")),
+      compacted_turns = list(),
       system_prompt = "new prompt",
       compaction_summary = NULL,
       tool_result_envelopes = list(),
@@ -328,7 +330,7 @@ test_that("Agent load_session validates payload before mutating conversation", {
   )
   expect_error(
     suppressMessages(agent$load_session(session_file)),
-    "expected version 2",
+    "expected version 3",
     class = "deputy_session_load"
   )
   expect_equal(chat$get_turns(), old_turns)
@@ -383,32 +385,13 @@ test_that("compact accepts custom summary", {
   mock_chat <- create_mock_chat()
   agent <- Agent$new(chat = mock_chat)
 
-  # Add mock turns
   mock_turns <- list(
-    structure(
-      list(text = "Hello", contents = list()),
-      class = c("UserTurn", "Turn")
-    ),
-    structure(
-      list(text = "Hi", contents = list()),
-      class = c("AssistantTurn", "Turn")
-    ),
-    structure(
-      list(text = "Q1", contents = list()),
-      class = c("UserTurn", "Turn")
-    ),
-    structure(
-      list(text = "A1", contents = list()),
-      class = c("AssistantTurn", "Turn")
-    ),
-    structure(
-      list(text = "Q2", contents = list()),
-      class = c("UserTurn", "Turn")
-    ),
-    structure(
-      list(text = "A2", contents = list()),
-      class = c("AssistantTurn", "Turn")
-    )
+    create_mock_user_turn("Hello"),
+    create_mock_assistant_turn("Hi"),
+    create_mock_user_turn("Q1"),
+    create_mock_assistant_turn("A1"),
+    create_mock_user_turn("Q2"),
+    create_mock_assistant_turn("A2")
   )
   mock_chat$set_turns(mock_turns)
 

--- a/tests/testthat/test-compaction-evidence.R
+++ b/tests/testthat/test-compaction-evidence.R
@@ -758,7 +758,7 @@ test_that("compaction keeps growing recovery sets behind a bounded catalog", {
       replace_set_turns(original_set_turns)
       after <- snapshot()
       expect_identical(agent$get_system_prompt(), before$system_prompt)
-      expect_identical(agent$get_turns(), before$turns)
+      expect_identical(agent$get_context_turns(), before$turns)
       expect_identical(
         names(after$tool_result_envelopes),
         names(before$tool_result_envelopes)

--- a/tests/testthat/test-compaction-notice.R
+++ b/tests/testthat/test-compaction-notice.R
@@ -1,0 +1,87 @@
+test_that("the Shiny notice clears busy status after failed or cancelled compaction", {
+  skip_if_not_installed("shiny")
+  withr::local_options(ellmer_max_tries = 1)
+  example <- new.env(parent = baseenv())
+  sys.source(
+    system.file(
+      "examples",
+      "shiny-chat",
+      "compaction-notice.R",
+      package = "deputy"
+    ),
+    envir = example
+  )
+
+  for (outcome in c("failure", "cancel")) {
+    for (previous_summary in c(FALSE, TRUE)) {
+      response <- if (outcome == "failure") {
+        runtime_failure(401L)
+      } else {
+        structure(runtime_reply("Unaccepted summary"), fixture_delay = 0.5)
+      }
+      server <- local_runtime_server(list(response))
+      agent <- Agent$new(
+        runtime_compaction_chat(server),
+        context_policy = ContextPolicy(max_tokens = 50)
+      )
+      session <- shiny::MockShinySession$new()
+      withr::defer(session$close())
+      module <- list(
+        history = list(
+          conversation_id = shiny::reactiveVal("conversation-a"),
+          on_restore = function(callback) NULL
+        )
+      )
+      shiny::withReactiveDomain(session, {
+        example$compaction_notice_server("compaction", agent, module, session)
+      })
+      if (previous_summary) {
+        agent$compact(keep_last = 4, summary = "Accepted <draft> & evidence.")
+        session$flushReact()
+        expect_match(
+          session$getOutput("compaction")$html,
+          "Accepted &lt;draft&gt; &amp; evidence.",
+          fixed = TRUE
+        )
+      }
+      busy <- NULL
+      agent$add_hook(HookMatcher(
+        event = "PreCompact",
+        callback = function(...) {
+          session$flushReact()
+          busy <<- session$getOutput("compaction")$html
+          if (outcome == "cancel") {
+            later::later(function() agent$interrupt(), 0.05)
+          }
+          NULL
+        }
+      ))
+      before <- agent$get_turns()
+      result <- shiny::withReactiveDomain(session, {
+        tryCatch(agent$run_sync("Continue"), error = identity)
+      })
+      session$flushReact()
+      expect_match(busy, "Summarizing earlier messages", fixed = TRUE)
+      if (outcome == "failure") {
+        expect_s3_class(result, "deputy_compaction_error")
+      } else {
+        expect_identical(agent$last_run()$stop_reason, "interrupted")
+      }
+      expect_identical(agent$get_turns(), before)
+      if (previous_summary) {
+        html <- session$getOutput("compaction")$html
+        expect_match(
+          html,
+          "Accepted &lt;draft&gt; &amp; evidence.",
+          fixed = TRUE
+        )
+        expect_false(grepl(
+          "Summarizing earlier messages|Unaccepted summary",
+          html
+        ))
+      } else {
+        expect_null(session$getOutput("compaction"))
+      }
+    }
+  }
+})

--- a/tests/testthat/test-conversation-approval.R
+++ b/tests/testthat/test-conversation-approval.R
@@ -1,0 +1,88 @@
+test_that("compacted conversation evidence survives durable approval without replay", {
+  directory <- withr::local_tempdir()
+  dir.create(file.path(directory, "approvals"))
+  server <- local_runtime_server(list(
+    runtime_reply(tool = "effect", arguments = list(value = "a")),
+    runtime_reply("The first effect is complete."),
+    runtime_reply(tool = "effect", arguments = list(value = "b")),
+    runtime_reply("The approved effect is complete.")
+  ))
+  effects <- character()
+  tool <- ellmer::tool(
+    function(value) {
+      effects <<- c(effects, value)
+      paste("Completed", value)
+    },
+    name = "effect",
+    description = "Record an effect",
+    arguments = list(value = ellmer::type_string()),
+    convert = FALSE,
+    annotations = ellmer::tool_annotations(
+      read_only_hint = FALSE,
+      destructive_hint = FALSE,
+      open_world_hint = FALSE
+    )
+  )
+  make_agent <- function() {
+    Agent$new(
+      runtime_chat(server),
+      tools = list(tool),
+      permissions = Permissions(can_use_tool = function(name, input, context) {
+        if (identical(input$value, "b")) {
+          PermissionResultPending("Review b")
+        } else {
+          PermissionResultAllow()
+        }
+      }),
+      approval_dir = file.path(directory, "approvals"),
+      working_dir = directory,
+      context_policy = ContextPolicy(
+        max_tokens = NULL,
+        offload_dir = file.path(directory, "offload")
+      ),
+      session_id = "history_approval_session",
+      agent_id = "history_approval_agent"
+    )
+  }
+  agent <- make_agent()
+  agent$run_sync("Perform a")
+  agent$compact(
+    keep_last = 0L,
+    summary = "a is already complete; do not repeat it."
+  )
+  prefix <- lapply(agent$get_turns(), ellmer::contents_record)
+  paused <- agent$run_sync("Perform b after review")
+  expect_identical(paused$stop_reason, "approval_pending")
+  expect_identical(effects, "a")
+  pending <- agent$pending_approval()
+  expect_s7_class(pending, ApprovalContinuation)
+  path <- pending$source$path
+  expect_identical(approval_read(path)$status, "pending")
+
+  snapshot <- file.path(directory, "display.rds")
+  suppressMessages(agent$save_session(snapshot))
+  display <- make_agent()
+  suppressMessages(display$load_session(snapshot))
+  expect_identical(
+    lapply(head(display$get_turns(), 4L), ellmer::contents_record),
+    prefix
+  )
+  expect_null(display$pending_approval())
+  expect_identical(approval_read(path)$status, "pending")
+  expect_identical(effects, "a")
+
+  resumed <- make_agent()
+  result <- resumed$resume_approval(path, "approve")
+  expect_identical(result$stop_reason, "complete")
+  expect_identical(effects, c("a", "b"))
+  expect_identical(approval_read(path)$status, "completed")
+  expect_length(resumed$get_turns(), 9L)
+  expect_length(resumed$get_context_turns(), 5L)
+  expect_equal(
+    lapply(head(resumed$get_turns(), 4L), ellmer::contents_record),
+    prefix,
+    ignore_attr = TRUE
+  )
+  expect_null(resumed$get_turns()[[2L]]@contents[[1L]]@tool)
+  expect_length(server$requests(), 4L)
+})

--- a/tests/testthat/test-conversation-history.R
+++ b/tests/testthat/test-conversation-history.R
@@ -86,7 +86,35 @@ test_that("native shinychat history retains later replies across repeated compac
     ),
     session = session
   )
+  notice_example <- new.env(parent = baseenv())
+  sys.source(
+    system.file(
+      "examples",
+      "shiny-chat",
+      "compaction-notice.R",
+      package = "deputy"
+    ),
+    envir = notice_example
+  )
+  shiny::withReactiveDomain(session, {
+    notice_example$compaction_notice_server(
+      "compaction",
+      agent,
+      module,
+      session
+    )
+  })
+  busy_notices <- character()
+  agent$add_hook(HookMatcher(
+    event = "PreCompact",
+    callback = function(...) {
+      session$flushReact()
+      busy_notices <<- c(busy_notices, session$getOutput("compaction")$html)
+      NULL
+    }
+  ))
   session$setInputs(chat_history_browser_token = "browser-a")
+  expect_null(session$getOutput("compaction"))
   append <- function(prompt) {
     shiny::withReactiveDomain(session, {
       resolve_async_value(
@@ -107,6 +135,17 @@ test_that("native shinychat history retains later replies across repeated compac
   compact_now <- TRUE
   append("First later question")
   append("Second later question")
+  expect_gt(length(busy_notices), 0L)
+  expect_true(all(grepl("Summarizing earlier messages", busy_notices)))
+  notice_html <- session$getOutput("compaction")$html
+  expect_match(
+    notice_html,
+    "Your full conversation is still available",
+    fixed = TRUE
+  )
+  expect_match(notice_html, "<summary>View summary</summary>", fixed = TRUE)
+  expect_match(notice_html, "Retain the evidence.", fixed = TRUE)
+  expect_false(grepl("Summarizing earlier messages", notice_html))
   expect_identical(effects, 2L)
   expect_length(agent$get_turns(), 54L)
   expect_lt(length(chat$get_turns()), 54L)
@@ -129,12 +168,14 @@ test_that("native shinychat history retains later replies across repeated compac
   )
   expected <- lapply(agent$get_turns(), ellmer::contents_record)
   session$setInputs(chat_history_new = 1L)
+  expect_null(session$getOutput("compaction"))
   expect_length(agent$get_turns(), 0L)
   compact_now <- FALSE
   append("Unrelated question")
   other_id <- shiny::isolate(module$history$conversation_id())
   expect_identical(identical(other_id, original_id), FALSE)
   session$setInputs(chat_history_select = list(id = original_id))
+  expect_null(session$getOutput("compaction"))
   expect_length(agent$get_turns(), 54L)
   expect_identical(lapply(agent$get_turns(), ellmer::contents_record), expected)
   expect_identical(effects, 2L)
@@ -145,6 +186,7 @@ test_that("native shinychat history retains later replies across repeated compac
   session$setInputs(
     chat_message_edit = list(index = 46L, content = "Alternate later question")
   )
+  expect_null(session$getOutput("compaction"))
   expect_length(agent$get_turns(), 46L)
   append("Alternate later question")
   alternate <- lapply(agent$get_turns(), ellmer::contents_record)

--- a/tests/testthat/test-conversation-history.R
+++ b/tests/testthat/test-conversation-history.R
@@ -95,7 +95,7 @@ test_that("native shinychat history retains later replies across repeated compac
           agent$stream_async(prompt, stream = "content"),
           session = session
         ),
-        timeout = 10
+        max_polls = 1000L
       )
     })
     session$flushReact()

--- a/tests/testthat/test-conversation-history.R
+++ b/tests/testthat/test-conversation-history.R
@@ -1,0 +1,362 @@
+test_that("native shinychat history retains later replies across repeated compaction", {
+  skip_if_not_installed("shinychat")
+  skip_if_not(all(
+    c("chat_server", "history_options", "FileConversationStore") %in%
+      getNamespaceExports("shinychat")
+  ))
+  directory <- withr::local_tempdir()
+  server <- local_runtime_server(local({
+    replies <- list(
+      summary = runtime_reply("Retain the evidence."),
+      evidence = runtime_reply(tool = "evidence"),
+      "Initial question" = runtime_reply("Initial explanation"),
+      "First later question" = runtime_reply("First later explanation"),
+      "Second later question" = runtime_reply("Second later explanation"),
+      "Unrelated question" = runtime_reply("Separate conversation"),
+      "Alternate later question" = runtime_reply("Alternate branch answer")
+    )
+    function(request, count) {
+      if (is.null(request$tools)) {
+        return(replies$summary)
+      }
+      users <- Filter(
+        function(message) identical(message$role, "user"),
+        request$messages
+      )
+      question <- tail(users, 1L)[[1L]]$content[[1L]]$text
+      if (
+        question %in%
+          c("First later question", "Second later question") &&
+          !identical(tail(request$messages, 1L)[[1L]]$role, "tool")
+      ) {
+        return(replies$evidence)
+      }
+      replies[[question]]
+    }
+  }))
+  chat <- runtime_chat(server)
+  compact_now <- FALSE
+  rlang::env_binding_unlock(chat, "token_count")
+  chat$token_count <- function(...) if (compact_now) 1000 else 0
+  seed <- unlist(
+    lapply(seq_len(22), function(i) {
+      list(
+        create_mock_user_turn(paste("Question", i)),
+        create_mock_assistant_turn(paste("Answer", i))
+      )
+    }),
+    recursive = FALSE
+  )
+  chat$set_turns(seed)
+  effects <- 0L
+  tool <- ellmer::tool(
+    function() {
+      effects <<- effects + 1L
+      paste("Evidence", effects)
+    },
+    name = "evidence",
+    description = "Read evidence",
+    arguments = list(),
+    annotations = ellmer::tool_annotations(
+      read_only_hint = TRUE,
+      open_world_hint = FALSE,
+      destructive_hint = FALSE
+    )
+  )
+  agent <- Agent$new(
+    chat = chat,
+    tools = list(tool),
+    context_policy = ContextPolicy(
+      max_tokens = 50,
+      offload_dir = file.path(directory, "offload")
+    )
+  )
+  session <- shiny::MockShinySession$new()
+  withr::defer(session$close())
+  module <- shinychat::chat_server(
+    "chat",
+    agent,
+    history = shinychat::history_options(
+      store = shinychat::FileConversationStore$new(file.path(
+        directory,
+        "history"
+      )),
+      scope = "workspace-a",
+      title = NULL
+    ),
+    session = session
+  )
+  session$setInputs(chat_history_browser_token = "browser-a")
+  append <- function(prompt) {
+    shiny::withReactiveDomain(session, {
+      resolve_async_value(
+        shinychat::chat_append(
+          "chat",
+          agent$stream_async(prompt, stream = "content"),
+          session = session
+        ),
+        timeout = 10
+      )
+    })
+    session$flushReact()
+    expect_identical(shiny::isolate(module$history$save()), TRUE)
+  }
+  append("Initial question")
+  original_id <- shiny::isolate(module$history$conversation_id())
+  expect_length(agent$get_turns(), 46L)
+  compact_now <- TRUE
+  append("First later question")
+  append("Second later question")
+  expect_identical(effects, 2L)
+  expect_length(agent$get_turns(), 54L)
+  expect_lt(length(chat$get_turns()), 54L)
+  expect_identical(agent$last_compaction()$automatic, TRUE)
+  requests <- server$requests()
+  later_requests <- Filter(
+    function(request) !is.null(request$body$tools),
+    requests
+  )[-1L]
+  expect_identical(length(later_requests), 4L)
+  expect_identical(
+    all(vapply(
+      later_requests,
+      function(request) {
+        length(request$body$messages) < 46L
+      },
+      logical(1)
+    )),
+    TRUE
+  )
+  expected <- lapply(agent$get_turns(), ellmer::contents_record)
+  session$setInputs(chat_history_new = 1L)
+  expect_length(agent$get_turns(), 0L)
+  compact_now <- FALSE
+  append("Unrelated question")
+  other_id <- shiny::isolate(module$history$conversation_id())
+  expect_identical(identical(other_id, original_id), FALSE)
+  session$setInputs(chat_history_select = list(id = original_id))
+  expect_length(agent$get_turns(), 54L)
+  expect_identical(lapply(agent$get_turns(), ellmer::contents_record), expected)
+  expect_identical(effects, 2L)
+  session$setInputs(chat_history_select = list(id = other_id))
+  expect_length(agent$get_turns(), 2L)
+  expect_match(format(agent$last_turn()), "Separate conversation", fixed = TRUE)
+  session$setInputs(chat_history_select = list(id = original_id))
+  session$setInputs(
+    chat_message_edit = list(index = 46L, content = "Alternate later question")
+  )
+  expect_length(agent$get_turns(), 46L)
+  append("Alternate later question")
+  alternate <- lapply(agent$get_turns(), ellmer::contents_record)
+  expect_length(alternate, 48L)
+  session$setInputs(
+    chat_message_navigate = list(index = 46L, direction = "prev")
+  )
+  expect_identical(lapply(agent$get_turns(), ellmer::contents_record), expected)
+  session$setInputs(
+    chat_message_navigate = list(index = 46L, direction = "next")
+  )
+  expect_identical(
+    lapply(agent$get_turns(), ellmer::contents_record),
+    alternate
+  )
+  expect_identical(effects, 2L)
+
+  for (scope in c("workspace-a", "workspace-b")) {
+    fresh <- Agent$new(runtime_chat(server))
+    fresh_session <- shiny::MockShinySession$new()
+    withr::defer(fresh_session$close())
+    shinychat::chat_server(
+      "chat",
+      fresh,
+      history = shinychat::history_options(
+        store = shinychat::FileConversationStore$new(file.path(
+          directory,
+          "history"
+        )),
+        scope = scope,
+        title = NULL
+      ),
+      session = fresh_session
+    )
+    fresh_session$setInputs(
+      chat_history_browser_token = paste0("browser-", scope),
+      chat_history_current_id = original_id
+    )
+    expect_identical(
+      lapply(fresh$get_turns(), ellmer::contents_record),
+      if (scope == "workspace-a") alternate else list()
+    )
+  }
+})
+
+test_that("conversation and model views survive repeated compaction and replacement", {
+  chat <- runtime_chat(local_runtime_server(list(runtime_reply())))
+  agent <- Agent$new(chat, system_prompt = "Host instructions")
+  agent$add_turn(
+    create_mock_user_turn("Question one"),
+    create_mock_assistant_turn("Answer one")
+  )
+  agent$add_turn(
+    create_mock_user_turn("Question two"),
+    create_mock_assistant_turn("Answer two")
+  )
+  original <- agent$get_turns()
+  agent$compact(keep_last = 2L, summary = "First summary")
+  expect_identical(agent$get_turns(), original)
+  expect_identical(agent$turns(), original)
+  expect_identical(agent$get_context_turns(), tail(original, 2L))
+  with_system <- agent$get_turns(include_system_prompt = TRUE)
+  expect_identical(with_system[-1L], original)
+  expect_identical(with_system[[1L]]@role, "system")
+  expect_match(with_system[[1L]]@text, "First summary", fixed = TRUE)
+  agent$add_turn(
+    create_mock_user_turn("Question three"),
+    create_mock_assistant_turn("Answer three")
+  )
+  agent$compact(keep_last = 0L, summary = "Second summary")
+  expect_length(agent$get_turns(), 6L)
+  expect_length(agent$get_context_turns(), 0L)
+  expect_identical(agent$last_turn()@text, "Answer three")
+  expect_identical(agent$last_turn("user")@text, "Question three")
+  clone <- agent$clone()
+  clone$set_turns(original[1:2])
+  clone$add_turn(
+    create_mock_user_turn("Branch question"),
+    create_mock_assistant_turn("Branch answer")
+  )
+  clone$compact(keep_last = 0L, summary = "Branch summary")
+  expect_length(clone$get_turns(), 4L)
+  expect_identical(clone$last_turn()@text, "Branch answer")
+  expect_length(agent$get_turns(), 6L)
+  expect_identical(agent$last_turn()@text, "Answer three")
+  agent$set_turns(list())
+  expect_length(agent$get_turns(), 0L)
+  expect_length(agent$get_context_turns(), 0L)
+  expect_null(agent$last_turn())
+  expect_identical(agent$get_system_prompt(), "Host instructions")
+})
+
+test_that("session snapshots retain both views without executable archived tools", {
+  directory <- withr::local_tempdir()
+  server <- local_runtime_server(list(
+    runtime_reply(tool = "run_r_code", arguments = list(code = "plot(1:3)")),
+    runtime_reply("A saved plot")
+  ))
+  agent <- Agent$new(
+    runtime_chat(server),
+    working_dir = directory,
+    permissions = Permissions(r_code = TRUE),
+    context_policy = ContextPolicy(
+      max_tokens = NULL,
+      offload_dir = file.path(directory, "results")
+    )
+  )
+  runtime <- RSession$new(agent)
+  withr::defer(runtime$close())
+  agent$register_tools(runtime$tools())
+  agent$run_sync("Plot the values")
+  recorded <- lapply(agent$get_turns(), ellmer::contents_record)
+  agent$compact(keep_last = 0L, summary = "Values were plotted.")
+  expect_identical(lapply(agent$get_turns(), ellmer::contents_record), recorded)
+  path <- file.path(directory, "session.rds")
+  suppressMessages(agent$save_session(path))
+  runtime$close()
+  snapshot <- readRDS(path)
+  expect_length(snapshot$turns, 0L)
+  expect_length(snapshot$compacted_turns, 4L)
+  request <- snapshot$compacted_turns[[2L]]@contents[[1L]]
+  result <- snapshot$compacted_turns[[3L]]@contents[[1L]]
+  expect_null(request@tool)
+  expect_null(result@request@tool)
+  expect_match(
+    as.character(result@extra$display$html),
+    "data:image/png;base64,",
+    fixed = TRUE
+  )
+  restored <- Agent$new(
+    runtime_chat(server),
+    permissions = permissions_readonly(),
+    context_policy = ContextPolicy(
+      offload_dir = file.path(directory, "restored")
+    )
+  )
+  suppressMessages(restored$load_session(path))
+  expect_identical(
+    lapply(restored$get_turns(), ellmer::contents_record),
+    recorded
+  )
+  expect_length(restored$get_context_turns(), 0L)
+  expect_identical(restored$get_permission_mode(), "readonly")
+  expect_identical("run_r_code" %in% names(restored$get_tools()), FALSE)
+  restored$add_turn(
+    create_mock_user_turn("Continue"),
+    create_mock_assistant_turn("New evidence")
+  )
+  restored$compact(keep_last = 0L, summary = "Continued")
+  expect_length(restored$get_turns(), 6L)
+  expect_identical(restored$last_turn()@text, "New evidence")
+})
+
+test_that("invalid saved history cannot partially replace a conversation", {
+  directory <- withr::local_tempdir()
+  agent <- Agent$new(runtime_chat(local_runtime_server(list(runtime_reply()))))
+  agent$add_turn(
+    create_mock_user_turn("Keep question"),
+    create_mock_assistant_turn("Keep answer")
+  )
+  agent$compact(keep_last = 0L, summary = "Keep summary")
+  before <- agent$get_turns()
+  path <- file.path(directory, "session.rds")
+  suppressMessages(agent$save_session(path))
+  payload <- readRDS(path)
+  payload$compacted_turns <- list("Invalid turn")
+  saveRDS(payload, path)
+  failure <- tryCatch(agent$load_session(path), deputy_session_load = identity)
+  expect_s3_class(failure, "deputy_session_load")
+  expect_match(conditionMessage(failure), "compacted_turns", fixed = TRUE)
+  expect_identical(agent$get_turns(), before)
+  expect_length(agent$get_context_turns(), 0L)
+  expect_match(agent$get_system_prompt(), "Keep summary", fixed = TRUE)
+})
+
+test_that("failed context installation leaves the retained transcript unchanged", {
+  chat <- runtime_chat(local_runtime_server(list(runtime_reply())))
+  agent <- Agent$new(chat, system_prompt = "Original instructions")
+  agent$add_turn(
+    create_mock_user_turn("First question"),
+    create_mock_assistant_turn("First answer")
+  )
+  agent$add_turn(
+    create_mock_user_turn("Second question"),
+    create_mock_assistant_turn("Second answer")
+  )
+  agent$compact(keep_last = 2L, summary = "Existing summary")
+  original <- agent$get_turns()
+  context <- agent$get_context_turns()
+  original_set <- chat$set_system_prompt
+  reject <- TRUE
+  rlang::env_binding_unlock(chat, "set_system_prompt")
+  chat$set_system_prompt <- function(value) {
+    if (reject) {
+      reject <<- FALSE
+      rlang::abort("Injected prompt installation failure")
+    }
+    original_set(value)
+  }
+  failure <- tryCatch(
+    agent$compact(keep_last = 0L, summary = "Replacement"),
+    error = identity
+  )
+  expect_s3_class(failure, "error")
+  expect_identical(agent$get_turns(), original)
+  expect_identical(agent$get_context_turns(), context)
+  reject <- TRUE
+  failure <- tryCatch(agent$set_turns(list()), error = identity)
+  expect_s3_class(failure, "error")
+  expect_identical(agent$get_turns(), original)
+  expect_identical(agent$get_context_turns(), context)
+  agent$compact(keep_last = 0L, summary = "Replacement")
+  expect_identical(agent$get_turns(), original)
+  expect_length(agent$get_context_turns(), 0L)
+})

--- a/tests/testthat/test-shinychat-integration.R
+++ b/tests/testthat/test-shinychat-integration.R
@@ -1,3 +1,36 @@
+test_that("native shinychat input reaches the Agent through dynamic dots", {
+  skip_if_not_installed("shinychat")
+  skip_if_not("chat_server" %in% getNamespaceExports("shinychat"))
+  server <- local_runtime_server(list(runtime_reply("Governed reply")))
+  agent <- Agent$new(runtime_chat(server))
+  session <- shiny::MockShinySession$new()
+  withr::defer(session$close())
+  shiny::withReactiveDomain(session, {
+    module <- shinychat::chat_server(
+      "chat",
+      agent,
+      history = FALSE,
+      session = session
+    )
+    session$setInputs(chat_user_input = list("Hello", "Second content part"))
+    for (poll in seq_len(1000L)) {
+      later::run_now(0.01)
+      session$flushReact()
+      if (!identical(shiny::isolate(module$status()), "streaming")) break
+    }
+  })
+  expect_null(shiny::isolate(module$last_error()))
+  expect_identical(trimws(agent$last_run()$response), "Governed reply")
+  expect_length(server$requests(), 1L)
+  if (length(server$requests())) {
+    sent <- server$requests()[[1L]]$body$messages[[1L]]$content
+    expect_identical(
+      vapply(sent, `[[`, "", "text"),
+      c("Hello", "Second content part")
+    )
+  }
+})
+
 test_that("Agent stream_async is consumed directly by shinychat", {
   skip_if_not_installed("shiny")
   skip_if_not_installed("shinychat")

--- a/tests/testthat/test-shinychat-integration.R
+++ b/tests/testthat/test-shinychat-integration.R
@@ -25,6 +25,7 @@ test_that("Agent stream_async is consumed directly by shinychat", {
   module <- shinychat::chat_server(
     "chat",
     agent,
+    history = FALSE,
     session = session
   )
 

--- a/vignettes/example-shiny-chat.Rmd
+++ b/vignettes/example-shiny-chat.Rmd
@@ -74,6 +74,15 @@ shinyApp(ui, server)
 the Agent unchanged. It also supplies shinychat history and cancellation around
 Deputy's stream.
 
+Compaction and native conversation history can be enabled together. Deputy's
+`get_turns()` supplies the complete selected conversation to shinychat, while
+`get_context_turns()` exposes only the compacted model context. Later completed
+replies remain available when the user switches conversations or restores a
+branch. Native history requires a shinychat version exporting `history_options()`
+and `FileConversationStore`; Deputy's transcript contract also works without
+shinychat. Hosts that previously rejected a non-NULL `ContextPolicy(max_tokens)`
+with native history can remove that workaround when using this implementation.
+
 ## What the Agent Adds
 
 Choose a method by the result your application needs:

--- a/vignettes/example-shiny-chat.Rmd
+++ b/vignettes/example-shiny-chat.Rmd
@@ -83,6 +83,25 @@ and `FileConversationStore`; Deputy's transcript contract also works without
 shinychat. Hosts that previously rejected a non-NULL `ContextPolicy(max_tokens)`
 with native history can remove that workaround when using this implementation.
 
+## Showing compaction to users
+
+The runnable `inst/examples/shiny-chat/` app includes a host-owned compaction
+notice above the transcript. While summarization runs it says "Summarizing
+earlier messages…". After successful installation it says "Earlier messages
+summarized for the assistant. Your full conversation is still available."
+An expandable "View summary" shows the accepted summary as escaped text,
+alongside an explanation that the assistant uses it with recent messages and
+that some earlier details may be omitted.
+
+The notice does not add, hide, or replace chat messages. `PreCompact` and
+`PostCompact` hooks update its state; a `Stop` hook clears the busy indication
+after failure or cancellation while retaining any previously accepted summary.
+The example scopes the notice to shinychat's public conversation ID and clears
+it through `history$on_restore()`, including branch navigation. Native history
+restores the complete transcript rather than the compacted context, so the
+notice stays hidden until compaction happens again. This presentation belongs
+to the host; Deputy does not insert UI messages into its conversation record.
+
 ## What the Agent Adds
 
 Choose a method by the result your application needs:

--- a/vignettes/example-shiny-chat.Rmd
+++ b/vignettes/example-shiny-chat.Rmd
@@ -95,7 +95,11 @@ that some earlier details may be omitted.
 
 The notice does not add, hide, or replace chat messages. `PreCompact` and
 `PostCompact` hooks update its state; a `Stop` hook clears the busy indication
-after failure or cancellation while retaining any previously accepted summary.
+after an automatic run fails or is interrupted, while retaining any previously
+accepted summary. Register custom compaction-veto hooks before this notice so
+their early return prevents the progress indication. Hosts that call
+`agent$compact()` directly must also clear progress when that call ends,
+including errors or vetoes; a manual call does not fire the run's `Stop` hook.
 The example scopes the notice to shinychat's public conversation ID and clears
 it through `history$on_restore()`, including branch navigation. Native history
 restores the complete transcript rather than the compacted context, so the

--- a/vignettes/runtime-integration.Rmd
+++ b/vignettes/runtime-integration.Rmd
@@ -109,8 +109,22 @@ the budget before task execution.
 `agent$last_compaction()` reports the method, run ID, usage, and destination
 attempts. Request and fallback events use `phase = "compaction"` for summary
 work. Manual `agent$compact()` keeps its synchronous, active-Chat-only contract.
-Removed turns are not archived by this policy; host-owned history retrieval
-remains a separate integration.
+`agent$get_turns()` and `agent$turns()` retain the complete selected conversation
+across compaction. `agent$get_context_turns()` returns only the smaller model
+context. The model receives that context and its installed summary; retaining
+the display transcript does not send old turns back to the provider.
+
+The retained prefix lives in memory and grows with the selected conversation.
+The host still owns durable history storage, conversation identity, and branches.
+`set_turns()` selects a replacement conversation, clears the old prefix and
+summary, and uses the supplied turns as context. Automatic compaction can reduce
+that restored context before the next request. A host needing retrieval can
+expose authorized bounded reads separately; transcript text grants no authority.
+
+`save_session()` uses snapshot schema 3 to preserve both views without executable
+tool references. `load_session()` restores them under the receiving Agent's
+permissions. Older development snapshot schemas are rejected; restore existing
+native conversation history through its host, then create a new snapshot.
 
 LeadAgent's fallback policy applies to the lead. Child definitions inherit the
 selected provider and do not implicitly gain additional destinations.


### PR DESCRIPTION
Closes #146

Compaction previously shrank the transcript returned to shinychat, so native history could silently omit later completed replies. `Agent$get_turns()` and `turns()` now retain the complete selected conversation; `get_context_turns()` exposes the smaller model context used by providers and accounting. The native regression starts with 46 saved turns, compacts repeatedly, completes two tool exchanges, and restores all 54 turns without replaying effects.

Accepted compaction retains a portable prefix in memory. Conversation replacement clears that prefix and the installed summary; clones, restored branches, and workspace scopes remain isolated. Snapshot schema 3 preserves the prefix and working context separately without executable archived tools. Approval records encode both views, and restoring display evidence leaves approval pending until explicitly approved. Hosts continue to own durable storage, branch identity, and access control.

The Shiny example displays “Summarizing earlier messages…”, followed by a quiet completion notice and an expandable “View summary”. It renders the accepted summary as escaped text outside the transcript and clears the notice on native history restoration. Automatic-run failure or interruption clears progress. Custom veto hooks must precede the notice; hosts calling `compact()` directly need call-level cleanup. Browser verification also exposed two existing blockers: duplicate tool registration in the example and unsupported `!!!` forwarding from native `chat_server()` input. The example now registers each tool once, and Agent chat methods accept dynamic dots before entering the governed run.

Callers that need compacted input should use `get_context_turns()`. Earlier development snapshot schemas are rejected; existing native history can be restored through its host and checkpointed anew. Retained history uses memory proportional to the selected conversation, independently of the model token allowance. Hosts using the #146 workaround can enable compaction with native history after upgrading.

## Validation

- Full suite: 5,715 passing assertions, zero failures, two existing filesystem-fixture warnings, and seven dependency/configuration skips. Qualified mcptools 1.0.2 tests executed.
- Released-dependency R CMD check with ellmer 0.5.0, shinychat 0.4.0, and mcptools 1.0.2: zero errors, warnings, or notes. Native-history compatibility also exercised with shinychat 0.4.0.9000.
- Focused UI/input tests: 119 passing assertions, including native input forwarding, failure/interruption, escaping, and history restoration. The input regression failed before the compatibility fix.
- Local browser: normal message submission, live progress, expanded summary, keyboard collapse, new conversation, and full restoration with no stale notice; deterministic local provider, no paid calls.
- Air, Jarl, pkgdown, the updated article, and `git diff --check` passed. Only the documented lifecycle clarification followed the full-run code snapshot; the article was rebuilt afterwards.
- Independent Standards and Spec reviews: no remaining findings within the documented contract. Review corrections cover approval serialization and notice lifecycle boundaries.
